### PR TITLE
#103 acg rule

### DIFF
--- a/docs/resources/access_control_group.md
+++ b/docs/resources/access_control_group.md
@@ -22,6 +22,24 @@ resource "ncloud_access_control_group" "acg" {
   name        = "my-acg"
   description = "description"
   vpc_no      = ncloud_vpc.vpc.id
+
+  inbound {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "22"
+  }
+
+  inbound {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "80"
+  }
+
+  outbound {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0" 
+    port_range  = "1-65535"
+  }
 }
 ```
 
@@ -32,6 +50,21 @@ The following arguments are supported:
 * `vpc_no` - (Required) The ID of the associated VPC.
 * `name` - (Optional) The name to create. If omitted, Terraform will assign a random, unique name.
 * `description` - (Optional) Indicates whether to get default group only
+* `inbound` - (Optional) Specifies an Inbound(ingress) rules. Parameters defined below. This argument is processed in [attriutbe-as-blocks](https://www.terraform.io/docs/configuration/attr-as-blocks.html) mode.
+* `outbound` - (Optional) Specifies an Outbound(egress) rules. Parameters defined below. This argument is processed in [attriutbe-as-blocks](https://www.terraform.io/docs/configuration/attr-as-blocks.html) mode.
+
+### Access Control Group Rule Reference
+
+Both `inbound` and `outbound` support  following attributes:
+
+* `protocol` - (Required) Select between TCP, UDP, and ICMP. Accepted values: `TCP` | `UDP` | `ICMP`
+* `ip_block` - (Optional) The CIDR block to match. This must be a valid network mask. Cannot be specified with `source_access_control_group_no`.
+* `source_access_control_group_no` - (Optional) The ID of specific ACG to apply this rule to. Cannot be specified with `ip_block`.
+* `port_range` - (Optional) Range of ports to apply. You can enter from `1` to `65535`. e.g. set single port: `22` or set range port : `8000-9000`
+
+~> **NOTE:** If the value of protocol is `ICMP`, the `port_range` values will be ignored and the rule will apply to all ports.
+
+* `description` - (Optional) description to create.
 
 ## Attributes Reference
 

--- a/docs/resources/network_acl.md
+++ b/docs/resources/network_acl.md
@@ -71,6 +71,10 @@ Both `inbound` and `outbound` support  following attributes:
 * `ip_block` - (Required) The CIDR block to match. This must be a valid network mask.
 * `port_range` - (Optional) Range of ports to apply. You can enter from `1` to `65535`. e.g. set single port: `22` or set range port : `8000-9000`
 
+~> **NOTE:** If the value of protocol is `ICMP`, the `port_range` values will be ignored and the rule will apply to all ports.
+
+* `description` - (Optional) description to create.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/ncloud/resource_ncloud_access_control_group_test.go
+++ b/ncloud/resource_ncloud_access_control_group_test.go
@@ -45,6 +45,31 @@ func TestAccResourceNcloudAccessControlGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceNcloudAccessControlGroup_rule(t *testing.T) {
+	var AccessControlGroup vserver.AccessControlGroup
+	name := fmt.Sprintf("tf-acg-rule-%s", acctest.RandString(5))
+	resourceNameFoo := "ncloud_access_control_group.foo"
+	resourceNameBar := "ncloud_access_control_group.bar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAccessControlGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNcloudAccessControlGroupConfigRule(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccessControlGroupExists(resourceNameFoo, &AccessControlGroup),
+					testAccCheckAccessControlGroupExists(resourceNameBar, &AccessControlGroup),
+					resource.TestCheckResourceAttr(resourceNameFoo, "inbound.#", "2"),
+					resource.TestCheckResourceAttr(resourceNameFoo, "outbound.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameBar, "inbound.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceNcloudAccessControlGroup_disappears(t *testing.T) {
 	var AccessControlGroup vserver.AccessControlGroup
 	name := fmt.Sprintf("tf-nic-disappear-%s", acctest.RandString(5))
@@ -95,6 +120,51 @@ resource "ncloud_access_control_group" "foo" {
 		protocol    = "TCP"
 		port_range  = "80"
 		ip_block    = "0.0.0.0/0"
+	}
+}
+`, name)
+}
+
+func testAccResourceNcloudAccessControlGroupConfigRule(name string) string {
+	return fmt.Sprintf(`
+resource "ncloud_vpc" "test" {
+	name               = "%[1]s"
+	ipv4_cidr_block    = "10.4.0.0/16"
+}
+
+resource "ncloud_access_control_group" "foo" {
+	name                  = "%[1]s-foo"
+	description           = "for acc test"
+	vpc_no                = ncloud_vpc.test.id
+
+	inbound {
+		protocol    = "TCP"
+		port_range  = "80"
+		ip_block    = "0.0.0.0/0"
+	}
+	
+	inbound {
+		protocol    = "TCP"
+		port_range  = "443"
+		ip_block    = "0.0.0.0/0"
+	}
+
+	outbound {
+		protocol    = "TCP"
+		port_range  = "80"
+		ip_block    = "0.0.0.0/0"
+	}
+}
+
+resource "ncloud_access_control_group" "bar" {
+	name                  = "%[1]s-bar"
+	description           = "for acc test"
+	vpc_no                = ncloud_vpc.test.id
+
+	inbound {
+		protocol    = "TCP"
+		port_range  = "80"
+		source_access_control_group_no = ncloud_access_control_group.foo.id
 	}
 }
 `, name)

--- a/ncloud/resource_ncloud_access_control_group_test.go
+++ b/ncloud/resource_ncloud_access_control_group_test.go
@@ -32,6 +32,8 @@ func TestAccResourceNcloudAccessControlGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "for acc test"),
 					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "is_default", "false"),
