### PR TITLE
find exact matching access_control_group

### DIFF
--- a/ncloud/data_source_ncloud_access_control_group.go
+++ b/ncloud/data_source_ncloud_access_control_group.go
@@ -25,13 +25,6 @@ func dataSourceNcloudAccessControlGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"most_recent": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
-			},
-
 			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -45,10 +38,10 @@ func dataSourceNcloudAccessControlGroupRead(d *schema.ResourceData, meta interfa
 
 	configNo, configNoOk := d.GetOk("configuration_no")
 	acgName, acgNameOk := d.GetOk("name")
-	mostRecent, mostRecentOk := d.GetOk("most_recent")
+	isDefaultGroup, isDefaultGroupOk := d.GetOk("is_default_group")
 
-	if !configNoOk && !acgNameOk && !mostRecentOk {
-		return fmt.Errorf("either configuration_no or name or most_recent is required")
+	if !configNoOk && !acgNameOk && !isDefaultGroupOk {
+		return fmt.Errorf("either configuration_no or name or is_default_group is required")
 	}
 
 	reqParams := server.GetAccessControlGroupListRequest{}
@@ -58,8 +51,7 @@ func dataSourceNcloudAccessControlGroupRead(d *schema.ResourceData, meta interfa
 	if acgNameOk {
 		reqParams.AccessControlGroupName = ncloud.String(acgName.(string))
 	}
-
-	if isDefaultGroup, ok := d.GetOk("is_default_group"); ok {
+	if isDefaultGroupOk {
 		reqParams.IsDefault = ncloud.Bool(isDefaultGroup.(bool))
 	}
 	reqParams.PageNo = ncloud.Int32(1)
@@ -84,13 +76,7 @@ func dataSourceNcloudAccessControlGroupRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("no results. please change search criteria and try again")
 	}
 
-	if len(accessControlGroups) > 1 && mostRecent.(bool) {
-		// Query returned single result.
-		accessControlGroup = mostRecentAccessControlGroup(accessControlGroups)
-	} else {
-		accessControlGroup = accessControlGroups[0]
-	}
-
+	accessControlGroup = accessControlGroups[0]
 	return accessControlGroupAttributes(d, accessControlGroup)
 }
 

--- a/ncloud/data_source_ncloud_access_control_group_test.go
+++ b/ncloud/data_source_ncloud_access_control_group_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNcloudAccessControlGroupBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudAccessControlGroupConfig,
+				Config: testAccDataSourceNcloudAccessControlGroupDefaultConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_access_control_group.test"),
 				),
@@ -24,7 +24,7 @@ func TestAccDataSourceNcloudAccessControlGroupBasic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudAccessControlGroupMostRecent(t *testing.T) {
+func TestAccDataSourceNcloudAccessControlGroupSelectByName(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
@@ -32,11 +32,7 @@ func TestAccDataSourceNcloudAccessControlGroupMostRecent(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudAccessControlGroupMostRecentConfig,
-				// ignore check: may be empty created data
-				SkipFunc: func() (bool, error) {
-					return skipNoResultsTest, nil
-				},
+				Config: testAccDataSourceNcloudAccessControlGroupSelectByNameConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_access_control_group.test"),
 				),
@@ -45,15 +41,14 @@ func TestAccDataSourceNcloudAccessControlGroupMostRecent(t *testing.T) {
 	})
 }
 
-var testAccDataSourceNcloudAccessControlGroupConfig = `
+var testAccDataSourceNcloudAccessControlGroupDefaultConfig = `
 data "ncloud_access_control_group" "test" {
 	"is_default_group" = true
-	"most_recent" = "true"
 }
 `
 
-var testAccDataSourceNcloudAccessControlGroupMostRecentConfig = `
+var testAccDataSourceNcloudAccessControlGroupSelectByNameConfig = `
 data "ncloud_access_control_group" "test" {
-	"most_recent" = "true"
+	"name" = "ncloud-default-acg"
 }
 `

--- a/website/docs/d/access_control_group.html.markdown
+++ b/website/docs/d/access_control_group.html.markdown
@@ -22,27 +22,16 @@ data "ncloud_access_control_group" "test" {
 }
 ```
 
-* Filter by most recent ACG
-
-```hcl
-data "ncloud_access_control_group" "test" {
-    # use the most recent ACG
-	"most_recent" = "true"
-}
-```
-
 
 ## Argument Reference
 
 The following arguments are supported:
 
 * `configuration_no` - (Optional) List of ACG configuration numbers you want to get
-    Conditional: Requires `configuration_no` or` name` or `most_recent`.
 * `name` - (Optional) Name of the ACG you want to get
-    Conditional: Requires `configuration_no` or` name` or `most_recent`.
-* `most_recent` - (Optional) If more than one result is returned, get the most recent created ACG.
-    Conditional: Requires `configuration_no` or` name` or `most_recent`.
-* `is_default_group` - (Optional) Indicates whether to get default groups only
+* `is_default_group` - (Optional) Indicates whether to get default group only
+
+Conditional: Requires `configuration_no` or` name` or `is_default_group`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
fix #89 find exact matching access_control_group

- remove most recent
- requires conditionally configuration_no or name or is_default_group