### PR TITLE
#90 test acc multiple platform

### DIFF
--- a/ncloud/data_source_ncloud_access_control_group_test.go
+++ b/ncloud/data_source_ncloud_access_control_group_test.go
@@ -14,13 +14,12 @@ func TestAccDataSourceNcloudVpcAccessControlGroupBasic(t *testing.T) {
 	dataName := "data.ncloud_access_control_group.by_id"
 	resourceName := "ncloud_access_control_group.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudVpcAccessControlGroupConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudVpcAccessControlGroupConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "id", resourceName, "id"),
@@ -40,11 +39,10 @@ func TestAccDataSourceNcloudClassicAccessControlGroup_basic(t *testing.T) {
 	dataName := "data.ncloud_access_control_group.by_name"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudClassicAccessControlConfig,
-				SkipFunc: testOnlyClassic,
+				Config: testAccDataSourceNcloudClassicAccessControlConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttr(dataName, "name", "ncloud-default-acg"),

--- a/ncloud/data_source_ncloud_access_control_groups_test.go
+++ b/ncloud/data_source_ncloud_access_control_groups_test.go
@@ -5,12 +5,26 @@ import (
 	"testing"
 )
 
-func TestAccDataSourceNcloudAccessControlGroupsBasic(t *testing.T) {
-	t.Parallel()
+func TestAccDataSourceNcloudAccessControlGroups_classic_basic(t *testing.T) {
+	testAccDataSourceNcloudAccessControlGroupsBasic(t, false)
+}
 
-	resource.Test(t, resource.TestCase{
+func TestAccDataSourceNcloudAccessControlGroups_vpc_basic(t *testing.T) {
+	testAccDataSourceNcloudAccessControlGroupsBasic(t, true)
+}
+
+func TestAccDataSourceNcloudAccessControlGroups_classic_default(t *testing.T) {
+	testAccDataSourceNcloudAccessControlGroupsDefault(t, false)
+}
+
+func TestAccDataSourceNcloudAccessControlGroups_vpc_default(t *testing.T) {
+	testAccDataSourceNcloudAccessControlGroupsDefault(t, true)
+}
+
+func testAccDataSourceNcloudAccessControlGroupsBasic(t *testing.T, isVpc bool) {
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAccessControlGroupsConfig,
@@ -22,19 +36,13 @@ func TestAccDataSourceNcloudAccessControlGroupsBasic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudAccessControlGroupsDefault(t *testing.T) {
-	t.Parallel()
-
-	resource.Test(t, resource.TestCase{
+func testAccDataSourceNcloudAccessControlGroupsDefault(t *testing.T, isVpc bool) {
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAccessControlGroupsDefaultConfig,
-				// ignore check: may be empty created data
-				SkipFunc: func() (bool, error) {
-					return skipNoResultsTest, nil
-				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_access_control_groups.default"),
 				),

--- a/ncloud/data_source_ncloud_access_control_rule_test.go
+++ b/ncloud/data_source_ncloud_access_control_rule_test.go
@@ -6,15 +6,12 @@ import (
 )
 
 func TestAccDataSourceNcloudAccessControlRuleBasic(t *testing.T) {
-	t.Parallel()
-
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudAccessControlRuleConfig,
-				SkipFunc: testOnlyClassic,
+				Config: testAccDataSourceNcloudAccessControlRuleConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_access_control_rule.test"),
 				),

--- a/ncloud/data_source_ncloud_access_control_rules_test.go
+++ b/ncloud/data_source_ncloud_access_control_rules_test.go
@@ -10,21 +10,18 @@ import (
 
 // ignore test : should use real access_control_group_configuration_no
 func testAccDataSourceNcloudAccessControlRulesBasic(t *testing.T) {
-	t.Parallel()
-
 	testId := os.Getenv("TEST_ID")
 	if testId == "" {
 		log.Println("[ERROR] ENV 'TEST_ID' is required")
 		return
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudAccessControlRulesConfig(testId),
-				SkipFunc: testOnlyClassic,
+				Config: testAccDataSourceNcloudAccessControlRulesConfig(testId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_access_control_rules.test"),
 				),

--- a/ncloud/data_source_ncloud_block_storage_test.go
+++ b/ncloud/data_source_ncloud_block_storage_test.go
@@ -1,56 +1,76 @@
 package ncloud
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceNcloudBlockStorage_basic(t *testing.T) {
+func TestAccDataSourceNcloudBlockStorage_classic_basic(t *testing.T) {
 	resourceName := "ncloud_block_storage.storage"
 	dataName := "data.ncloud_block_storage.by_id"
 	name := fmt.Sprintf("tf-ds-storage-%s", acctest.RandString(5))
 
-	testCheckResourceAttrPair := func() func(*terraform.State) error {
-		return resource.ComposeTestCheckFunc(
-			resource.TestCheckResourceAttrPair(dataName, "id", resourceName, "id"),
-			resource.TestCheckResourceAttrPair(dataName, "name", resourceName, "name"),
-			resource.TestCheckResourceAttrPair(dataName, "status", resourceName, "status"),
-			resource.TestCheckResourceAttrPair(dataName, "product_code", resourceName, "product_code"),
-			resource.TestCheckResourceAttrPair(dataName, "size", resourceName, "size"),
-			resource.TestCheckResourceAttrPair(dataName, "type", resourceName, "type"),
-			resource.TestCheckResourceAttrPair(dataName, "disk_detail_type", resourceName, "disk_detail_type"),
-			resource.TestCheckResourceAttrPair(dataName, "disk_type", resourceName, "disk_type"),
-			resource.TestCheckResourceAttrPair(dataName, "block_storage_no", resourceName, "block_storage_no"),
-			resource.TestCheckResourceAttrPair(dataName, "server_instance_no", resourceName, "server_instance_no"),
-			resource.TestCheckResourceAttrPair(dataName, "description", resourceName, "description"),
-			resource.TestCheckResourceAttrPair(dataName, "device_name", resourceName, "device_name"),
-		)
-	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccClassicProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: composeConfig(
+					testAccBlockStorageClassicConfig(name),
+					testAccDataSourceNcloudBlockStorageConfig,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceID(dataName),
+					resource.TestCheckResourceAttrPair(dataName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataName, "status", resourceName, "status"),
+					resource.TestCheckResourceAttrPair(dataName, "product_code", resourceName, "product_code"),
+					resource.TestCheckResourceAttrPair(dataName, "size", resourceName, "size"),
+					resource.TestCheckResourceAttrPair(dataName, "type", resourceName, "type"),
+					resource.TestCheckResourceAttrPair(dataName, "disk_detail_type", resourceName, "disk_detail_type"),
+					resource.TestCheckResourceAttrPair(dataName, "disk_type", resourceName, "disk_type"),
+					resource.TestCheckResourceAttrPair(dataName, "block_storage_no", resourceName, "block_storage_no"),
+					resource.TestCheckResourceAttrPair(dataName, "server_instance_no", resourceName, "server_instance_no"),
+					resource.TestCheckResourceAttrPair(dataName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataName, "device_name", resourceName, "device_name"),
+					testAccCheckDataSourceID("data.ncloud_block_storage.by_filter"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNcloudBlockStorage_vpc_basic(t *testing.T) {
+	resourceName := "ncloud_block_storage.storage"
+	dataName := "data.ncloud_block_storage.by_id"
+	name := fmt.Sprintf("tf-ds-storage-%s", acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudBlockStorageClassicConfig(name),
-				SkipFunc: testOnlyClassic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceID(dataName),
-					testCheckResourceAttrPair(),
-					testAccCheckDataSourceID("data.ncloud_block_storage.by_filter"),
+				Config: composeConfig(
+					testAccBlockStorageVpcConfig(name),
+					testAccDataSourceNcloudBlockStorageConfig,
 				),
-			},
-			{
-				Config:   testAccDataSourceNcloudBlockStorageVpcConfig(name),
-				SkipFunc: testOnlyVpc,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
-					testCheckResourceAttrPair(),
+					resource.TestCheckResourceAttrPair(dataName, "id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataName, "status", resourceName, "status"),
+					resource.TestCheckResourceAttrPair(dataName, "product_code", resourceName, "product_code"),
+					resource.TestCheckResourceAttrPair(dataName, "size", resourceName, "size"),
+					resource.TestCheckResourceAttrPair(dataName, "type", resourceName, "type"),
+					resource.TestCheckResourceAttrPair(dataName, "disk_detail_type", resourceName, "disk_detail_type"),
+					resource.TestCheckResourceAttrPair(dataName, "disk_type", resourceName, "disk_type"),
+					resource.TestCheckResourceAttrPair(dataName, "block_storage_no", resourceName, "block_storage_no"),
+					resource.TestCheckResourceAttrPair(dataName, "server_instance_no", resourceName, "server_instance_no"),
+					resource.TestCheckResourceAttrPair(dataName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataName, "device_name", resourceName, "device_name"),
 					testAccCheckDataSourceID("data.ncloud_block_storage.by_filter"),
 				),
 			},
@@ -70,17 +90,3 @@ data "ncloud_block_storage" "by_filter" {
 	}
 }
 `
-
-func testAccDataSourceNcloudBlockStorageClassicConfig(name string) string {
-	var buf bytes.Buffer
-	buf.WriteString(testAccBlockStorageClassicConfig(name))
-	buf.WriteString(testAccDataSourceNcloudBlockStorageConfig)
-	return buf.String()
-}
-
-func testAccDataSourceNcloudBlockStorageVpcConfig(name string) string {
-	var buf bytes.Buffer
-	buf.WriteString(testAccBlockStorageVpcConfig(name))
-	buf.WriteString(testAccDataSourceNcloudBlockStorageConfig)
-	return buf.String()
-}

--- a/ncloud/data_source_ncloud_init_script_test.go
+++ b/ncloud/data_source_ncloud_init_script_test.go
@@ -15,8 +15,7 @@ func TestAccDataSourceNcloudInitScriptBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudInitScriptConfig,
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudInitScriptConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "name", resourceName, "name"),
@@ -32,13 +31,12 @@ func TestAccDataSourceNcloudInitScriptFilter(t *testing.T) {
 	resourceName := "ncloud_init_script.foo"
 	dataName := "data.ncloud_init_script.by_filter"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudInitScriptConfigFilter,
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudInitScriptConfigFilter,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_init_script.by_filter"),
 					testAccCheckDataSourceID(dataName),

--- a/ncloud/data_source_ncloud_nas_volume_test.go
+++ b/ncloud/data_source_ncloud_nas_volume_test.go
@@ -6,14 +6,22 @@ import (
 	"testing"
 )
 
-func TestAccDataSourceNcloudNasVolumeBasic(t *testing.T) {
+func TestAccDataSourceNcloudNasVolume_classic_basic(t *testing.T) {
+	testAccDataSourceNcloudNasVolumeBasic(t, false)
+}
+
+func TestAccDataSourceNcloudNasVolume_vpc_basic(t *testing.T) {
+	testAccDataSourceNcloudNasVolumeBasic(t, true)
+}
+
+func testAccDataSourceNcloudNasVolumeBasic(t *testing.T, isVpc bool) {
 	dataName := "data.ncloud_nas_volume.by_id"
 	resourceName := "ncloud_nas_volume.test"
 	postfix := getTestPrefix()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNasVolumeConfig(postfix),

--- a/ncloud/data_source_ncloud_nas_volumes_test.go
+++ b/ncloud/data_source_ncloud_nas_volumes_test.go
@@ -6,12 +6,20 @@ import (
 	"testing"
 )
 
-func TestAccDataSourceNcloudNasVolumesBasic(t *testing.T) {
+func TestAccDataSourceNcloudNasVolumes_classic_basic(t *testing.T) {
+	testAccDataSourceNcloudNasVolumesBasic(t, false)
+}
+
+func TestAccDataSourceNcloudNasVolumes_vpc_basic(t *testing.T) {
+	testAccDataSourceNcloudNasVolumesBasic(t, true)
+}
+
+func testAccDataSourceNcloudNasVolumesBasic(t *testing.T, isVpc bool) {
 	postfix := getTestPrefix()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNasVolumesConfig(postfix),

--- a/ncloud/data_source_ncloud_nat_gateway_test.go
+++ b/ncloud/data_source_ncloud_nat_gateway_test.go
@@ -18,8 +18,7 @@ func TestAccDataSourceNcloudNatGateway_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudNatGatewayConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudNatGatewayConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					testAccCheckDataSourceID("data.ncloud_nat_gateway.by_filter"),

--- a/ncloud/data_source_ncloud_network_acls_test.go
+++ b/ncloud/data_source_ncloud_network_acls_test.go
@@ -54,12 +54,22 @@ func TestAccDataSourceNcloudNetworkAclsVpcNo(t *testing.T) {
 
 func testAccDataSourceNcloudNetworkAclsConfig() string {
 	return `
+resource "ncloud_vpc" "test" {
+	name               = "testacc-data-network-acl"
+	ipv4_cidr_block    = "10.2.0.0/16"
+}
+
 data "ncloud_network_acls" "all" {}
 `
 }
 
 func testAccDataSourceNcloudNetworkAclsConfigName(name string) string {
 	return fmt.Sprintf(`
+resource "ncloud_vpc" "test" {
+	name               = "testacc-data-network-acl"
+	ipv4_cidr_block    = "10.2.0.0/16"
+}
+
 data "ncloud_network_acls" "by_name" {
 	name = "%s"
 }

--- a/ncloud/data_source_ncloud_network_acls_test.go
+++ b/ncloud/data_source_ncloud_network_acls_test.go
@@ -13,8 +13,7 @@ func TestAccDataSourceNcloudNetworkAclsBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudNetworkAclsConfig(),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudNetworkAclsConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_network_acls.all"),
 				),
@@ -29,8 +28,7 @@ func TestAccDataSourceNcloudNetworkAclsName(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudNetworkAclsConfigName("default"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudNetworkAclsConfigName("default"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_network_acls.by_name"),
 				),
@@ -45,8 +43,7 @@ func TestAccDataSourceNcloudNetworkAclsVpcNo(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudNetworkAclsConfigVpcNo(),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudNetworkAclsConfigVpcNo(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_network_acls.by_vpc_no"),
 				),

--- a/ncloud/data_source_ncloud_network_interface_test.go
+++ b/ncloud/data_source_ncloud_network_interface_test.go
@@ -18,8 +18,7 @@ func TestAccDataSourceNcloudNetworkInterfaceBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudNetworkInterfaceConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudNetworkInterfaceConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "network_interface_no", resourceName, "network_interface_no"),
@@ -42,13 +41,12 @@ func TestAccDataSourceNcloudNetworkInterfaceFilter(t *testing.T) {
 	resourceName := "ncloud_network_interface.foo"
 	dataName := "data.ncloud_network_interface.by_filter"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudNetworkInterfaceConfigFilter(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudNetworkInterfaceConfigFilter(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_network_interface.by_filter"),
 					testAccCheckDataSourceID(dataName),

--- a/ncloud/data_source_ncloud_network_interfaces_test.go
+++ b/ncloud/data_source_ncloud_network_interfaces_test.go
@@ -40,8 +40,7 @@ func TestAccDataSourceNcloudNetworkInterfaces_privateIp(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudNetworkInterfacesConfigPrivateIp(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudNetworkInterfacesConfigPrivateIp(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "network_interfaces.0.network_interface_no", resourceName, "network_interface_no"),
@@ -64,13 +63,12 @@ func TestAccDataSourceNcloudNetworkInterfaces_filter(t *testing.T) {
 	resourceName := "ncloud_network_interface.foo"
 	dataName := "data.ncloud_network_interfaces.by_filter"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudNetworkInterfacesConfigFilter(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudNetworkInterfacesConfigFilter(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_network_interfaces.by_filter"),
 					testAccCheckDataSourceID(dataName),

--- a/ncloud/data_source_ncloud_placement_group_test.go
+++ b/ncloud/data_source_ncloud_placement_group_test.go
@@ -19,8 +19,7 @@ func TestAccDataSourceNcloudPlacementGroup_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudPlacementGroupConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudPlacementGroupConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					testAccCheckDataSourceID(dataNameFilter),

--- a/ncloud/data_source_ncloud_port_forwarding_rule_test.go
+++ b/ncloud/data_source_ncloud_port_forwarding_rule_test.go
@@ -6,11 +6,9 @@ import (
 )
 
 func TestAccDataSourceNcloudPortForwardingRuleBasic(t *testing.T) {
-	t.Parallel()
-
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudPortForwardingRuleConfig,

--- a/ncloud/data_source_ncloud_port_forwarding_rules_test.go
+++ b/ncloud/data_source_ncloud_port_forwarding_rules_test.go
@@ -7,11 +7,9 @@ import (
 )
 
 func TestAccDataSourceNcloudPortForwardingRulesBasic(t *testing.T) {
-	t.Parallel()
-
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudPortForwardingRulesConfig,

--- a/ncloud/data_source_ncloud_public_ip_test.go
+++ b/ncloud/data_source_ncloud_public_ip_test.go
@@ -7,13 +7,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceNcloudPublicIpBasic(t *testing.T) {
+func TestAccDataSourceNcloudPublicIp_classic_basic(t *testing.T) {
+	testAccDataSourceNcloudPublicIpBasic(t, false)
+}
+
+func TestAccDataSourceNcloudPublicIp_vpc_basic(t *testing.T) {
+	testAccDataSourceNcloudPublicIpBasic(t, true)
+}
+
+func testAccDataSourceNcloudPublicIpBasic(t *testing.T, isVpc bool) {
 	resourceName := "ncloud_public_ip.public_ip"
 	dataName := "data.ncloud_public_ip.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudPublicIpConfig,

--- a/ncloud/data_source_ncloud_public_ip_test.go
+++ b/ncloud/data_source_ncloud_public_ip_test.go
@@ -1,6 +1,8 @@
 package ncloud
 
 import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"regexp"
 	"testing"
 
@@ -8,23 +10,16 @@ import (
 )
 
 func TestAccDataSourceNcloudPublicIp_classic_basic(t *testing.T) {
-	testAccDataSourceNcloudPublicIpBasic(t, false)
-}
-
-func TestAccDataSourceNcloudPublicIp_vpc_basic(t *testing.T) {
-	testAccDataSourceNcloudPublicIpBasic(t, true)
-}
-
-func testAccDataSourceNcloudPublicIpBasic(t *testing.T, isVpc bool) {
 	resourceName := "ncloud_public_ip.public_ip"
 	dataName := "data.ncloud_public_ip.test"
+	name := fmt.Sprintf("tf-public-ip-basic-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: getTestAccProviders(isVpc),
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudPublicIpConfig,
+				Config: testAccDataSourceNcloudPublicIpClassicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "description", resourceName, "description"),
@@ -36,6 +31,29 @@ func testAccDataSourceNcloudPublicIpBasic(t *testing.T, isVpc bool) {
 					resource.TestCheckResourceAttrPair(dataName, "zone", resourceName, "zone"),
 					resource.TestCheckResourceAttrPair(dataName, "internet_line_type", resourceName, "internet_line_type"),
 					resource.TestCheckResourceAttrPair(dataName, "kind_type", resourceName, "kind_type"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNcloudPublicIp_vpc_basic(t *testing.T) {
+	resourceName := "ncloud_public_ip.public_ip"
+	dataName := "data.ncloud_public_ip.test"
+	name := fmt.Sprintf("tf-public-ip-basic-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudPublicIpVpcConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceID(dataName),
+					resource.TestCheckResourceAttrPair(dataName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataName, "public_ip", resourceName, "public_ip"),
+					resource.TestCheckResourceAttrPair(dataName, "server_instance_no", resourceName, "server_instance_no"),
+					resource.TestCheckResourceAttrPair(dataName, "server_name", resourceName, "server_name"),
 				),
 			},
 		},
@@ -84,12 +102,67 @@ func TestAccDataSourceNcloudPublicIpSearch(t *testing.T) {
 	})
 }
 
-var testAccDataSourceNcloudPublicIpConfig = `
-resource "ncloud_public_ip" "public_ip" {}
+func testAccDataSourceNcloudPublicIpClassicConfig(name string) string {
+	return fmt.Sprintf(`
+resource "ncloud_login_key" "loginkey" {
+	key_name = "%[1]s-key"
+}
+
+resource "ncloud_server" "server" {
+	name = "%[1]s"
+	server_image_product_code = "SPSW0LINUX000032"
+	server_product_code = "SPSVRSTAND000004"
+	login_key_name = "${ncloud_login_key.loginkey.key_name}"
+}
+
+resource "ncloud_public_ip" "public_ip" {
+	description = "%[1]s"
+	depends_on = [ncloud_server.server]
+}
+
 data "ncloud_public_ip" "test" {
 	public_ip_no = ncloud_public_ip.public_ip.id
 }
-`
+`, name)
+}
+
+func testAccDataSourceNcloudPublicIpVpcConfig(name string) string {
+	return fmt.Sprintf(`
+resource "ncloud_login_key" "loginkey" {
+	key_name = "%[1]s-key"
+}
+
+resource "ncloud_vpc" "test" {
+	name               = "%[1]s"
+	ipv4_cidr_block    = "10.5.0.0/16"
+}
+
+resource "ncloud_subnet" "test" {
+	vpc_no             = ncloud_vpc.test.vpc_no
+	name               = "%[1]s"
+	subnet             = "10.5.0.0/24"
+	zone               = "KR-2"
+	network_acl_no     = ncloud_vpc.test.default_network_acl_no
+	subnet_type        = "PUBLIC"
+	usage_type         = "GEN"
+}
+
+resource "ncloud_server" "server" {
+	subnet_no = ncloud_subnet.test.id
+	name = "%[1]s"
+	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	login_key_name = ncloud_login_key.loginkey.key_name
+}
+
+resource "ncloud_public_ip" "public_ip" {
+	depends_on = [ncloud_server.server]
+}
+
+data "ncloud_public_ip" "test" {
+	public_ip_no = ncloud_public_ip.public_ip.id
+}
+`, name)
+}
 
 var testAccDataSourceNcloudPublicIpAssociatedConfig = `
 data "ncloud_public_ip" "test" {

--- a/ncloud/data_source_ncloud_regions_test.go
+++ b/ncloud/data_source_ncloud_regions_test.go
@@ -5,12 +5,18 @@ import (
 	"testing"
 )
 
-func TestAccDataSourceNcloudRegionsBasic(t *testing.T) {
-	t.Parallel()
+func TestAccDataSourceNcloudRegions_classic_basic(t *testing.T) {
+	testAccDataSourceNcloudRegionsBasic(t, false)
+}
 
-	resource.Test(t, resource.TestCase{
+func TestAccDataSourceNcloudRegions_vpc_basic(t *testing.T) {
+	testAccDataSourceNcloudRegionsBasic(t, true)
+}
+
+func testAccDataSourceNcloudRegionsBasic(t *testing.T, isVpc bool) {
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudRegionsConfig,

--- a/ncloud/data_source_ncloud_root_password_test.go
+++ b/ncloud/data_source_ncloud_root_password_test.go
@@ -7,7 +7,26 @@ import (
 	"testing"
 )
 
-func TestAccDataSourceNcloudRootPasswordBasic(t *testing.T) {
+func TestAccDataSourceNcloudRootPassword_classic_basic(t *testing.T) {
+	resourceName := "data.ncloud_root_password.default"
+	name := fmt.Sprintf("tf-passwd-basic-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccClassicProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRootPasswordClassicConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "server_instance_no"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_key"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNcloudRootPassword_vpc_basic(t *testing.T) {
 	resourceName := "data.ncloud_root_password.default"
 	name := fmt.Sprintf("tf-passwd-basic-%s", acctest.RandString(5))
 
@@ -16,16 +35,7 @@ func TestAccDataSourceNcloudRootPasswordBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceRootPasswordClassicConfig(name),
-				SkipFunc: testOnlyClassic,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "server_instance_no"),
-					resource.TestCheckResourceAttrSet(resourceName, "private_key"),
-				),
-			},
-			{
-				Config:   testAccDataSourceRootPasswordVpcConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceRootPasswordVpcConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "server_instance_no"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_key"),

--- a/ncloud/data_source_ncloud_route_table_test.go
+++ b/ncloud/data_source_ncloud_route_table_test.go
@@ -18,8 +18,7 @@ func TestAccDataSourceNcloudRouteTable_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudRouteTableConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudRouteTableConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataName, "description", resourceName, "description"),

--- a/ncloud/data_source_ncloud_route_tables_test.go
+++ b/ncloud/data_source_ncloud_route_tables_test.go
@@ -15,8 +15,7 @@ func TestAccDataSourceNcloudRouteTablesBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudRouteTablesConfig(),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudRouteTablesConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_route_tables.all"),
 				),
@@ -34,8 +33,7 @@ func TestAccDataSourceNcloudRouteTablesFilter(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudRouteTablesConfigFilter(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudRouteTablesConfigFilter(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttr(dataName, "route_tables.#", "1"),
@@ -54,8 +52,7 @@ func TestAccDataSourceNcloudRouteTablesName(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudRouteTablesConfigName("test"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudRouteTablesConfigName("test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_route_tables.by_name"),
 				),
@@ -72,8 +69,7 @@ func TestAccDataSourceNcloudRouteTablesVpcNo(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudRouteTablesConfigVpcNo(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudRouteTablesConfigVpcNo(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_route_tables.by_vpc_no"),
 				),

--- a/ncloud/data_source_ncloud_server_image_test.go
+++ b/ncloud/data_source_ncloud_server_image_test.go
@@ -1,18 +1,19 @@
 package ncloud
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceNcloudServerImageByCode(t *testing.T) {
+func TestAccDataSourceNcloudServerImage_classic_byCode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerImageByCodeConfig,
+				Config: testAccDataSourceNcloudServerImageByCodeConfig("SPSW0LINUX000139"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_server_image.test1"),
 				),
@@ -21,13 +22,28 @@ func TestAccDataSourceNcloudServerImageByCode(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudServerImageByFilterProductCode(t *testing.T) {
+func TestAccDataSourceNcloudServerImage_vpc_byCode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerImageByFilterProductCodeConfig,
+				Config: testAccDataSourceNcloudServerImageByCodeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceID("data.ncloud_server_image.test1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNcloudServerImage_classic_byFilterProductCode(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccClassicProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudServerImageByFilterProductCodeConfig("SPSW0LINUX000139"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_server_image.test2"),
 				),
@@ -36,10 +52,33 @@ func TestAccDataSourceNcloudServerImageByFilterProductCode(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudServerImageByFilterProductName(t *testing.T) {
+func TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudServerImageByFilterProductCodeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceID("data.ncloud_server_image.test2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNcloudServerImage_classic_byFilterProductName(t *testing.T) {
+	testAccDataSourceNcloudServerImageByFilterProductName(t, false)
+}
+
+func TestAccDataSourceNcloudServerImage_vpc_byFilterProductName(t *testing.T) {
+	testAccDataSourceNcloudServerImageByFilterProductName(t, true)
+}
+
+func testAccDataSourceNcloudServerImageByFilterProductName(t *testing.T, isVpc bool) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImageByFilterProductNameConfig,
@@ -51,10 +90,18 @@ func TestAccDataSourceNcloudServerImageByFilterProductName(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudServerImageByBlockStorageSize(t *testing.T) {
+func TestAccDataSourceNcloudServerImage_classic_byBlockStorageSize(t *testing.T) {
+	testAccDataSourceNcloudServerImageByBlockStorageSize(t, false)
+}
+
+func TestAccDataSourceNcloudServerImage_vpc_byBlockStorageSize(t *testing.T) {
+	testAccDataSourceNcloudServerImageByBlockStorageSize(t, true)
+}
+
+func testAccDataSourceNcloudServerImageByBlockStorageSize(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImageByBlockStorageSizeConfig,
@@ -66,20 +113,24 @@ func TestAccDataSourceNcloudServerImageByBlockStorageSize(t *testing.T) {
 	})
 }
 
-var testAccDataSourceNcloudServerImageByCodeConfig = `
+func testAccDataSourceNcloudServerImageByCodeConfig(productCode string) string {
+	return fmt.Sprintf(`
 data "ncloud_server_image" "test1" {
-  product_code = "SPSW0LINUX000139"
+  product_code = "%s"
 }
-`
+`, productCode)
+}
 
-var testAccDataSourceNcloudServerImageByFilterProductCodeConfig = `
+func testAccDataSourceNcloudServerImageByFilterProductCodeConfig(productCode string) string {
+	return fmt.Sprintf(`
 data "ncloud_server_image" "test2" {
   filter {
     name = "product_code"
-    values = ["SPSW0LINUX000139"]
+    values = ["%s"]
   }
 }
-`
+`, productCode)
+}
 
 var testAccDataSourceNcloudServerImageByFilterProductNameConfig = `
 data "ncloud_server_image" "test3" {

--- a/ncloud/data_source_ncloud_server_images_test.go
+++ b/ncloud/data_source_ncloud_server_images_test.go
@@ -6,10 +6,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceNcloudServerImagesBasic(t *testing.T) {
+func TestAccDataSourceNcloudServerImages_classic_basic(t *testing.T) {
+	testAccDataSourceNcloudServerImagesBasic(t, false)
+}
+
+func TestAccDataSourceNcloudServerImages_vpc_basic(t *testing.T) {
+	testAccDataSourceNcloudServerImagesBasic(t, false)
+}
+
+func testAccDataSourceNcloudServerImagesBasic(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImagesConfig,
@@ -21,10 +29,18 @@ func TestAccDataSourceNcloudServerImagesBasic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudServerImagesLinux(t *testing.T) {
+func TestAccDataSourceNcloudServerImages_classic_linux(t *testing.T) {
+	testAccDataSourceNcloudServerImagesLinux(t, false)
+}
+
+func TestAccDataSourceNcloudServerImages_vpc_linux(t *testing.T) {
+	testAccDataSourceNcloudServerImagesLinux(t, false)
+}
+
+func testAccDataSourceNcloudServerImagesLinux(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImagesLinuxConfig,
@@ -36,10 +52,18 @@ func TestAccDataSourceNcloudServerImagesLinux(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudServerImagesWindows(t *testing.T) {
+func TestAccDataSourceNcloudServerImages_classic_windows(t *testing.T) {
+	testAccDataSourceNcloudServerImagesWindows(t, false)
+}
+
+func TestAccDataSourceNcloudServerImages_vpc_windows(t *testing.T) {
+	testAccDataSourceNcloudServerImagesWindows(t, false)
+}
+
+func testAccDataSourceNcloudServerImagesWindows(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImagesWindowsConfig,
@@ -51,10 +75,18 @@ func TestAccDataSourceNcloudServerImagesWindows(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudServerImagesBareMetal(t *testing.T) {
+func TestAccDataSourceNcloudServerImages_classic_bareMetal(t *testing.T) {
+	testAccDataSourceNcloudServerImagesBareMetal(t, false)
+}
+
+func TestAccDataSourceNcloudServerImages_vpc_bareMetal(t *testing.T) {
+	testAccDataSourceNcloudServerImagesBareMetal(t, false)
+}
+
+func testAccDataSourceNcloudServerImagesBareMetal(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImagesBareMetalConfig,
@@ -66,10 +98,18 @@ func TestAccDataSourceNcloudServerImagesBareMetal(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudServerImagesBlockStorageSize(t *testing.T) {
+func TestAccDataSourceNcloudServerImages_classic_blockStorageSize(t *testing.T) {
+	testAccDataSourceNcloudServerImagesBlockStorageSize(t, false)
+}
+
+func TestAccDataSourceNcloudServerImages_vpc_blockStorageSize(t *testing.T) {
+	testAccDataSourceNcloudServerImagesBlockStorageSize(t, false)
+}
+
+func testAccDataSourceNcloudServerImagesBlockStorageSize(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImagesBlockStorageSizeConfig,

--- a/ncloud/data_source_ncloud_server_product_test.go
+++ b/ncloud/data_source_ncloud_server_product_test.go
@@ -1,18 +1,19 @@
 package ncloud
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceNcloudServerProductBasic(t *testing.T) {
+func TestAccDataSourceNcloudServerProduct_classic_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductConfig,
+				Config: testAccDataSourceNcloudServerProductConfig("SPSW0LINUX000032", "SPSVRSTAND000056"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_server_product.test1"),
 				),
@@ -21,13 +22,28 @@ func TestAccDataSourceNcloudServerProductBasic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudServerProductFilterByProductCode(t *testing.T) {
+func TestAccDataSourceNcloudServerProduct_vpc_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductFilterByProductCodeConfig,
+				Config: testAccDataSourceNcloudServerProductConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050", "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceID("data.ncloud_server_product.test1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccClassicProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudServerProductFilterByProductCodeConfig("SPSW0LINUX000032", "SPSVRSTAND000056"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_server_product.test2"),
 				),
@@ -36,13 +52,32 @@ func TestAccDataSourceNcloudServerProductFilterByProductCode(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceNcloudServerProductFilterByProductNameProductType(t *testing.T) {
+func TestAccDataSourceNcloudServerProduct_vpc_FilterByProductCode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig,
+				Config: testAccDataSourceNcloudServerProductFilterByProductCodeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050", "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceID("data.ncloud_server_product.test2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccClassicProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig("SPSW0LINUX000032"),
+				// ignore check: `generation_code` is will be added classic env.
+				SkipFunc: func() (bool, error) {
+					return skipNoResultsTest, nil
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_server_product.test3"),
 				),
@@ -51,34 +86,59 @@ func TestAccDataSourceNcloudServerProductFilterByProductNameProductType(t *testi
 	})
 }
 
-var testAccDataSourceNcloudServerProductConfig = `
-data "ncloud_server_product" "test1" {
-	server_image_product_code = "SPSW0LINUX000032"
-  product_code = "SPSVRSTAND000056"
+func TestAccDataSourceNcloudServerProduct_vpc_FilterByProductNameProductType(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceID("data.ncloud_server_product.test3"),
+				),
+			},
+		},
+	})
 }
-`
 
-var testAccDataSourceNcloudServerProductFilterByProductCodeConfig = `
-data "ncloud_server_product" "test2" {
-	server_image_product_code = "SPSW0LINUX000032"
-  filter {
-    name = "product_code"
-    values = ["SPSVRSTAND000056"]
+func testAccDataSourceNcloudServerProductConfig(imageProductCode, productCode string) string {
+	return fmt.Sprintf(`
+data "ncloud_server_product" "test1" {
+	server_image_product_code = "%s"
+	product_code = "%s"
+}
+`, imageProductCode, productCode)
+}
+
+func testAccDataSourceNcloudServerProductFilterByProductCodeConfig(imageProductCode, productCode string) string {
+	return fmt.Sprintf(`
+ data "ncloud_server_product" "test2" {
+	server_image_product_code = "%s"
+	filter {
+		name = "product_code"
+		values = ["%s"]
 	}
 }
-`
-
-var testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig = `
-data "ncloud_server_product" "test3" {
-	server_image_product_code = "SPSW0LINUX000032"
-  filter {
-    name = "product_name"
-    values = ["vCPU 1EA, Memory 1GB, Disk 50GB"]
-  }
-
-  filter {
-    name = "product_type"
-    values = ["MICRO"]
-  }
+`, imageProductCode, productCode)
 }
-`
+
+func testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig(imageProductCode string) string {
+	return fmt.Sprintf(`
+data "ncloud_server_product" "test3" {
+	server_image_product_code = "%s"
+	filter {
+		name = "product_name"
+		values = ["vCPU 2EA, Memory 8GB, Disk 50GB"]
+	}
+
+	filter {
+		name = "product_type"
+		values = ["STAND"]
+	}
+
+	filter {
+		name = "generation_code"
+		values = ["G2"]
+	}
+}`, imageProductCode)
+}

--- a/ncloud/data_source_ncloud_server_products_test.go
+++ b/ncloud/data_source_ncloud_server_products_test.go
@@ -1,18 +1,21 @@
 package ncloud
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceNcloudServerProductsBasic(t *testing.T) {
+func TestAccDataSourceNcloudServerProducts_classic_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:   func() { testAccPreCheck(t) },
+		IsUnitTest: false,
+		Providers:  testAccClassicProviders,
+
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductsConfig,
+				Config: testAccDataSourceNcloudServerProductsConfig("SPSW0LINUX000032"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_server_products.all"),
 				),
@@ -21,8 +24,27 @@ func TestAccDataSourceNcloudServerProductsBasic(t *testing.T) {
 	})
 }
 
-var testAccDataSourceNcloudServerProductsConfig = `
-data "ncloud_server_products" "all" {
-	server_image_product_code = "SPSW0LINUX000032"
+func TestAccDataSourceNcloudServerProducts_vpc_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:   func() { testAccPreCheck(t) },
+		IsUnitTest: false,
+		Providers:  testAccProviders,
+
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudServerProductsConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceID("data.ncloud_server_products.all"),
+				),
+			},
+		},
+	})
 }
-`
+
+func testAccDataSourceNcloudServerProductsConfig(productCode string) string {
+	return fmt.Sprintf(`
+data "ncloud_server_products" "all" {
+	server_image_product_code = "%s"
+}
+`, productCode)
+}

--- a/ncloud/data_source_ncloud_server_test.go
+++ b/ncloud/data_source_ncloud_server_test.go
@@ -18,8 +18,7 @@ func TestAccDataSourceNcloudServer_vpc_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceServerVpcConfig(testServerName),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceServerVpcConfig(testServerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestMatchResourceAttr(dataName, "id", regexp.MustCompile(`^\d+$`)),
@@ -57,11 +56,10 @@ func TestAccDataSourceNcloudServer_classic_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceServerClassicConfig(testServerName),
-				SkipFunc: testOnlyClassic,
+				Config: testAccDataSourceServerClassicConfig(testServerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestMatchResourceAttr(dataName, "id", regexp.MustCompile(`^\d+$`)),

--- a/ncloud/data_source_ncloud_subnet_test.go
+++ b/ncloud/data_source_ncloud_subnet_test.go
@@ -19,8 +19,7 @@ func TestAccDataSourceNcloudSubnet(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudSubnetConfig(name, cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudSubnetConfig(name, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "subnet_no", resourceName, "subnet_no"),

--- a/ncloud/data_source_ncloud_subnets_test.go
+++ b/ncloud/data_source_ncloud_subnets_test.go
@@ -13,8 +13,7 @@ func TestAccDataSourceNcloudSubnetsBasic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudSubnetsConfig(),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudSubnetsConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_subnets.all"),
 				),
@@ -29,8 +28,7 @@ func TestAccDataSourceNcloudSubnetsName(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudSubnetsConfigSubnet("10.2.1.0"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudSubnetsConfigSubnet("10.2.1.0"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_subnets.by_cidr"),
 				),
@@ -45,8 +43,7 @@ func TestAccDataSourceNcloudSubnetsVpcNo(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudSubnetsConfigVpcNo("502"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudSubnetsConfigVpcNo("502"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_subnets.by_vpc_no"),
 				),

--- a/ncloud/data_source_ncloud_vpc_peering_test.go
+++ b/ncloud/data_source_ncloud_vpc_peering_test.go
@@ -21,8 +21,7 @@ func TestAccDataSourceNcloudVpcPeering_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudVpcPeeringConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudVpcPeeringConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testVpcPeeringCheckResourceAttrPair(dataNameByName, resourceName),
 					testVpcPeeringCheckResourceAttrPair(dataNameBySourceName, resourceName),

--- a/ncloud/data_source_ncloud_vpc_test.go
+++ b/ncloud/data_source_ncloud_vpc_test.go
@@ -20,8 +20,7 @@ func TestAccDataSourceNcloudVpc(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudVpcConfig(name, cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudVpcConfig(name, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "vpc_no", resourceName, "vpc_no"),

--- a/ncloud/data_source_ncloud_vpcs_test.go
+++ b/ncloud/data_source_ncloud_vpcs_test.go
@@ -8,13 +8,12 @@ import (
 )
 
 func TestAccDataSourceNcloudVpcsBasic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudVpcsConfig(),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudVpcsConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_vpcs.all"),
 				),
@@ -24,13 +23,12 @@ func TestAccDataSourceNcloudVpcsBasic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudVpcsName(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudVpcsConfigName("test"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudVpcsConfigName("test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_vpcs.by_name"),
 				),
@@ -40,13 +38,12 @@ func TestAccDataSourceNcloudVpcsName(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudVpcsVpcNo(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				SkipFunc: testOnlyVpc,
-				Config:   testAccDataSourceNcloudVpcsConfigVpcNo("446"),
+				Config: testAccDataSourceNcloudVpcsConfigVpcNo("446"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_vpcs.by_vpc_no"),
 					testAccCheckDataSourceID("data.ncloud_vpcs.by_filter"),

--- a/ncloud/data_source_ncloud_zones_test.go
+++ b/ncloud/data_source_ncloud_zones_test.go
@@ -6,12 +6,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourceNcloudZonesBasic(t *testing.T) {
-	t.Parallel()
+func TestAccDataSourceNcloudZones_classic_basic(t *testing.T) {
+	testAccDataSourceNcloudZonesBasic(t, false)
+}
 
-	resource.Test(t, resource.TestCase{
+func TestAccDataSourceNcloudZones_vpc_basic(t *testing.T) {
+	testAccDataSourceNcloudZonesBasic(t, true)
+}
+
+func testAccDataSourceNcloudZonesBasic(t *testing.T, isVpc bool) {
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: getTestAccProviders(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudZonesConfig,

--- a/ncloud/provider.go
+++ b/ncloud/provider.go
@@ -1,12 +1,9 @@
 package ncloud
 
 import (
-	"fmt"
-	"os"
-	"strconv"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"os"
 )
 
 var NcloudResources map[string]*schema.Resource
@@ -48,7 +45,7 @@ func schemaMap() map[string]*schema.Schema {
 			Description: descriptions["site"],
 		},
 		"support_vpc": {
-			Type:        schema.TypeString,
+			Type:        schema.TypeBool,
 			Optional:    true,
 			DefaultFunc: schema.EnvDefaultFunc("NCLOUD_SUPPORT_VPC", nil),
 			Description: descriptions["support_vpc"],
@@ -80,13 +77,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		}
 	}
 
-	if supportVpc, ok := d.GetOk("support_vpc"); ok {
-		b, err := strconv.ParseBool(supportVpc.(string))
-		if err != nil {
-			fmt.Errorf("error to converting bool `support_vpc`: %s", supportVpc)
-		}
-		providerConfig.SupportVPC = b
-	}
+	providerConfig.SupportVPC = d.Get("support_vpc").(bool)
 
 	client, err := config.Client()
 	if err != nil {

--- a/ncloud/provider.go
+++ b/ncloud/provider.go
@@ -1,7 +1,9 @@
 package ncloud
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -12,41 +14,45 @@ var NcloudDataSources map[string]*schema.Resource
 
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
-		Schema: map[string]*schema.Schema{
-			"access_key": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NCLOUD_ACCESS_KEY", nil),
-				Description: descriptions["access_key"],
-			},
-			"secret_key": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NCLOUD_SECRET_KEY", nil),
-				Description: descriptions["secret_key"],
-			},
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NCLOUD_REGION", nil),
-				Description: descriptions["region"],
-			},
-			"site": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NCLOUD_SITE", nil),
-				Description: descriptions["site"],
-			},
-			"support_vpc": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NCLOUD_SUPPORT_VPC", nil),
-				Description: descriptions["support_vpc"],
-			},
-		},
+		Schema:         schemaMap(),
 		DataSourcesMap: DataSourcesMap(),
 		ResourcesMap:   ResourcesMap(),
 		ConfigureFunc:  providerConfigure,
+	}
+}
+
+func schemaMap() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"access_key": {
+			Type:        schema.TypeString,
+			Required:    true,
+			DefaultFunc: schema.EnvDefaultFunc("NCLOUD_ACCESS_KEY", nil),
+			Description: descriptions["access_key"],
+		},
+		"secret_key": {
+			Type:        schema.TypeString,
+			Required:    true,
+			DefaultFunc: schema.EnvDefaultFunc("NCLOUD_SECRET_KEY", nil),
+			Description: descriptions["secret_key"],
+		},
+		"region": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("NCLOUD_REGION", nil),
+			Description: descriptions["region"],
+		},
+		"site": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("NCLOUD_SITE", nil),
+			Description: descriptions["site"],
+		},
+		"support_vpc": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("NCLOUD_SUPPORT_VPC", nil),
+			Description: descriptions["support_vpc"],
+		},
 	}
 }
 
@@ -75,7 +81,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	if supportVpc, ok := d.GetOk("support_vpc"); ok {
-		providerConfig.SupportVPC = supportVpc.(bool)
+		b, err := strconv.ParseBool(supportVpc.(string))
+		if err != nil {
+			fmt.Errorf("error to converting bool `support_vpc`: %s", supportVpc)
+		}
+		providerConfig.SupportVPC = b
 	}
 
 	client, err := config.Client()

--- a/ncloud/provider_test.go
+++ b/ncloud/provider_test.go
@@ -61,7 +61,7 @@ func getTestAccProvider(isVpc bool) terraform.ResourceProvider {
 		ResourcesMap:   ResourcesMap(),
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {
 			d.Set("region", testAccGetRegion())
-			d.Set("support_vpc", fmt.Sprintf("%v", isVpc))
+			d.Set("support_vpc", isVpc)
 			return providerConfigure(d)
 		},
 	}

--- a/ncloud/provider_test.go
+++ b/ncloud/provider_test.go
@@ -24,7 +24,6 @@ var credsEnvVars = []string{
 }
 
 var regionEnvVar = "NCLOUD_REGION"
-var supportVpcEnvVar = "NCLOUD_SUPPORT_VPC"
 
 func init() {
 	testAccProvider = getTestAccProvider(true).(*schema.Provider)

--- a/ncloud/resource_ncloud_access_control_group_rule_test.go
+++ b/ncloud/resource_ncloud_access_control_group_rule_test.go
@@ -25,8 +25,7 @@ func TestAccResourceNcloudAccessControlGroupRule_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAccessControlGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudAccessControlGroupRuleConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudAccessControlGroupRuleConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessControlGroupRuleExists(resourceName, &AccessControlGroupRule),
 					resource.TestMatchResourceAttr(resourceName, "access_control_group_no", regexp.MustCompile(`^\d+$`)),
@@ -44,7 +43,6 @@ func TestAccResourceNcloudAccessControlGroupRule_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateIdFunc: testAccNcloudAccessControlGroupImportStateIDFunc(resourceName),
@@ -89,8 +87,7 @@ func TestAccResourceNcloudAccessControlGroupRule_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAccessControlGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudAccessControlGroupRuleConfigDisappear(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudAccessControlGroupRuleConfigDisappear(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessControlGroupRuleExists(resourceName, &AccessControlGroupRule),
 					testAccCheckAccessControlGroupRuleDisappears(&AccessControlGroupRule),

--- a/ncloud/resource_ncloud_access_control_group_test.go
+++ b/ncloud/resource_ncloud_access_control_group_test.go
@@ -23,8 +23,7 @@ func TestAccResourceNcloudAccessControlGroup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAccessControlGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudAccessControlGroupConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudAccessControlGroupConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessControlGroupExists(resourceName, &AccessControlGroup),
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
@@ -36,7 +35,6 @@ func TestAccResourceNcloudAccessControlGroup_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -56,8 +54,7 @@ func TestAccResourceNcloudAccessControlGroup_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckAccessControlGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudAccessControlGroupConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudAccessControlGroupConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccessControlGroupExists(resourceName, &AccessControlGroup),
 					testAccCheckAccessControlGroupDisappears(&AccessControlGroup),

--- a/ncloud/resource_ncloud_block_storage_snapshot_test.go
+++ b/ncloud/resource_ncloud_block_storage_snapshot_test.go
@@ -32,12 +32,11 @@ func ignore_TestAccResourceNcloudBlockStorageSnapshotBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccClassicProviders,
 		CheckDestroy: testAccCheckBlockStorageSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccBlockStorageSnapshotConfig(testLoginKeyName, testServerInstanceName, testBlockStorageName, testSnapshotName),
-				SkipFunc: testOnlyClassic,
+				Config: testAccBlockStorageSnapshotConfig(testLoginKeyName, testServerInstanceName, testBlockStorageName, testSnapshotName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBlockStorageSnapshotExists(
 						"ncloud_block_storage_snapshot.ss", &snapshotInstance),
@@ -49,7 +48,6 @@ func ignore_TestAccResourceNcloudBlockStorageSnapshotBasic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyClassic,
 				ResourceName:      "ncloud_block_storage_snapshot.ss",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -59,7 +57,7 @@ func ignore_TestAccResourceNcloudBlockStorageSnapshotBasic(t *testing.T) {
 }
 
 func testAccCheckBlockStorageSnapshotExists(n string, i *server.BlockStorageSnapshotInstance) resource.TestCheckFunc {
-	return testAccCheckBlockStorageSnapshotExistsWithProvider(n, i, func() *schema.Provider { return testAccProvider })
+	return testAccCheckBlockStorageSnapshotExistsWithProvider(n, i, func() *schema.Provider { return testAccClassicProvider })
 }
 
 func testAccCheckBlockStorageSnapshotExistsWithProvider(n string, i *server.BlockStorageSnapshotInstance, providerF func() *schema.Provider) resource.TestCheckFunc {
@@ -92,7 +90,7 @@ func testAccCheckBlockStorageSnapshotExistsWithProvider(n string, i *server.Bloc
 }
 
 func testAccCheckBlockStorageSnapshotDestroy(s *terraform.State) error {
-	return testAccCheckBlockStorageSnapshotDestroyWithProvider(s, testAccProvider)
+	return testAccCheckBlockStorageSnapshotDestroyWithProvider(s, testAccClassicProvider)
 }
 
 func testAccCheckBlockStorageSnapshotDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {

--- a/ncloud/resource_ncloud_block_storage_test.go
+++ b/ncloud/resource_ncloud_block_storage_test.go
@@ -11,21 +11,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccResourceNcloudBlockStorage_Classic_basic(t *testing.T) {
+func TestAccResourceNcloudBlockStorage_classic_basic(t *testing.T) {
 	var storageInstance BlockStorage
 	name := fmt.Sprintf("tf-storage-basic-%s", acctest.RandString(5))
 	resourceName := "ncloud_block_storage.storage"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBlockStorageDestroy,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccClassicProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccCheckBlockStorageDestroyWithProvider(state, testAccClassicProvider)
+		},
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccBlockStorageClassicConfig(name),
-				SkipFunc: testOnlyClassic,
+				Config: testAccBlockStorageClassicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageExists(resourceName, &storageInstance),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccClassicProvider),
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "status", "ATTAC"),
@@ -41,7 +42,6 @@ func TestAccResourceNcloudBlockStorage_Classic_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyClassic,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -50,21 +50,22 @@ func TestAccResourceNcloudBlockStorage_Classic_basic(t *testing.T) {
 	})
 }
 
-func TestAccResourceNcloudBlockStorage_Vpc_basic(t *testing.T) {
+func TestAccResourceNcloudBlockStorage_vpc_basic(t *testing.T) {
 	var storageInstance BlockStorage
 	name := fmt.Sprintf("tf-storage-basic-%s", acctest.RandString(5))
 	resourceName := "ncloud_block_storage.storage"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBlockStorageDestroy,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccCheckBlockStorageDestroyWithProvider(state, testAccProvider)
+		},
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccBlockStorageVpcConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccBlockStorageVpcConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageExists(resourceName, &storageInstance),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccProvider),
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "status", "ATTAC"),
@@ -80,7 +81,6 @@ func TestAccResourceNcloudBlockStorage_Vpc_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -89,67 +89,63 @@ func TestAccResourceNcloudBlockStorage_Vpc_basic(t *testing.T) {
 	})
 }
 
-func TestAccResourceNcloudBlockStorage_Classic_ChangeServerInstance(t *testing.T) {
+func TestAccResourceNcloudBlockStorage_classic_ChangeServerInstance(t *testing.T) {
 	var storageInstance BlockStorage
 	name := fmt.Sprintf("tf-storage-update-%s", acctest.RandString(5))
 	resourceName := "ncloud_block_storage.storage"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBlockStorageDestroy,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccClassicProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccCheckBlockStorageDestroyWithProvider(state, testAccClassicProvider)
+		},
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccBlockStorageClassicConfigUpdate(name, "ncloud_server.foo.id"),
-				SkipFunc: testOnlyClassic,
+				Config: testAccBlockStorageClassicConfigUpdate(name, "ncloud_server.foo.id"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageExists(resourceName, &storageInstance),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccClassicProvider),
 				),
 			},
 			{
-				Config:   testAccBlockStorageClassicConfigUpdate(name, "ncloud_server.bar.id"),
-				SkipFunc: testOnlyClassic,
+				Config: testAccBlockStorageClassicConfigUpdate(name, "ncloud_server.bar.id"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageExists(resourceName, &storageInstance),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccClassicProvider),
 				),
 			},
 		},
 	})
 }
 
-func TestAccResourceNcloudBlockStorage_Vpc_ChangeServerInstance(t *testing.T) {
+func TestAccResourceNcloudBlockStorage_vpc_ChangeServerInstance(t *testing.T) {
 	var storageInstance BlockStorage
 	name := fmt.Sprintf("tf-storage-update-%s", acctest.RandString(5))
 	resourceName := "ncloud_block_storage.storage"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBlockStorageDestroy,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccCheckBlockStorageDestroyWithProvider(state, testAccProvider)
+		},
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccBlockStorageVpcConfigUpdate(name, "ncloud_server.foo.id"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccBlockStorageVpcConfigUpdate(name, "ncloud_server.foo.id"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageExists(resourceName, &storageInstance),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccProvider),
 				),
 			},
 			{
-				Config:   testAccBlockStorageVpcConfigUpdate(name, "ncloud_server.bar.id"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccBlockStorageVpcConfigUpdate(name, "ncloud_server.bar.id"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageExists(resourceName, &storageInstance),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccProvider),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckBlockStorageExists(n string, i *BlockStorage) resource.TestCheckFunc {
-	return testAccCheckBlockStorageExistsWithProvider(n, i, func() *schema.Provider { return testAccProvider })
-}
-
-func testAccCheckBlockStorageExistsWithProvider(n string, i *BlockStorage, providerF func() *schema.Provider) resource.TestCheckFunc {
+func testAccCheckBlockStorageExistsWithProvider(n string, i *BlockStorage, provider *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -160,7 +156,6 @@ func testAccCheckBlockStorageExistsWithProvider(n string, i *BlockStorage, provi
 			return fmt.Errorf("no ID is set")
 		}
 
-		provider := providerF()
 		config := provider.Meta().(*ProviderConfig)
 		storage, err := getBlockStorage(config, rs.Primary.ID)
 		if err != nil {
@@ -174,10 +169,6 @@ func testAccCheckBlockStorageExistsWithProvider(n string, i *BlockStorage, provi
 
 		return fmt.Errorf("block storage not found")
 	}
-}
-
-func testAccCheckBlockStorageDestroy(s *terraform.State) error {
-	return testAccCheckBlockStorageDestroyWithProvider(s, testAccProvider)
 }
 
 func testAccCheckBlockStorageDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
@@ -312,7 +303,7 @@ resource "ncloud_subnet" "test" {
 
 resource "ncloud_server" "foo" {
 	subnet_no = ncloud_subnet.test.id
-	name = "%[1]s"
+	name = "%[1]s-foo"
 	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	login_key_name = ncloud_login_key.loginkey.key_name
@@ -320,7 +311,7 @@ resource "ncloud_server" "foo" {
 
 resource "ncloud_server" "bar" {
 	subnet_no = ncloud_subnet.test.id
-	name = "%[1]s"
+	name = "%[1]s-bar"
 	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	login_key_name = ncloud_login_key.loginkey.key_name

--- a/ncloud/resource_ncloud_init_script_test.go
+++ b/ncloud/resource_ncloud_init_script_test.go
@@ -22,14 +22,12 @@ func TestAccResourceNcloudInitScript_basic(t *testing.T) {
 		CheckDestroy: testAccCheckInitScriptDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudInitScriptConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudInitScriptConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitScriptExists(resourceName, &InitScript),
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -49,8 +47,7 @@ func TestAccResourceNcloudInitScript_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckInitScriptDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudInitScriptConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudInitScriptConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitScriptExists(resourceName, &InitScript),
 					testAccCheckInitScriptDisappears(&InitScript),

--- a/ncloud/resource_ncloud_load_balancer_ssl_certificate_test.go
+++ b/ncloud/resource_ncloud_load_balancer_ssl_certificate_test.go
@@ -80,12 +80,11 @@ GTfhUTV7jTQ0dt9U1E+oxRkjqC2HFYlpewXP0rcQxhtK7p6kiaUDIw==
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccClassicProviders,
 		CheckDestroy: testAccCheckLoadBalancerSSLCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccLoadBalancerSSLCertificateConfig(testSSLCertificateName, testPrivateKey, testCertPEM, testLoadBalancerName),
-				SkipFunc: testOnlyClassic,
+				Config: testAccLoadBalancerSSLCertificateConfig(testSSLCertificateName, testPrivateKey, testCertPEM, testLoadBalancerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLoadBalancerSSLCertificateExists("ncloud_load_balancer_ssl_certificate.cert", &sc),
 					testCheck(),
@@ -104,7 +103,6 @@ GTfhUTV7jTQ0dt9U1E+oxRkjqC2HFYlpewXP0rcQxhtK7p6kiaUDIw==
 				),
 			},
 			{
-				SkipFunc:          testOnlyClassic,
 				ResourceName:      "ncloud_load_balancer_ssl_certificate.cert",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -114,7 +112,7 @@ GTfhUTV7jTQ0dt9U1E+oxRkjqC2HFYlpewXP0rcQxhtK7p6kiaUDIw==
 }
 
 func testAccCheckLoadBalancerSSLCertificateExists(n string, i *loadbalancer.SslCertificate) resource.TestCheckFunc {
-	return testAccCheckLoadBalancerSSLCertificateExistsWithProvider(n, i, func() *schema.Provider { return testAccProvider })
+	return testAccCheckLoadBalancerSSLCertificateExistsWithProvider(n, i, func() *schema.Provider { return testAccClassicProvider })
 }
 
 func testAccCheckLoadBalancerSSLCertificateExistsWithProvider(n string, i *loadbalancer.SslCertificate, providerF func() *schema.Provider) resource.TestCheckFunc {
@@ -145,7 +143,7 @@ func testAccCheckLoadBalancerSSLCertificateExistsWithProvider(n string, i *loadb
 }
 
 func testAccCheckLoadBalancerSSLCertificateDestroy(s *terraform.State) error {
-	return testAccCheckLoadBalancerSSLCertificateDestroyWithProvider(s, testAccProvider)
+	return testAccCheckLoadBalancerSSLCertificateDestroyWithProvider(s, testAccClassicProvider)
 }
 
 func testAccCheckLoadBalancerSSLCertificateDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {

--- a/ncloud/resource_ncloud_load_balancer_test.go
+++ b/ncloud/resource_ncloud_load_balancer_test.go
@@ -26,12 +26,11 @@ func TestAccNcloudLoadBalancerBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccClassicProviders,
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccLoadBalancerConfig(testLoadBalancerName),
-				SkipFunc: testOnlyClassic,
+				Config: testAccLoadBalancerConfig(testLoadBalancerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLoadBalancerExists("ncloud_load_balancer.lb", &loadBalancerInstance),
 					testCheck(),
@@ -46,7 +45,6 @@ func TestAccNcloudLoadBalancerBasic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:                testOnlyClassic,
 				ResourceName:            "ncloud_load_balancer.lb",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -64,19 +62,17 @@ func TestAccNcloudLoadBalancerChangeConfiguration(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccClassicProviders,
 		CheckDestroy: testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccLoadBalancerConfig(testLoadBalancerName),
-				SkipFunc: testOnlyClassic,
+				Config: testAccLoadBalancerConfig(testLoadBalancerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLoadBalancerExists("ncloud_load_balancer.lb", &before),
 				),
 			},
 			{
-				Config:   testAccLoadBalancerChangedConfig(testLoadBalancerName),
-				SkipFunc: testOnlyClassic,
+				Config: testAccLoadBalancerChangedConfig(testLoadBalancerName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLoadBalancerExists("ncloud_load_balancer.lb", &after),
 					resource.TestCheckResourceAttr(
@@ -85,7 +81,6 @@ func TestAccNcloudLoadBalancerChangeConfiguration(t *testing.T) {
 						"tftest_lb change port")),
 			},
 			{
-				SkipFunc:                testOnlyClassic,
 				ResourceName:            "ncloud_load_balancer.lb",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -96,7 +91,7 @@ func TestAccNcloudLoadBalancerChangeConfiguration(t *testing.T) {
 }
 
 func testAccCheckLoadBalancerExists(n string, i *loadbalancer.LoadBalancerInstance) resource.TestCheckFunc {
-	return testAccCheckLoadBalancerExistsWithProvider(n, i, func() *schema.Provider { return testAccProvider })
+	return testAccCheckLoadBalancerExistsWithProvider(n, i, func() *schema.Provider { return testAccClassicProvider })
 }
 
 func testAccCheckLoadBalancerExistsWithProvider(n string, i *loadbalancer.LoadBalancerInstance, providerF func() *schema.Provider) resource.TestCheckFunc {
@@ -127,7 +122,7 @@ func testAccCheckLoadBalancerExistsWithProvider(n string, i *loadbalancer.LoadBa
 }
 
 func testAccCheckLoadBalancerDestroy(s *terraform.State) error {
-	return testAccCheckLoadBalancerDestroyWithProvider(s, testAccProvider)
+	return testAccCheckLoadBalancerDestroyWithProvider(s, testAccClassicProvider)
 }
 
 func testAccCheckLoadBalancerDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {

--- a/ncloud/resource_ncloud_login_key_test.go
+++ b/ncloud/resource_ncloud_login_key_test.go
@@ -9,7 +9,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccResourceNcloudLoginKeyBasic(t *testing.T) {
+func TestAccResourceNcloudLoginKey_classic_basic(t *testing.T) {
+	testAccResourceNcloudLoginKeyBasic(t, false)
+}
+
+func TestAccResourceNcloudLoginKey_vpc_basic(t *testing.T) {
+	testAccResourceNcloudLoginKeyBasic(t, true)
+}
+
+func testAccResourceNcloudLoginKeyBasic(t *testing.T, isVpc bool) {
 	var fingerprint *string
 	prefix := getTestPrefix()
 	testKeyName := prefix + "-key"
@@ -22,16 +30,19 @@ func TestAccResourceNcloudLoginKeyBasic(t *testing.T) {
 			return nil
 		}
 	}
+	provider := getTestProvider(isVpc)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckLoginKeyDestroy,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: getTestAccProviders(isVpc),
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccCheckLoginKeyDestroyWithProvider(state, provider)
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLoginKeyConfig(testKeyName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLoginKeyExists("ncloud_login_key.loginkey", fingerprint),
+					testAccCheckLoginKeyExistsWithProvider("ncloud_login_key.loginkey", fingerprint, provider),
 					testCheck(),
 					resource.TestCheckResourceAttr(
 						"ncloud_login_key.loginkey",
@@ -49,11 +60,7 @@ func TestAccResourceNcloudLoginKeyBasic(t *testing.T) {
 	})
 }
 
-func testAccCheckLoginKeyExists(n string, i *string) resource.TestCheckFunc {
-	return testAccCheckLoginKeyExistsWithProvider(n, i, func() *schema.Provider { return testAccProvider })
-}
-
-func testAccCheckLoginKeyExistsWithProvider(n string, i *string, providerF func() *schema.Provider) resource.TestCheckFunc {
+func testAccCheckLoginKeyExistsWithProvider(n string, i *string, provider *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -64,7 +71,6 @@ func testAccCheckLoginKeyExistsWithProvider(n string, i *string, providerF func(
 			return fmt.Errorf("no ID is set")
 		}
 
-		provider := providerF()
 		config := provider.Meta().(*ProviderConfig)
 		fingerPrint, err := getFingerPrint(config, &rs.Primary.ID)
 		if err != nil {
@@ -78,10 +84,6 @@ func testAccCheckLoginKeyExistsWithProvider(n string, i *string, providerF func(
 
 		return fmt.Errorf("fingerprint is not found")
 	}
-}
-
-func testAccCheckLoginKeyDestroy(s *terraform.State) error {
-	return testAccCheckLoginKeyDestroyWithProvider(s, testAccProvider)
 }
 
 func testAccCheckLoginKeyDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {

--- a/ncloud/resource_ncloud_nat_gateway_test.go
+++ b/ncloud/resource_ncloud_nat_gateway_test.go
@@ -23,8 +23,7 @@ func TestAccResourceNcloudNatGateway_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNatGatewayConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNatGatewayConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatGatewayExists(resourceName, &natGateway),
 					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
@@ -33,7 +32,6 @@ func TestAccResourceNcloudNatGateway_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -53,8 +51,7 @@ func TestAccResourceNcloudNatGateway_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNatGatewayConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNatGatewayConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatGatewayExists(resourceName, &natGateway),
 					testAccCheckNatGatewayDisappears(&natGateway),
@@ -76,8 +73,7 @@ func TestAccResourceNcloudNatGateway_onlyRequiredParam(t *testing.T) {
 		CheckDestroy: testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNatGatewayConfigOnlyRequiredParam(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNatGatewayConfigOnlyRequiredParam(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatGatewayExists(resourceName, &natGateway),
 					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
@@ -86,7 +82,6 @@ func TestAccResourceNcloudNatGateway_onlyRequiredParam(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -107,16 +102,14 @@ func TestAccResourceNcloudNatGateway_updateName(t *testing.T) {
 		CheckDestroy: testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNatGatewayConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNatGatewayConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatGatewayExists(resourceName, &natGateway),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudNatGatewayConfigUpdate(name, updateName),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNatGatewayConfigUpdate(name, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatGatewayExists(resourceName, &natGateway),
 				),
@@ -137,23 +130,20 @@ func TestAccResourceNcloudNatGateway_description(t *testing.T) {
 		CheckDestroy: testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNatGatewayConfigDescription(name, "foo"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNatGatewayConfigDescription(name, "foo"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatGatewayExists(resourceName, &natGateway),
 					resource.TestCheckResourceAttr(resourceName, "description", "foo"),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudNatGatewayConfigDescription(name, "bar"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNatGatewayConfigDescription(name, "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatGatewayExists(resourceName, &natGateway),
 					resource.TestCheckResourceAttr(resourceName, "description", "bar"),
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/ncloud/resource_ncloud_network_acl_rule_test.go
+++ b/ncloud/resource_ncloud_network_acl_rule_test.go
@@ -24,8 +24,7 @@ func TestAccResourceNcloudNetworkACLRule_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNetworkACLRuleConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkACLRuleConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLRuleExists("ncloud_network_acl_rule.nacl_rule_inbound_100", &networkACLRule),
 					testAccCheckNetworkACLRuleExists("ncloud_network_acl_rule.nacl_rule_inbound_110", &networkACLRule),
@@ -34,14 +33,12 @@ func TestAccResourceNcloudNetworkACLRule_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      "ncloud_network_acl_rule.nacl_rule_inbound_100",
 				ImportState:       true,
 				ImportStateIdFunc: testAccNcloudNetworkACLRuleImportStateIDFunc("ncloud_network_acl_rule.nacl_rule_inbound_100"),
 				ImportStateVerify: true,
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      "ncloud_network_acl_rule.nacl_rule_outbound_100",
 				ImportState:       true,
 				ImportStateIdFunc: testAccNcloudNetworkACLRuleImportStateIDFunc("ncloud_network_acl_rule.nacl_rule_outbound_100"),
@@ -62,8 +59,7 @@ func TestAccResourceNcloudNetworkACLRule_AssociatedSubnet(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNetworkACLRuleConfigAssociatedSubnet(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkACLRuleConfigAssociatedSubnet(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLRuleExists("ncloud_network_acl_rule.nacl_rule_inbound_100", &networkACLRule),
 					testAccCheckNetworkACLRuleExists("ncloud_network_acl_rule.nacl_rule_inbound_110", &networkACLRule),
@@ -86,8 +82,7 @@ func TestAccResourceNcloudNetworkACLRule_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNetworkACLRuleConfigDisappear(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkACLRuleConfigDisappear(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLRuleExists("ncloud_network_acl_rule.test", &networkACLRule),
 					testAccCheckNetworkACLRuleDisappears(&networkACLRule),

--- a/ncloud/resource_ncloud_network_acl_test.go
+++ b/ncloud/resource_ncloud_network_acl_test.go
@@ -23,8 +23,7 @@ func TestAccResourceNcloudNetworkACL_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNetworkACLConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkACLConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &networkACL),
 					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
@@ -33,7 +32,6 @@ func TestAccResourceNcloudNetworkACL_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -53,8 +51,7 @@ func TestAccResourceNcloudNetworkACL_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNetworkACLConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkACLConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &networkACL),
 					testAccCheckNetworkACLDisappears(&networkACL),
@@ -76,8 +73,7 @@ func TestAccResourceNcloudNetworkACL_onlyRequiredParam(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNetworkACLConfigOnlyRequired(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkACLConfigOnlyRequired(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &networkACL),
 					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
@@ -86,7 +82,6 @@ func TestAccResourceNcloudNetworkACL_onlyRequiredParam(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -106,22 +101,19 @@ func TestAccResourceNcloudNetworkACL_updateName(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNetworkACLConfigOnlyRequired(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkACLConfigOnlyRequired(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &networkACL),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudNetworkACLConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkACLConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &networkACL),
 				),
 				ExpectError: regexp.MustCompile("Change 'name' is not support, Please set `name` as a old value"),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -141,23 +133,20 @@ func TestAccResourceNcloudNetworkACL_description(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudNetworkACLConfigDescription(name, "foo"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkACLConfigDescription(name, "foo"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &networkACL),
 					resource.TestCheckResourceAttr(resourceName, "description", "foo"),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudNetworkACLConfigDescription(name, "bar"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkACLConfigDescription(name, "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkACLExists(resourceName, &networkACL),
 					resource.TestCheckResourceAttr(resourceName, "description", "bar"),
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/ncloud/resource_ncloud_network_interface_test.go
+++ b/ncloud/resource_ncloud_network_interface_test.go
@@ -23,8 +23,7 @@ func TestAccresourceNcloudNetworkInterface_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccresourceNcloudNetworkInterfaceConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkInterfaceConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInterfaceExists(resourceName, &networkInterface),
 					resource.TestMatchResourceAttr(resourceName, "network_interface_no", regexp.MustCompile(`^\d+$`)),
@@ -39,7 +38,6 @@ func TestAccresourceNcloudNetworkInterface_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -59,24 +57,17 @@ func TestAccresourceNcloudNetworkInterface_update(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccresourceNcloudNetworkInterfaceUpdate(name, ""),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkInterfaceUpdate(name, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInterfaceExists(resourceName, &networkInterface),
+					resource.TestCheckResourceAttr(resourceName, "server_instance_no", ""),
 				),
 			},
 			{
-				Config:   testAccresourceNcloudNetworkInterfaceUpdate(name, "${ncloud_server.server.id}"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkInterfaceUpdate(name, "${ncloud_server.server.id}"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInterfaceExists(resourceName, &networkInterface),
-				),
-			},
-			{
-				Config:   testAccresourceNcloudNetworkInterfaceUpdate(name, ""),
-				SkipFunc: testOnlyVpc,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkInterfaceExists(resourceName, &networkInterface),
+					resource.TestMatchResourceAttr(resourceName, "server_instance_no", regexp.MustCompile(`^\d+$`)),
 				),
 			},
 		},
@@ -94,8 +85,7 @@ func TestAccresourceNcloudNetworkInterface_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccresourceNcloudNetworkInterfaceConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudNetworkInterfaceConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkInterfaceExists(resourceName, &networkInterface),
 					testAccCheckNetworkInterfaceDisappears(&networkInterface),
@@ -106,7 +96,7 @@ func TestAccresourceNcloudNetworkInterface_disappears(t *testing.T) {
 	})
 }
 
-func testAccresourceNcloudNetworkInterfaceConfig(name string) string {
+func testAccResourceNcloudNetworkInterfaceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "test" {
 	name               = "%[1]s"
@@ -133,7 +123,7 @@ resource "ncloud_network_interface" "foo" {
 `, name)
 }
 
-func testAccresourceNcloudNetworkInterfaceUpdate(name, instanceNo string) string {
+func testAccResourceNcloudNetworkInterfaceUpdate(name, instanceNo string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "test" {
 	name               = "%[1]s"

--- a/ncloud/resource_ncloud_placement_group_test.go
+++ b/ncloud/resource_ncloud_placement_group_test.go
@@ -23,8 +23,7 @@ func TestAccResourceNcloudPlacementGroup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckPlacementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudPlacementGroupConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudPlacementGroupConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &PlacementGroup),
 					resource.TestMatchResourceAttr(resourceName, "placement_group_no", regexp.MustCompile(`^\d+$`)),
@@ -33,7 +32,6 @@ func TestAccResourceNcloudPlacementGroup_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -53,8 +51,7 @@ func TestAccResourceNcloudPlacementGroup_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckPlacementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudPlacementGroupConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudPlacementGroupConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &PlacementGroup),
 					testAccCheckPlacementGroupDisappears(&PlacementGroup),
@@ -77,22 +74,19 @@ func TestAccResourceNcloudPlacementGroup_updateName(t *testing.T) {
 		CheckDestroy: testAccCheckPlacementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudPlacementGroupConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudPlacementGroupConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &PlacementGroup),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudPlacementGroupConfig(updateName),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudPlacementGroupConfig(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &PlacementGroup),
 				),
 				ExpectError: regexp.MustCompile("Change 'name' is not support, Please set `name` as a old value"),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/ncloud/resource_ncloud_port_forwarding_rule_test.go
+++ b/ncloud/resource_ncloud_port_forwarding_rule_test.go
@@ -23,12 +23,11 @@ func TestAccResourceNcloudPortForwardingRuleBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccClassicProviders,
 		CheckDestroy: testAccCheckPortForwardingRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccPortForwardingRuleBasicConfig(externalPort),
-				SkipFunc: testOnlyClassic,
+				Config: testAccPortForwardingRuleBasicConfig(externalPort),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPortForwardingRuleExists("ncloud_port_forwarding_rule.test", &portForwarding),
 					resource.TestCheckResourceAttr(
@@ -59,7 +58,7 @@ func ignore_TestAccResourceNcloudPortForwardingRuleExistingServer(t *testing.T) 
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccClassicProviders,
 		CheckDestroy: testAccCheckPortForwardingRuleDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -85,7 +84,7 @@ func ignore_TestAccResourceNcloudPortForwardingRuleExistingServer(t *testing.T) 
 }
 
 func testAccCheckPortForwardingRuleExists(n string, i *server.PortForwardingRule) resource.TestCheckFunc {
-	return testAccCheckPortForwardingRuleExistsWithProvider(n, i, func() *schema.Provider { return testAccProvider })
+	return testAccCheckPortForwardingRuleExistsWithProvider(n, i, func() *schema.Provider { return testAccClassicProvider })
 }
 
 func testAccCheckPortForwardingRuleExistsWithProvider(n string, i *server.PortForwardingRule, providerF func() *schema.Provider) resource.TestCheckFunc {
@@ -117,7 +116,7 @@ func testAccCheckPortForwardingRuleExistsWithProvider(n string, i *server.PortFo
 }
 
 func testAccCheckPortForwardingRuleDestroy(s *terraform.State) error {
-	return testAccCheckPortForwardingRuleDestroyWithProvider(s, testAccProvider)
+	return testAccCheckPortForwardingRuleDestroyWithProvider(s, testAccClassicProvider)
 }
 
 func testAccCheckPortForwardingRuleDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
@@ -163,7 +162,6 @@ resource "ncloud_port_forwarding_rule" "test" {
 	port_forwarding_external_port = "%d"
 	port_forwarding_internal_port = "22"
 }`, testServerName, testServerName, externalPort)
-
 }
 
 func testAccPortForwardingRuleExistingServerConfig(externalPort int) string {
@@ -173,5 +171,4 @@ resource "ncloud_port_forwarding_rule" "test" {
 	port_forwarding_external_port = "%d"
 	port_forwarding_internal_port = "22"
 }`, externalPort)
-
 }

--- a/ncloud/resource_ncloud_public_ip_test.go
+++ b/ncloud/resource_ncloud_public_ip_test.go
@@ -12,49 +12,59 @@ import (
 )
 
 func TestAccResourceNcloudPublicIpInstance_classic_basic(t *testing.T) {
-	testAccResourceNcloudPublicIpInstanceBasic(t, false)
-}
-
-func TestAccResourceNcloudPublicIpInstance_vpc_basic(t *testing.T) {
-	testAccResourceNcloudPublicIpInstanceBasic(t, true)
-}
-
-func testAccResourceNcloudPublicIpInstanceBasic(t *testing.T, isVpc bool) {
 	instance := map[string]interface{}{}
 
 	description := fmt.Sprintf("test-public-ip-basic-%s", acctest.RandString(5))
 	resourceName := "ncloud_public_ip.public_ip"
 
-	testCheckAttribute := func() func(*terraform.State) error {
-		return func(*terraform.State) error {
-			config := getTestProvider(isVpc).Meta().(*ProviderConfig)
-
-			if instance["status"] != GetValueClassicOrVPC(config, "CREAT", "RUN") {
-				return fmt.Errorf("invalid public ip status: %s ", instance["status"])
-			}
-
-			return nil
-		}
-	}
-
-	provider := getTestProvider(isVpc)
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: getTestAccProviders(isVpc),
+		Providers: testAccClassicProviders,
 		CheckDestroy: func(s *terraform.State) error {
-			return testAccCheckPublicIpInstanceDestroy(s, provider)
+			return testAccCheckPublicIpInstanceDestroy(s, testAccClassicProvider)
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPublicIpInstanceConfig(description),
+				Config: testAccPublicIpInstanceClassicConfig(description),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPublicIpInstanceExists(resourceName, instance, provider),
-					testCheckAttribute(),
+					testAccCheckPublicIpInstanceExists(resourceName, instance, testAccClassicProvider),
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
 					resource.TestMatchResourceAttr(resourceName, "public_ip_no", regexp.MustCompile(`^\d+$`)),
 					resource.TestMatchResourceAttr(resourceName, "public_ip", regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`)),
 					resource.TestCheckResourceAttr(resourceName, "description", description),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"server_instance_no"},
+			},
+		},
+	})
+}
+
+func TestAccResourceNcloudPublicIpInstance_vpc_basic(t *testing.T) {
+	instance := map[string]interface{}{}
+
+	name := fmt.Sprintf("test-public-ip-basic-%s", acctest.RandString(5))
+	resourceName := "ncloud_public_ip.public_ip"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(s *terraform.State) error {
+			return testAccCheckPublicIpInstanceDestroy(s, testAccProvider)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPublicIpInstanceVpcConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPublicIpInstanceExists(resourceName, instance, testAccProvider),
+					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "public_ip_no", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "public_ip", regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`)),
+					resource.TestCheckResourceAttr(resourceName, "description", name),
 				),
 			},
 			{
@@ -188,12 +198,58 @@ func testAccCheckPublicIpInstanceDestroy(s *terraform.State, provider *schema.Pr
 	return nil
 }
 
-func testAccPublicIpInstanceConfig(description string) string {
+func testAccPublicIpInstanceClassicConfig(description string) string {
 	return fmt.Sprintf(`
+resource "ncloud_login_key" "loginkey" {
+	key_name = "%[1]s-key"
+}
+
+resource "ncloud_server" "server" {
+	name = "%[1]s"
+	server_image_product_code = "SPSW0LINUX000032"
+	server_product_code = "SPSVRSTAND000004"
+	login_key_name = "${ncloud_login_key.loginkey.key_name}"
+}
+
 resource "ncloud_public_ip" "public_ip" {
-	description = "%s"
+	description = "%[1]s"
+	depends_on = [ncloud_server.server]
 }
 `, description)
+}
+
+func testAccPublicIpInstanceVpcConfig(name string) string {
+	return fmt.Sprintf(`
+resource "ncloud_login_key" "loginkey" {
+	key_name = "%[1]s-key"
+}
+
+resource "ncloud_vpc" "test" {
+	name               = "%[1]s"
+	ipv4_cidr_block    = "10.5.0.0/16"
+}
+
+resource "ncloud_subnet" "test" {
+	vpc_no             = ncloud_vpc.test.vpc_no
+	name               = "%[1]s"
+	subnet             = "10.5.0.0/24"
+	zone               = "KR-2"
+	network_acl_no     = ncloud_vpc.test.default_network_acl_no
+	subnet_type        = "PUBLIC"
+	usage_type         = "GEN"
+}
+
+resource "ncloud_server" "server" {
+	subnet_no = ncloud_subnet.test.id
+	name = "%[1]s"
+	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	login_key_name = ncloud_login_key.loginkey.key_name
+}
+
+resource "ncloud_public_ip" "public_ip" {
+	depends_on = [ncloud_server.server]
+	description = "%[1]s"
+}`, name)
 }
 
 func testAccPublicIpInstanceConfigClassicServer(serverNameFoo, serverNameBar, serverInstanceNo string) string {
@@ -219,6 +275,7 @@ resource "ncloud_server" "bar" {
 resource "ncloud_public_ip" "public_ip" {
 	description = "%[1]s"
 	server_instance_no = "%[3]s"
+	depends_on = [ncloud_server.foo]
 }
 `, serverNameFoo, serverNameBar, serverInstanceNo)
 }
@@ -263,6 +320,7 @@ resource "ncloud_server" "bar" {
 resource "ncloud_public_ip" "public_ip" {
 	description = "%[1]s"
 	server_instance_no = "%[3]s"
+	depends_on  = [ncloud_server.foo]
 }
 `, serverNameFoo, serverNameBar, serverInstanceNo)
 }

--- a/ncloud/resource_ncloud_route_table_association_test.go
+++ b/ncloud/resource_ncloud_route_table_association_test.go
@@ -25,15 +25,13 @@ func TestAccresourceNcloudRouteTableAssociation_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccresourceNcloudRouteTableAssociationConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteTableAssociationConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(resourceName, &association, &routeTableNo),
 					testAccCheckDataSourceID(resourceName),
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateIdFunc: testAccNcloudRouteTableAssociationImportStateIDFunc(resourceName),
@@ -56,8 +54,7 @@ func TestAccresourceNcloudRouteTableAssociation_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccresourceNcloudRouteTableAssociationConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteTableAssociationConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableAssociationExists(resourceName, &association, &routeTableNo),
 					testAccCheckRouteTableAssociationDisappears(&association, &routeTableNo),
@@ -68,7 +65,7 @@ func TestAccresourceNcloudRouteTableAssociation_disappears(t *testing.T) {
 	})
 }
 
-func testAccresourceNcloudRouteTableAssociationConfig(name string) string {
+func testAccResourceNcloudRouteTableAssociationConfig(name string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name            = "%[1]s"
@@ -89,7 +86,7 @@ resource "ncloud_route_table" "route_table" {
 	vpc_no                = ncloud_vpc.vpc.id
 	name                  = "%[1]s"
 	description           = "for test"
-	supported_subnet_type = "PRIVATE"
+	supported_subnet_type = "PUBLIC"
 }
 
 resource "ncloud_route_table_association" "test" {

--- a/ncloud/resource_ncloud_route_table_test.go
+++ b/ncloud/resource_ncloud_route_table_test.go
@@ -23,8 +23,7 @@ func TestAccResourceNcloudRouteTable_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudRouteTableConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteTableConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
@@ -33,7 +32,6 @@ func TestAccResourceNcloudRouteTable_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -53,8 +51,7 @@ func TestAccResourceNcloudRouteTable_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudRouteTableConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteTableConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					testAccCheckRouteTableDisappears(&routeTable),
@@ -76,8 +73,7 @@ func TestAccResourceNcloudRouteTable_onlyRequiredParam(t *testing.T) {
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudRouteTableConfigOnlyRequired(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteTableConfigOnlyRequired(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
@@ -86,7 +82,6 @@ func TestAccResourceNcloudRouteTable_onlyRequiredParam(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -106,22 +101,19 @@ func TestAccResourceNcloudRouteTable_updateName(t *testing.T) {
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudRouteTableConfigOnlyRequired(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteTableConfigOnlyRequired(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudRouteTableConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteTableConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 				),
 				ExpectError: regexp.MustCompile("Change 'name' is not support, Please set `name` as a old value"),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -141,23 +133,20 @@ func TestAccResourceNcloudRouteTable_description(t *testing.T) {
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudRouteTableConfigDescription(name, "foo"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteTableConfigDescription(name, "foo"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "description", "foo"),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudRouteTableConfigDescription(name, "bar"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteTableConfigDescription(name, "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(resourceName, &routeTable),
 					resource.TestCheckResourceAttr(resourceName, "description", "bar"),
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/ncloud/resource_ncloud_route_test.go
+++ b/ncloud/resource_ncloud_route_test.go
@@ -23,14 +23,12 @@ func TestAccresourceNcloudRoute_basic(t *testing.T) {
 		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccresourceNcloudRouteConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateIdFunc: testAccNcloudRouteImportStateIDFunc(resourceName),
@@ -51,8 +49,7 @@ func TestAccresourceNcloudRoute_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccresourceNcloudRouteConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudRouteConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteExists(resourceName, &route),
 					testAccCheckRouteDisappears(&route),
@@ -63,7 +60,7 @@ func TestAccresourceNcloudRoute_disappears(t *testing.T) {
 	})
 }
 
-func testAccresourceNcloudRouteConfig(name string) string {
+func testAccResourceNcloudRouteConfig(name string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name            = "%[1]s"

--- a/ncloud/resource_ncloud_server_test.go
+++ b/ncloud/resource_ncloud_server_test.go
@@ -28,14 +28,13 @@ func TestAccResourceNcloudServer_classic_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccClassicProviders,
 		CheckDestroy: testAccCheckServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccServerClassicConfig(testServerName, productCode),
-				SkipFunc: testOnlyClassic,
+				Config: testAccServerClassicConfig(testServerName, productCode),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerExists(resourceName, &serverInstance),
+					testAccCheckServerExistsWithProvider(resourceName, &serverInstance, testAccClassicProvider),
 					testCheck(),
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "server_image_product_code", "SPSW0LINUX000032"),
@@ -60,7 +59,6 @@ func TestAccResourceNcloudServer_classic_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:                testOnlyClassic,
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -82,9 +80,8 @@ func TestAccResourceNcloudServer_vpc_basic(t *testing.T) {
 		CheckDestroy: testAccCheckServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccServerVpcConfig(testServerName, productCode),
-				SkipFunc: testOnlyVpc,
-				Check: resource.ComposeTestCheckFunc(testAccCheckServerExists("ncloud_server.server", &serverInstance),
+				Config: testAccServerVpcConfig(testServerName, productCode),
+				Check: resource.ComposeTestCheckFunc(testAccCheckServerExistsWithProvider("ncloud_server.server", &serverInstance, testAccProvider),
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "server_image_product_code", "SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
 					resource.TestCheckResourceAttr(resourceName, "server_product_code", productCode),
@@ -111,7 +108,6 @@ func TestAccResourceNcloudServer_vpc_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -132,9 +128,8 @@ func TestAccResourceNcloudServer_vpc_networkInterface(t *testing.T) {
 		CheckDestroy: testAccCheckServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccServerVpcConfigNetworkInterface(testServerName, productCode),
-				SkipFunc: testOnlyVpc,
-				Check: resource.ComposeTestCheckFunc(testAccCheckServerExists("ncloud_server.server", &serverInstance),
+				Config: testAccServerVpcConfigNetworkInterface(testServerName, productCode),
+				Check: resource.ComposeTestCheckFunc(testAccCheckServerExistsWithProvider("ncloud_server.server", &serverInstance, testAccProvider),
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "server_image_product_code", "SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
 					resource.TestCheckResourceAttr(resourceName, "server_product_code", productCode),
@@ -161,7 +156,6 @@ func TestAccResourceNcloudServer_vpc_networkInterface(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -180,28 +174,25 @@ func TestAccResourceNcloudServer_classic_changeSpec(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    testAccClassicProviders,
 		CheckDestroy: testAccCheckServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccServerClassicConfig(testServerName, productCode),
-				SkipFunc: testOnlyClassic,
-				Check: resource.ComposeTestCheckFunc(testAccCheckServerExists(resourceName, &before),
+				Config: testAccServerClassicConfig(testServerName, productCode),
+				Check: resource.ComposeTestCheckFunc(testAccCheckServerExistsWithProvider(resourceName, &before, testAccClassicProvider),
 					resource.TestCheckResourceAttr(resourceName, "cpu_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "memory_size", "4294967296"),
 				),
 			},
 			{
-				Config:   testAccServerClassicConfig(testServerName, targetProductCode),
-				SkipFunc: testOnlyClassic,
-				Check: resource.ComposeTestCheckFunc(testAccCheckServerExists(resourceName, &after),
+				Config: testAccServerClassicConfig(testServerName, targetProductCode),
+				Check: resource.ComposeTestCheckFunc(testAccCheckServerExistsWithProvider(resourceName, &after, testAccClassicProvider),
 					resource.TestCheckResourceAttr(resourceName, "cpu_count", "4"),
 					resource.TestCheckResourceAttr(resourceName, "memory_size", "8589934592"),
 					testAccCheckInstanceNotRecreated(t, &before, &after),
 				),
 			},
 			{
-				SkipFunc:          testOnlyClassic,
 				ResourceName:      "ncloud_server.server",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -224,24 +215,21 @@ func TestAccResourceNcloudServer_vpc_changeSpec(t *testing.T) {
 		CheckDestroy: testAccCheckServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccServerVpcConfig(testServerName, productCode),
-				SkipFunc: testOnlyVpc,
-				Check: resource.ComposeTestCheckFunc(testAccCheckServerExists(resourceName, &before),
+				Config: testAccServerVpcConfig(testServerName, productCode),
+				Check: resource.ComposeTestCheckFunc(testAccCheckServerExistsWithProvider(resourceName, &before, testAccProvider),
 					resource.TestCheckResourceAttr(resourceName, "cpu_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "memory_size", "8589934592"),
 				),
 			},
 			{
-				Config:   testAccServerVpcConfig(testServerName, targetProductCode),
-				SkipFunc: testOnlyVpc,
-				Check: resource.ComposeTestCheckFunc(testAccCheckServerExists(resourceName, &after),
+				Config: testAccServerVpcConfig(testServerName, targetProductCode),
+				Check: resource.ComposeTestCheckFunc(testAccCheckServerExistsWithProvider(resourceName, &after, testAccProvider),
 					resource.TestCheckResourceAttr(resourceName, "cpu_count", "4"),
 					resource.TestCheckResourceAttr(resourceName, "memory_size", "17179869184"),
 					testAccCheckInstanceNotRecreated(t, &before, &after),
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      "ncloud_server.server",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -250,11 +238,7 @@ func TestAccResourceNcloudServer_vpc_changeSpec(t *testing.T) {
 	})
 }
 
-func testAccCheckServerExists(n string, i *ServerInstance) resource.TestCheckFunc {
-	return testAccCheckInstanceExistsWithProvider(n, i, func() *schema.Provider { return testAccProvider })
-}
-
-func testAccCheckInstanceExistsWithProvider(n string, i *ServerInstance, providerF func() *schema.Provider) resource.TestCheckFunc {
+func testAccCheckServerExistsWithProvider(n string, i *ServerInstance, provider *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -265,7 +249,6 @@ func testAccCheckInstanceExistsWithProvider(n string, i *ServerInstance, provide
 			return fmt.Errorf("no ID is set")
 		}
 
-		provider := providerF()
 		config := provider.Meta().(*ProviderConfig)
 		instance, err := getServerInstance(config, rs.Primary.ID)
 		if err != nil {

--- a/ncloud/resource_ncloud_subnet.go
+++ b/ncloud/resource_ncloud_subnet.go
@@ -184,7 +184,7 @@ func resourceNcloudSubnetUpdate(d *schema.ResourceData, meta interface{}) error 
 		}
 		logResponse("SetSubnetNetworkAcl", resp)
 
-		if err := waitForNcloudNetworkACLUpdate(config, d.Id()); err != nil {
+		if err := waitForNcloudNetworkACLUpdate(config, d.Get("network_acl_no").(string)); err != nil {
 			return err
 		}
 	}

--- a/ncloud/resource_ncloud_subnet_test.go
+++ b/ncloud/resource_ncloud_subnet_test.go
@@ -24,8 +24,7 @@ func TestAccResourceNcloudSubnet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudSubnetConfig(name, cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudSubnetConfig(name, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -36,7 +35,6 @@ func TestAccResourceNcloudSubnet_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -57,8 +55,7 @@ func TestAccResourceNcloudSubnet_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudSubnetConfig(name, cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudSubnetConfig(name, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 					testAccCheckSubnetDisappears(&subnet),
@@ -81,22 +78,21 @@ func TestAccResourceNcloudSubnet_updateName(t *testing.T) {
 		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudSubnetConfig(name, cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudSubnetConfig(name, cidr),
+
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudSubnetConfig("testacc-subnet-update", cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudSubnetConfig("testacc-subnet-update", cidr),
+
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 				),
 				ExpectError: regexp.MustCompile("Change 'name' is not support, Please set `name` as a old value"),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -117,15 +113,13 @@ func TestAccResourceNcloudSubnet_updateNetworkACL(t *testing.T) {
 		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudSubnetConfig(name, cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudSubnetConfig(name, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudSubnetConfigUpdateNetworkACL(name, cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudSubnetConfigUpdateNetworkACL(name, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetExists(resourceName, &subnet),
 				),
@@ -145,7 +139,6 @@ func TestAccResourceNcloudSubnet_InvalidCIDR(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceNcloudSubnetConfigInvalidCIDR(name, cidr),
-				SkipFunc:    testOnlyVpc,
 				ExpectError: regexp.MustCompile("The subnet must belong to the IPv4 CIDR of the specified VPC."),
 			},
 		},

--- a/ncloud/resource_ncloud_vpc_peering_test.go
+++ b/ncloud/resource_ncloud_vpc_peering_test.go
@@ -23,8 +23,7 @@ func TestAccResourceNcloudVpcPeering_basic(t *testing.T) {
 		CheckDestroy: testAccCheckVpcPeeringDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudVpcPeeringConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudVpcPeeringConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcPeeringExists(resourceName, &vpcPeeringInstance),
 					resource.TestMatchResourceAttr(resourceName, "source_vpc_no", regexp.MustCompile(`^\d+$`)),
@@ -34,7 +33,6 @@ func TestAccResourceNcloudVpcPeering_basic(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -55,8 +53,7 @@ func TestAccResourceNcloudVpcPeering_Peering(t *testing.T) {
 		CheckDestroy: testAccCheckVpcPeeringDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudVpcPeeringConfigAdd(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudVpcPeeringConfigAdd(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcPeeringExists(resourceNamePeer, &vpcPeeringInstance),
 					resource.TestMatchResourceAttr(resourceNamePeer, "source_vpc_no", regexp.MustCompile(`^\d+$`)),
@@ -81,8 +78,7 @@ func TestAccResourceNcloudVpcPeering_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckVpcPeeringDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudVpcPeeringConfig(name),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudVpcPeeringConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcPeeringExists(resourceName, &vpcPeeringInstance),
 					testAccCheckVpcPeeringDisappears(&vpcPeeringInstance),
@@ -104,23 +100,20 @@ func TestAccResourceNcloudVpcPeering_description(t *testing.T) {
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudVpcPeeringConfigDescription(name, "foo"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudVpcPeeringConfigDescription(name, "foo"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcPeeringExists(resourceName, &vpcPeeringInstance),
 					resource.TestCheckResourceAttr(resourceName, "description", "foo"),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudVpcPeeringConfigDescription(name, "bar"),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudVpcPeeringConfigDescription(name, "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcPeeringExists(resourceName, &vpcPeeringInstance),
 					resource.TestCheckResourceAttr(resourceName, "description", "bar"),
 				),
 			},
 			{
-				SkipFunc:          testOnlyVpc,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/ncloud/resource_ncloud_vpc_test.go
+++ b/ncloud/resource_ncloud_vpc_test.go
@@ -26,8 +26,7 @@ func TestAccResourceNcloudVpc_basic(t *testing.T) {
 		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudVpcConfig(name, cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudVpcConfig(name, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "ipv4_cidr_block", cidr),
@@ -54,8 +53,7 @@ func TestAccResourceNcloudVpc_disappears(t *testing.T) {
 		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccDataSourceNcloudVpcConfig(name, cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccDataSourceNcloudVpcConfig(name, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists(resourceName, &vpc),
 					testAccCheckVpcDisappears(&vpc),
@@ -79,15 +77,13 @@ func TestAccResourceNcloudVpc_updateName(t *testing.T) {
 		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:   testAccResourceNcloudVpcConfig(name, cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudVpcConfig(name, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists(resourceName, &vpc),
 				),
 			},
 			{
-				Config:   testAccResourceNcloudVpcConfig("testacc-vpc-basic-update", cidr),
-				SkipFunc: testOnlyVpc,
+				Config: testAccResourceNcloudVpcConfig("testacc-vpc-basic-update", cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists(resourceName, &vpc),
 				),

--- a/ncloud/zone_test.go
+++ b/ncloud/zone_test.go
@@ -20,14 +20,14 @@ func testZoneSchema() map[string]*schema.Schema {
 func TestParseZoneNoParameterBasic(t *testing.T) {
 	testZoneCode := "KR-2"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: `data "ncloud_zones" "zones" {}`,
+				Config: zonesConfig,
 				Check: func(*terraform.State) error {
-					config := testAccProvider.Meta().(*ProviderConfig)
+					config := testAccClassicProvider.Meta().(*ProviderConfig)
 					s := testZoneSchema()
 					d := schema.TestResourceDataRaw(t, s, map[string]interface{}{
 						"zone": testZoneCode,
@@ -43,12 +43,12 @@ func TestParseZoneNoParameterBasic(t *testing.T) {
 }
 
 func TestParseZoneNoParameterInputNil(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: `data "ncloud_zones" "zones" {}`,
+				Config: zonesConfig,
 				Check: func(*terraform.State) error {
 					config := testAccProvider.Meta().(*ProviderConfig)
 					if zoneNo, _ := parseZoneNoParameter(config, &schema.ResourceData{}); zoneNo != nil {
@@ -62,7 +62,7 @@ func TestParseZoneNoParameterInputNil(t *testing.T) {
 }
 
 func TestParseZoneNoParameterInputUnknownZoneCode(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -86,14 +86,14 @@ func TestParseZoneNoParameterInputUnknownZoneCode(t *testing.T) {
 
 func TestGetZoneNoByCodeBasic(t *testing.T) {
 	testZoneCode := "KR-2"
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: `data "ncloud_zones" "zones" {}`,
+				Config: zonesConfig,
 				Check: func(*terraform.State) error {
-					config := testAccProvider.Meta().(*ProviderConfig)
+					config := testAccClassicProvider.Meta().(*ProviderConfig)
 					if zoneNo := getZoneNoByCode(config, testZoneCode); zoneNo == "" {
 						t.Fatalf("No zone data for zone_code: %s", testZoneCode)
 					}
@@ -106,14 +106,14 @@ func TestGetZoneNoByCodeBasic(t *testing.T) {
 
 func TestGetZoneNoByCodeInputUnknownZoneCode(t *testing.T) {
 	testZoneCode := "unknown-zone-code"
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: `data "ncloud_zones" "zones" {}`,
+				Config: zonesConfig,
 				Check: func(*terraform.State) error {
-					config := testAccProvider.Meta().(*ProviderConfig)
+					config := testAccClassicProvider.Meta().(*ProviderConfig)
 					if zoneNo := getZoneNoByCode(config, testZoneCode); zoneNo != "" {
 						t.Fatalf("Unknown zone code must return nil. zone_code: %s", testZoneCode)
 					}
@@ -126,12 +126,12 @@ func TestGetZoneNoByCodeInputUnknownZoneCode(t *testing.T) {
 
 func TestGetZoneByCodeBasic(t *testing.T) {
 	testZoneCode := "KR-2"
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: `data "ncloud_zones" "zones" {}`,
+				Config: zonesConfig,
 				Check: func(*terraform.State) error {
 					config := testAccProvider.Meta().(*ProviderConfig)
 					if zone, err := getZoneByCode(config, testZoneCode); err != nil || zone == nil {
@@ -146,12 +146,12 @@ func TestGetZoneByCodeBasic(t *testing.T) {
 
 func TestGetZoneByCodeInputUnknownZoneCode(t *testing.T) {
 	testZoneCode := "unknown-zone-code"
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: `data "ncloud_zones" "zones" {}`,
+				Config: zonesConfig,
 				Check: func(*terraform.State) error {
 					config := testAccProvider.Meta().(*ProviderConfig)
 					if zone, _ := getZoneByCode(config, testZoneCode); zone != nil {
@@ -165,12 +165,12 @@ func TestGetZoneByCodeInputUnknownZoneCode(t *testing.T) {
 }
 
 func TestGetZonesBasic(t *testing.T) {
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: `data "ncloud_zones" "zones" {}`,
+				Config: zonesConfig,
 				Check: func(*terraform.State) error {
 					config := testAccProvider.Meta().(*ProviderConfig)
 					if zones, err := getZones(config); err != nil || zones == nil || len(zones) == 0 {
@@ -182,3 +182,5 @@ func TestGetZonesBasic(t *testing.T) {
 		},
 	})
 }
+
+var zonesConfig = `data "ncloud_zones" "zones" {}`


### PR DESCRIPTION
resolve #90
- add `testAccClassicProviders` for classic env.
  - set `support_vpc` is `false` whenever
- `testAccProvider` set `support_vpc` is `true`
- modify `Providers` for classic test case, and check destory, exists functions
- Fix `getTestPrefix()` method `RandIntRange(1, 9999)` to `RandString(5)` 
  - RandIntRange use timestamp but it returns same results if multiple call same time.
- fix `support_vpc` set boolean value fix #92 