### PR TITLE
support multiple rules, add note that waring about slowdown in docs

### DIFF
--- a/docs/resources/access_control_group_rule.md
+++ b/docs/resources/access_control_group_rule.md
@@ -4,6 +4,9 @@ Provides an rule of ACG(Access Control Group) resource.
 
 ~> **NOTE:** This resource only support VPC environment.
 
+~> **NOTE:** To performance, we recommend using one resource per ACG(Access Control Group). If you use multiple resources in a single ACG(Access Control Group), then can cause a slowdown.
+
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/network_acl_rule.md
+++ b/docs/resources/network_acl_rule.md
@@ -2,6 +2,8 @@
 
 Provides a rule of Network ACL  resource.
 
+~> **NOTE:** To performance, we recommend using one resource per Network ACL. If you use multiple resources in a single Network ACL, then can cause a slowdown.
+
 ## Example Usage
 
 ### Basic Usage

--- a/ncloud/resource_ncloud_access_control_group_rule_test.go
+++ b/ncloud/resource_ncloud_access_control_group_rule_test.go
@@ -31,11 +31,6 @@ func TestAccResourceNcloudAccessControlGroupRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "outbound.#", "1"),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }

--- a/ncloud/resource_ncloud_network_acl_rule.go
+++ b/ncloud/resource_ncloud_network_acl_rule.go
@@ -22,9 +22,6 @@ func resourceNcloudNetworkACLRule() *schema.Resource {
 		Read:   resourceNcloudNetworkACLRuleRead,
 		Update: resourceNcloudNetworkACLRuleUpdate,
 		Delete: resourceNcloudNetworkACLRuleDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 		Schema: map[string]*schema.Schema{
 			"network_acl_no": {
 				Type:     schema.TypeString,
@@ -145,11 +142,16 @@ func resourceNcloudNetworkACLRuleRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("network_acl_no", d.Id())
 
-	var inbound []map[string]interface{}
-	var outbound []map[string]interface{}
+	i := d.Get("inbound").(*schema.Set)
+	o := d.Get("outbound").(*schema.Set)
+
+	// Create empty set for getNetworkACLRuleList
+	iSet := schema.NewSet(schema.HashResource(resourceNcloudNetworkACLRule().Schema["inbound"].Elem.(*schema.Resource)), []interface{}{})
+	oSet := schema.NewSet(schema.HashResource(resourceNcloudNetworkACLRule().Schema["outbound"].Elem.(*schema.Resource)), []interface{}{})
+
 	for _, r := range rules {
 		m := map[string]interface{}{
-			"priority":    *r.Priority,
+			"priority":    int(*r.Priority),
 			"protocol":    *r.ProtocolType.Code,
 			"port_range":  *r.PortRange,
 			"rule_action": *r.RuleAction.Code,
@@ -158,17 +160,18 @@ func resourceNcloudNetworkACLRuleRead(d *schema.ResourceData, meta interface{}) 
 		}
 
 		if *r.NetworkAclRuleType.Code == "INBND" {
-			inbound = append(inbound, m)
+			iSet.Add(m)
 		} else {
-			outbound = append(outbound, m)
+			oSet.Add(m)
 		}
 	}
 
-	if err := d.Set("inbound", inbound); err != nil {
+	// Only set data intersection between resource and list
+	if err := d.Set("inbound", i.Intersection(iSet).List()); err != nil {
 		log.Printf("[WARN] Error setting inbound rule set for (%s): %s", d.Id(), err)
 	}
 
-	if err := d.Set("outbound", outbound); err != nil {
+	if err := d.Set("outbound", o.Intersection(oSet).List()); err != nil {
 		log.Printf("[WARN] Error setting outbound rule set for (%s): %s", d.Id(), err)
 	}
 

--- a/ncloud/resource_ncloud_network_acl_rule_test.go
+++ b/ncloud/resource_ncloud_network_acl_rule_test.go
@@ -32,11 +32,6 @@ func TestAccResourceNcloudNetworkACLRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "outbound.#", "1"),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }


### PR DESCRIPTION
#### Improve
- resolve #114 

#### Result of acceptance testing

##### Network ACL
```
=== RUN   TestAccResourceNcloudNetworkACLRule_basic
--- PASS: TestAccResourceNcloudNetworkACLRule_basic (63.15s)
=== RUN   TestAccResourceNcloudNetworkACLRule_AssociatedSubnet
--- PASS: TestAccResourceNcloudNetworkACLRule_AssociatedSubnet (147.80s)
=== RUN   TestAccResourceNcloudNetworkACLRule_disappears
--- PASS: TestAccResourceNcloudNetworkACLRule_disappears (60.92s)
PASS
```

##### ACG
```
=== RUN   TestAccResourceNcloudAccessControlGroupRule_basic
--- PASS: TestAccResourceNcloudAccessControlGroupRule_basic (62.25s)
=== RUN   TestAccResourceNcloudAccessControlGroupRule_disappears
--- PASS: TestAccResourceNcloudAccessControlGroupRule_disappears (53.91s)
PASS
```