### PR TITLE
Support GOV(gov-ncloud.com) and FIN(fin-ncloud.com)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
-## 1.2.1 (Unreleased)
+## 1.3.0 (Unreleased)
+
+ENHANCEMENTS:
+
+* Support "Gov" and "Fin" sites. "Gov" : ncloud for government (www.gov-ncloud.com) / "Fin" : ncloud for finance site (www.fin-ncloud.com). Default: "public" (www.ncloud.com)
+
 ## 1.2.0 (December 18, 2019)
 
 ENHANCEMENTS:
+
 * Add a "clean" rule to Makefile
 
 ## 1.1.0 (November 05, 2019)

--- a/ncloud/provider.go
+++ b/ncloud/provider.go
@@ -28,6 +28,11 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("NCLOUD_REGION", nil),
 				Description: descriptions["region"],
 			},
+			"site": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["site"],
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"ncloud_regions":               dataSourceNcloudRegions(),
@@ -74,6 +79,15 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		os.Setenv("NCLOUD_REGION", region.(string))
 	}
 
+	if site, ok := d.GetOk("site"); ok {
+		switch site {
+		case "gov":
+			os.Setenv("NCLOUD_API_GW", "https://ncloud.apigw.gov-ntruss.com")
+		case "fin":
+			os.Setenv("NCLOUD_API_GW", "https://ncloud.apigw.fin-ntruss.com")
+		}
+	}
+
 	sdk, err := config.Client()
 	if err != nil {
 		return nil, err
@@ -88,5 +102,6 @@ func init() {
 		"access_key": "Access key of ncloud",
 		"secret_key": "Secret key of ncloud",
 		"region":     "Region of ncloud",
+		"site":       "Site of ncloud (public / gov / fin)",
 	}
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -22,6 +22,7 @@ provider "ncloud" {
   access_key = var.access_key
   secret_key = var.secret_key
   region     = var.region
+  site       = var.site
 }
 
 // Create a new server instance
@@ -41,7 +42,7 @@ The following methods are supported, in this order, and explained below:
 
 ### Static credentials ###
 
-Static credentials can be provided by adding an `access_key` `secret_key` and `region` in-line in the
+Static credentials can be provided by adding an `access_key` `secret_key` `region` and `site` in-line in the
 ncloud provider block:
 
 Usage:
@@ -51,6 +52,7 @@ provider "ncloud" {
   access_key = var.access_key
   secret_key = var.secret_key
   region     = var.region
+  site       = var.site
 }
 ```
 
@@ -88,6 +90,8 @@ The following arguments are supported:
 
 * `region` - (Optional) Ncloud region. default 'KR'
   it can also be sourced from the `NCLOUD_REGION` environment variables.
+
+* `site` - (Optional) Ncloud site. By default, the value is "public". You can specify only the following value: "public", "gov", "fin". "public" is for `www.ncloud.com`. "gov" is for `www.gov-ncloud.com`. "fin" is for `www.fin-ncloud.com`.
 
 ~> **Note** `access_key`, `secret_key` : (Get authentication keys for your account)[http://docs.ncloud.com/en/api_new/api_new-1-1.html#preparation]
 


### PR DESCRIPTION
resolve #1 

### Support GOV(gov-ncloud.com) and FIN(fin-ncloud.com)
new variable : `site` (Optional) Ncloud site. By default, the value is "public". You can specify only the following value: "public", "gov", "fin". "public" is for www.ncloud.com. "gov" is for www.gov-ncloud.com. "fin" is for www.fin-ncloud.com.

sample 
```
{
  access_key = var.access_key
  secret_key = var.secret_key
  region     = var.region
  site       = var.site
}
```