+					resource.TestCheckResourceAttr(resourceName, "inbound.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "outbound.#", "1"),
 				),
 			},
 			{
@@ -76,6 +78,24 @@ resource "ncloud_access_control_group" "foo" {
 	name                  = "%[1]s"
 	description           = "for acc test"
 	vpc_no                = ncloud_vpc.test.id
+
+	inbound {
+		protocol    = "TCP"
+		port_range  = "80"
+		ip_block    = "0.0.0.0/0"
+	}
+	
+	inbound {
+		protocol    = "TCP"
+		port_range  = "443"
+		ip_block    = "0.0.0.0/0"
+	}
+
+	outbound {
+		protocol    = "TCP"
+		port_range  = "80"
+		ip_block    = "0.0.0.0/0"
+	}
 }
 `, name)
 }


### PR DESCRIPTION
### Isssue
- resolve #103 
  - `access_control_group` rule in-line style
  - refactor `network_acl` rule

#### Result of acceptance testing
##### Access Control Group
```
=== RUN   TestAccResourceNcloudAccessControlGroup_basic
--- PASS: TestAccResourceNcloudAccessControlGroup_basic (51.77s)
=== RUN   TestAccResourceNcloudAccessControlGroup_rule
--- PASS: TestAccResourceNcloudAccessControlGroup_rule (45.81s)
=== RUN   TestAccResourceNcloudAccessControlGroup_disappears
--- PASS: TestAccResourceNcloudAccessControlGroup_disappears (30.16s)
PASS
```
##### Network ACL
```
=== RUN   TestAccResourceNcloudNetworkACL_basic
--- PASS: TestAccResourceNcloudNetworkACL_basic (47.70s)
=== RUN   TestAccResourceNcloudNetworkACL_disappears
--- PASS: TestAccResourceNcloudNetworkACL_disappears (48.27s)
=== RUN   TestAccResourceNcloudNetworkACL_onlyRequiredParam
--- PASS: TestAccResourceNcloudNetworkACL_onlyRequiredParam (42.26s)
=== RUN   TestAccResourceNcloudNetworkACL_updateName
--- PASS: TestAccResourceNcloudNetworkACL_updateName (43.22s)
=== RUN   TestAccResourceNcloudNetworkACL_description
--- PASS: TestAccResourceNcloudNetworkACL_description (50.03s)
PASS
```