### PR TITLE
#116 refactor code

### DIFF
--- a/docs/data-sources/server_image.md
+++ b/docs/data-sources/server_image.md
@@ -8,7 +8,15 @@ To create a server instance (VM), you should select a server image. This data so
 
 ```hcl
 data "ncloud_server_image" "image" {
-  product_name_regex = "^Windows Server 2012(.*)"
+  product_name = "CentOS 7.3 (64-bit)"
+}
+
+// Use filter
+data "ncloud_server_image" "image_by_filter" {
+  filter {
+    name = "product_name"
+    values = ["CentOS 7.3 (64-bit)"]
+  }
 }
 ```
 
@@ -16,33 +24,38 @@ data "ncloud_server_image" "image" {
 
 ```hcl
 data "ncloud_server_image" "image" {
-  product_type_code = "WINNT"
+  platform_type = "WINNT"
+}
+
+// Use filter
+data "ncloud_server_image" "image_by_filter" {
+  filter {
+    name = "platform_type"
+    values = ["WINNT"]
+  }
 }
 ```
+
+
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `product_name_regex` - (Optional) A regex string to apply to the server image list returned by ncloud.
-* `exclusion_product_code` - (Optional) Product code you want to exclude from the list.
 * `product_code` - (Optional) Product code you want to view on the list. Use this when searching for 1 product.
 * `product_type` - (Optional) Product type code
-* `platform_type_code_list` - (Optional) Values required for identifying platforms in list-type.
+* `platform_type` - (Optional) Values required for identifying platform
     The available values are as follows: Linux 32Bit(LNX32) | Linux 64Bit(LNX64) | Windows 32Bit(WND32) | Windows 64Bit(WND64) | Ubuntu Desktop 64Bit(UBD64) | Ubuntu Server 64Bit(UBS64)
-* `block_storage_size` - (Optional) Block storage size.
-* `region` - (Optional) Region code. Get available values using the data source `ncloud_regions`.
-    Default: KR region.
 * `infra_resource_detail_type_code` - (Optional) infra resource detail type code.
+* `filter` - (Optional) Custom filter block as described below.
+  * `name` - (Required) The name of the field to filter by
+  * `values` - (Required) Set of values that are accepted for the given field.
+  * `regex` - (Optional) is `values` treated as a regular expression.
 
 ## Attributes Reference
 
 * `product_name` - Product name
 * `product_description` - Product description
 * `infra_resource_type` - Infra resource type code
-* `cpu_count` - CPU count
-* `memory_size` - Memory size
 * `base_block_storage_size` - Base block storage size
-* `platform_type` - Platform type code
 * `os_information` - OS Information
-* `add_block_storage_size` - Additional block storage size

--- a/docs/data-sources/server_images.md
+++ b/docs/data-sources/server_images.md
@@ -6,6 +6,11 @@ To create a server instance (VM), you should select a server image. This data so
 
 ```hcl
 data "ncloud_server_images" "all" {
+  filter {
+    name = "product_name"
+    values = ["CentOS 7.3 (64-bit)"]
+  }
+
   output_file = "server_images.json"
 }
 ```
@@ -14,16 +19,15 @@ data "ncloud_server_images" "all" {
 
 The following arguments are supported:
 
-* `product_name_regex` - (Optional) A regex string to apply to the server image list returned by ncloud.
-* `exclusion_product_code` - (Optional) Product code you want to exclude from the list.
 * `product_code` - (Optional) Product code you want to view on the list. Use this when searching for 1 product.
 * `platform_type_code_list` - (Optional) Values required for identifying platforms in list-type.
     The available values are as follows: Linux 32Bit(LNX32) | Linux 64Bit(LNX64) | Windows 32Bit(WND32) | Windows 64Bit(WND64) | Ubuntu Desktop 64Bit(UBD64) | Ubuntu Server 64Bit(UBS64)
-* `block_storage_size` - (Optional) Block storage size.
-* `region` - (Optional) Region code. Get available values using the data source `ncloud_regions`.
-    Default: KR region.
 * `infra_resource_detail_type_code` - (Optional) infra resource detail type code.
 * `output_file` - (Optional) The name of file that can save data source after running `terraform plan`.
+* `filter` - (Optional) Custom filter block as described below.
+  * `name` - (Required) The name of the field to filter by
+  * `values` - (Required) Set of values that are accepted for the given field.
+  * `regex` - (Optional) is `values` treated as a regular expression.
 
 ## Attributes Reference
 

--- a/docs/data-sources/server_product.md
+++ b/docs/data-sources/server_product.md
@@ -7,7 +7,34 @@ To this end, we provide data source by which you can search a server product.
 
 ```hcl
 data "ncloud_server_product" "product" {
-	server_image_product_code = "SPSW0LINUX000032"
+  server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"  // Search by 'CentOS 7.3 (64-bit)' image vpc
+  // server_image_product_code = "SPSW0LINUX000032"  // Search by 'CentOS 7.3 (64-bit)' image classic
+
+  filter {
+    name   = "product_code"
+    values = ["SSD"]
+    regex  = true
+  }
+
+  filter {
+    name   = "cpu_count"
+    values = ["2"]
+  }
+
+  filter {
+    name   = "memory_size"
+    values = ["8GB"]
+  }
+
+  filter {
+    name   = "base_block_storage_size"
+    values = ["50GB"]
+  }
+
+  filter {
+    name   = "product_type"
+    values = ["STAND"]
+  }
 }
 ```
 
@@ -16,14 +43,14 @@ data "ncloud_server_product" "product" {
 The following arguments are supported:
 
 * `server_image_product_code` - (Required) You can get one from `data ncloud_server_images`. This is a required value, and each available server's specification varies depending on the server image product.
-* `product_name_regex` - (Optional) A regex string to apply to the Server Product list returned.
-* `exclusion_product_code` - (Optional) Enter a product code to exclude from the list.
 * `product_code` - (Optional) Enter a product code to search from the list. Use it for a single search.
-* `region` - (Optional) Region code. Get available values using the data source `ncloud_regions`.
-    Default: KR region.
 * `zone` - (Optional) Zone code. You can decide a zone where servers are created. You can decide which zone the product list will be requested at. default : Select the first Zone in the specific region
     Get available values using the data source `ncloud_zones`.
 * `internet_line_type_code` - (Optional) Internet line code. PUBLC(Public), GLBL(Global)
+* `filter` - (Optional) Custom filter block as described below.
+  * `name` - (Required) The name of the field to filter by
+  * `values` - (Required) Set of values that are accepted for the given field.
+  * `regex` - (Optional) is `values` treated as a regular expression.
 
 ## Attributes Reference
 
@@ -34,6 +61,4 @@ The following arguments are supported:
 * `cpu_count` - CPU count
 * `memory_size` - Memory size
 * `base_block_storage_size` - Base block storage size
-* `platform_type` - Platform type code
-* `os_information` - OS Information
-* `add_block_storage_size` - Additional block storage size
+* `generation_code` - Generation Code

--- a/docs/data-sources/server_products.md
+++ b/docs/data-sources/server_products.md
@@ -6,9 +6,36 @@ To this end, we provide data source by which you can search a server product.
 ## Example Usage
 
 ```hcl
-data "ncloud_server_products" "all" {
-  # server_image_product_code: You can get one from `data ncloud_server_images`
-  server_image_product_code = "SPSW0LINUX000032"
+# Classic
+data "ncloud_server_products" "product_ids" {
+  server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"  // Search by 'CentOS 7.3 (64-bit)' image vpc
+  // server_image_product_code = "SPSW0LINUX000032"  // Search by 'CentOS 7.3 (64-bit)' image classic
+  
+  filter {
+    name   = "product_code"
+    values = ["SSD"]
+    regex  = true
+  }
+
+  filter {
+    name   = "cpu_count"
+    values = ["2"]
+  }
+
+  filter {
+    name   = "memory_size"
+    values = ["8GB"]
+  }
+
+  filter {
+    name   = "base_block_storage_size"
+    values = ["50GB"]
+  }
+
+  filter {
+    name   = "product_type"
+    values = ["STAND"]
+  }
 }
 ```
 
@@ -17,14 +44,15 @@ data "ncloud_server_products" "all" {
 The following arguments are supported:
 
 * `server_image_product_code` - (Required) You can get one from `data ncloud_server_images`. This is a required value, and each available server's specification varies depending on the server image product.
-* `product_name_regex` - (Optional) A regex string to apply to the Server Product list returned.
-* `exclusion_product_code` - (Optional) Enter a product code to exclude from the list.
 * `product_code` - (Optional) Enter a product code to search from the list. Use it for a single search.
-* `region` - (Optional) Region code. Get available values using the data source `ncloud_regions`.
-    Default: KR region.
 * `zone` - (Optional) Zone code. You can decide a zone where servers are created. You can decide which zone the product list will be requested at. default : Select the first Zone in the specific region
     Get available values using the data source `ncloud_zones`.
 * `internet_line_type_code` - (Optional) Internet line code. PUBLC(Public), GLBL(Global)
+* `filter` - (Optional) Custom filter block as described below.
+  * `name` - (Required) The name of the field to filter by
+  * `values` - (Required) Set of values that are accepted for the given field.
+  * `regex` - (Optional) is `values` treated as a regular expression.
+
 
 ## Attributes Reference
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/terraform-providers/terraform-provider-ncloud
 go 1.13
 
 require (
-	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.6
+	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.7-0.20201113013430-6bf46ebe0fd3
 	github.com/hashicorp/terraform-plugin-sdk v1.15.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.6 h1:XvFMb1zdEEjyzF3VUSF763tCDLRBWKujuzsvArbN6DY=
 github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.6/go.mod h1:P+3VS0ETiQPyWOx3vB/oeC8J3qd7jnVZLYAFwWgGRt8=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.7-0.20201113013430-6bf46ebe0fd3 h1:hS6sMh3B6Y11UHNgI2iUfBXq9bpjEmCZhptNAFlJoko=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.1.7-0.20201113013430-6bf46ebe0fd3/go.mod h1:P+3VS0ETiQPyWOx3vB/oeC8J3qd7jnVZLYAFwWgGRt8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/ncloud/data_source_ncloud_server_image_test.go
+++ b/ncloud/data_source_ncloud_server_image_test.go
@@ -8,14 +8,23 @@ import (
 )
 
 func TestAccDataSourceNcloudServerImage_classic_byCode(t *testing.T) {
+	dataName := "data.ncloud_server_image.test1"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerImageByCodeConfig("SPSW0LINUX000139"),
+				Config: testAccDataSourceNcloudServerImageByCodeConfig("SPSW0LINUX000046"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceID("data.ncloud_server_image.test1"),
+					testAccCheckDataSourceID(dataName),
+					resource.TestCheckResourceAttr(dataName, "product_code", "SPSW0LINUX000046"),
+					resource.TestCheckResourceAttr(dataName, "product_name", "CentOS 7.3 (64-bit)"),
+					resource.TestCheckResourceAttr(dataName, "product_description", "CentOS 7.3 (64-bit)"),
+					resource.TestCheckResourceAttr(dataName, "infra_resource_type", "SW"),
+					resource.TestCheckResourceAttr(dataName, "os_information", "CentOS 7.3 (64-bit)"),
+					resource.TestCheckResourceAttr(dataName, "platform_type", "LNX64"),
+					resource.TestCheckResourceAttr(dataName, "base_block_storage_size", "50GB"),
 				),
 			},
 		},
@@ -23,6 +32,8 @@ func TestAccDataSourceNcloudServerImage_classic_byCode(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServerImage_vpc_byCode(t *testing.T) {
+	dataName := "data.ncloud_server_image.test1"
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -30,7 +41,14 @@ func TestAccDataSourceNcloudServerImage_vpc_byCode(t *testing.T) {
 			{
 				Config: testAccDataSourceNcloudServerImageByCodeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceID("data.ncloud_server_image.test1"),
+					testAccCheckDataSourceID(dataName),
+					resource.TestCheckResourceAttr(dataName, "product_code", "SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
+					resource.TestCheckResourceAttr(dataName, "product_name", "CentOS 7.3 (64-bit)"),
+					resource.TestCheckResourceAttr(dataName, "product_description", "CentOS 7.3 (64-bit)"),
+					resource.TestCheckResourceAttr(dataName, "infra_resource_type", "SW"),
+					resource.TestCheckResourceAttr(dataName, "os_information", "CentOS 7.3 (64-bit)"),
+					resource.TestCheckResourceAttr(dataName, "platform_type", "LNX64"),
+					resource.TestCheckResourceAttr(dataName, "base_block_storage_size", "50GB"),
 				),
 			},
 		},
@@ -136,17 +154,21 @@ var testAccDataSourceNcloudServerImageByFilterProductNameConfig = `
 data "ncloud_server_image" "test3" {
   filter {
     name = "product_name"
-    values = ["CentOS 7.8 (64-bit)"]
+    values = ["CentOS 7.3 (64-bit)"]
   }
 }
 `
 
 var testAccDataSourceNcloudServerImageByBlockStorageSizeConfig = `
 data "ncloud_server_image" "test4" {
-	block_storage_size = 50
 	filter {
-    name = "product_name"
-    values = ["CentOS 7.8 (64-bit)"]
-  }
+		name = "product_name"
+		values = ["CentOS 7.3 (64-bit)"]
+	}
+
+	filter {
+		name = "base_block_storage_size"
+		values = ["50GB"]
+	}
 }
 `

--- a/ncloud/data_source_ncloud_server_product.go
+++ b/ncloud/data_source_ncloud_server_product.go
@@ -85,14 +85,14 @@ func dataSourceNcloudServerProduct() *schema.Resource {
 			"exclusion_product_code": {
 				Type:       schema.TypeString,
 				Optional:   true,
-				Deprecated: "This field no longer support",
+				Deprecated: "This field is no longer support",
 			},
 		},
 	}
 }
 
 func dataSourceNcloudServerProductRead(d *schema.ResourceData, meta interface{}) error {
-	resources, err := getClassicServerProductListFiltered(d, meta.(*ProviderConfig))
+	resources, err := getServerProductListFiltered(d, meta.(*ProviderConfig))
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func dataSourceNcloudServerProductRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func getClassicServerProductListFiltered(d *schema.ResourceData, config *ProviderConfig) ([]map[string]interface{}, error) {
+func getServerProductListFiltered(d *schema.ResourceData, config *ProviderConfig) ([]map[string]interface{}, error) {
 	var resources []map[string]interface{}
 	var err error
 

--- a/ncloud/data_source_ncloud_server_product.go
+++ b/ncloud/data_source_ncloud_server_product.go
@@ -1,6 +1,7 @@
 package ncloud
 
 import (
+	"fmt"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
@@ -18,140 +19,113 @@ func dataSourceNcloudServerProduct() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"server_image_product_code": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "You can get one from `data ncloud_server_images`. This is a required value, and each available server's specification varies depending on the server image product.",
-			},
-			"product_name_regex": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.ValidateRegexp,
-				Description:  "A regex string to apply to the Server Product list returned.",
-				Deprecated:   "use filter instead",
-			},
-			"exclusion_product_code": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Enter a product code to exclude from the list.",
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"product_code": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Enter a product code to search from the list. Use it for a single search.",
-			},
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Region code. Get available values using the `data ncloud_regions`.",
-				Deprecated:  "use region attribute of provider instead",
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"zone": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Zone code. Get available values using the `data ncloud_zones`.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"internet_line_type_code": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"PUBLC", "GLBL"}, false),
-				Description:  "Internet line identification code. PUBLC(Public), GLBL(Global). default : PUBLC(Public)",
 			},
 			"filter": dataSourceFiltersSchema(),
 
 			"product_name": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Product name",
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"product_type": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Product type",
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"product_description": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Product description",
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"infra_resource_type": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Infra resource type",
-			},
-			"infra_resource_detail_type_code": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "infra resource detail type code.",
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"cpu_count": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "CPU count",
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 			"memory_size": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Memory size",
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"base_block_storage_size": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Base block storage size",
-			},
-			"platform_type": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Platform type",
-			},
-			"os_information": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "OS Information",
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"disk_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"add_block_storage_size": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Additional block storage size",
-			},
 			"generation_code": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			// Deprecated
+			"product_name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.ValidateRegexp,
+				Deprecated:   "use filter instead",
+			},
+			"exclusion_product_code": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "This field no longer support",
 			},
 		},
 	}
 }
 
 func dataSourceNcloudServerProductRead(d *schema.ResourceData, meta interface{}) error {
-	var resources []map[string]interface{}
-	var err error
-
-	if meta.(*ProviderConfig).SupportVPC == true {
-		resources, err = getVpcServerProductList(d, meta.(*ProviderConfig))
-	} else {
-		resources, err = getClassicServerProductList(d, meta.(*ProviderConfig))
-	}
-
+	resources, err := getClassicServerProductListFiltered(d, meta.(*ProviderConfig))
 	if err != nil {
 		return err
 	}
 
-	if f, ok := d.GetOk("filter"); ok {
-		resources = ApplyFilters(f.(*schema.Set), resources, dataSourceNcloudServerProduct().Schema)
-	}
-
 	if err := validateOneResult(len(resources)); err != nil {
+
 		return err
 	}
 
 	SetSingularResourceDataFromMap(d, resources[0])
 
 	return nil
+}
+
+func getClassicServerProductListFiltered(d *schema.ResourceData, config *ProviderConfig) ([]map[string]interface{}, error) {
+	var resources []map[string]interface{}
+	var err error
+
+	if config.SupportVPC == true {
+		resources, err = getVpcServerProductList(d, config)
+	} else {
+		resources, err = getClassicServerProductList(d, config)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if f, ok := d.GetOk("filter"); ok {
+		resources = ApplyFilters(f.(*schema.Set), resources, dataSourceNcloudServerProduct().Schema)
+	}
+
+	return resources, nil
 }
 
 func getClassicServerProductList(d *schema.ResourceData, config *ProviderConfig) ([]map[string]interface{}, error) {
@@ -177,9 +151,9 @@ func getClassicServerProductList(d *schema.ResourceData, config *ProviderConfig)
 		logErrorResponse("getClassicServerProductList", err, reqParams)
 		return nil, err
 	}
-	logCommonResponse("getClassicServerProductList", GetCommonResponse(resp))
+	logResponse("getClassicServerProductList", resp)
 
-	resources := []map[string]interface{}{}
+	var resources []map[string]interface{}
 
 	for _, r := range resp.ProductList {
 		instance := map[string]interface{}{
@@ -190,18 +164,10 @@ func getClassicServerProductList(d *schema.ResourceData, config *ProviderConfig)
 			"product_description":     *r.ProductDescription,
 			"infra_resource_type":     *r.InfraResourceType.Code,
 			"cpu_count":               *r.CpuCount,
-			"memory_size":             *r.MemorySize,
-			"base_block_storage_size": *r.BaseBlockStorageSize,
-			"os_information":          *r.OsInformation,
+			"memory_size":             fmt.Sprintf("%dGB", *r.MemorySize/GIGABYTE),
+			"base_block_storage_size": fmt.Sprintf("%dGB", *r.BaseBlockStorageSize/GIGABYTE),
 			"disk_type":               *r.DiskType.Code,
-			"add_block_storage_size":  *r.AddBlockStorageSize,
-		}
-
-		if r.InfraResourceDetailType != nil {
-			instance["infra_resource_detail_type_code"] = *r.InfraResourceDetailType.Code
-		}
-		if r.PlatformType != nil {
-			instance["platform_type"] = *r.PlatformType.Code
+			"generation_code":         *r.GenerationCode,
 		}
 
 		resources = append(resources, instance)
@@ -228,9 +194,9 @@ func getVpcServerProductList(d *schema.ResourceData, config *ProviderConfig) ([]
 		logErrorResponse("getVpcServerProductList", err, reqParams)
 		return nil, err
 	}
-	logCommonResponse("getVpcServerProductList", GetCommonResponse(resp))
+	logResponse("getVpcServerProductList", resp)
 
-	resources := []map[string]interface{}{}
+	var resources []map[string]interface{}
 
 	for _, r := range resp.ProductList {
 		instance := map[string]interface{}{
@@ -241,19 +207,10 @@ func getVpcServerProductList(d *schema.ResourceData, config *ProviderConfig) ([]
 			"product_description":     *r.ProductDescription,
 			"infra_resource_type":     *r.InfraResourceType.Code,
 			"cpu_count":               *r.CpuCount,
-			"memory_size":             *r.MemorySize,
-			"base_block_storage_size": *r.BaseBlockStorageSize,
-			"os_information":          *r.OsInformation,
+			"memory_size":             fmt.Sprintf("%dGB", *r.MemorySize/GIGABYTE),
+			"base_block_storage_size": fmt.Sprintf("%dGB", *r.BaseBlockStorageSize/GIGABYTE),
 			"disk_type":               *r.DiskType.Code,
-			"add_block_storage_size":  *r.AddBlockStorageSize,
 			"generation_code":         *r.GenerationCode,
-		}
-
-		if r.InfraResourceDetailType != nil {
-			instance["infra_resource_detail_type_code"] = *r.InfraResourceDetailType.Code
-		}
-		if r.PlatformType != nil {
-			instance["platform_type"] = *r.PlatformType.Code
 		}
 
 		resources = append(resources, instance)

--- a/ncloud/data_source_ncloud_server_products.go
+++ b/ncloud/data_source_ncloud_server_products.go
@@ -16,58 +16,46 @@ func dataSourceNcloudServerProducts() *schema.Resource {
 		Read: dataSourceNcloudServerProductsRead,
 
 		Schema: map[string]*schema.Schema{
-			"product_name_regex": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.ValidateRegexp,
-				Description:  "A regex string to apply to the Server Product list returned.",
-				Deprecated:   "use filter instead",
-			},
-			"exclusion_product_code": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Enter a product code to exclude from the list.",
-				Deprecated:  "use filter instead",
-			},
 			"product_code": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "Enter a product code to search from the list. Use it for a single search.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"server_image_product_code": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "You can get one from `data ncloud_server_images`. This is a required value, and each available server's specification varies depending on the server image product.",
-			},
-			"region": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Region code. Get available values using the `data ncloud_regions`.",
-				Deprecated:  "use region attribute of provider instead",
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"zone": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Zone code. You can decide a zone where servers are created. You can decide which zone the product list will be requested at. You can get one by calling `data ncloud_zones`. default : Select the first Zone in the specific region",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"internet_line_type_code": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"PUBLC", "GLBL"}, false),
-				Description:  "Internet line identification code. PUBLC(Public), GLBL(Global). default : PUBLC(Public)",
 			},
 			"server_products": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "A list of server product code.",
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"filter": dataSourceFiltersSchema(),
 			"output_file": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			// Deprecated
+			"product_name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.ValidateRegexp,
+				Deprecated:   "use filter instead",
+			},
+			"exclusion_product_code": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "use filter instead",
 			},
 		},
 	}

--- a/ncloud/data_source_ncloud_server_products_test.go
+++ b/ncloud/data_source_ncloud_server_products_test.go
@@ -45,6 +45,32 @@ func testAccDataSourceNcloudServerProductsConfig(productCode string) string {
 	return fmt.Sprintf(`
 data "ncloud_server_products" "all" {
 	server_image_product_code = "%s"
+
+	filter {
+		name = "product_code"
+		values = ["SSD"]
+		regex = true
+	}
+
+	filter {
+		name = "cpu_count"
+		values = ["2"]
+	}
+
+	filter {
+		name = "memory_size"
+		values = ["8GB"]
+	}
+
+	filter {
+		name = "base_block_storage_size"
+		values = ["50GB"]
+	}
+
+	filter {
+		name = "product_type"
+		values = ["STAND"]
+	}
 }
 `, productCode)
 }

--- a/ncloud/filters.go
+++ b/ncloud/filters.go
@@ -238,7 +238,7 @@ func orComparator(target interface{}, filters []interface{}, stringsEqual String
 			if val.Bool() == fBool {
 				return true
 			}
-		case reflect.Int:
+		case reflect.Int, reflect.Int32, reflect.Int64:
 			// the target field is of type int, but the filter values list element type is string, users can supply string
 			// or int like `values = [300, "3600"]` but terraform will converts to string, so use ParseInt
 			fInt, err := strconv.ParseInt(fVal.(string), 10, 64)

--- a/ncloud/validators.go
+++ b/ncloud/validators.go
@@ -89,7 +89,7 @@ func validateOneResult(resultCount int) error {
 		return fmt.Errorf("no results. please change search criteria and try again")
 	}
 	if resultCount > 1 {
-		return fmt.Errorf("more than one found results. please change search criteria and try again")
+		return fmt.Errorf("more than one found results(%d). please change search criteria and try again", resultCount)
 	}
 	return nil
 }


### PR DESCRIPTION
### Bugs
- Fix `filter` if values is numeric  (fix #117)

### Improve
- refactor fields unnecessary (fix #116)

#### Result of test
##### ncloud_server_product
```
=== RUN   TestAccDataSourceNcloudServerProduct_classic_basic
=== PAUSE TestAccDataSourceNcloudServerProduct_classic_basic
=== CONT  TestAccDataSourceNcloudServerProduct_classic_basic
--- PASS: TestAccDataSourceNcloudServerProduct_classic_basic (1.10s)
=== RUN   TestAccDataSourceNcloudServerProduct_vpc_basic
=== PAUSE TestAccDataSourceNcloudServerProduct_vpc_basic
=== CONT  TestAccDataSourceNcloudServerProduct_vpc_basic
--- PASS: TestAccDataSourceNcloudServerProduct_vpc_basic (2.00s)
=== RUN   TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode
=== PAUSE TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode
=== CONT  TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode
--- PASS: TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode (1.25s)
=== RUN   TestAccDataSourceNcloudServerProduct_vpc_FilterByProductCode
=== PAUSE TestAccDataSourceNcloudServerProduct_vpc_FilterByProductCode
=== CONT  TestAccDataSourceNcloudServerProduct_vpc_FilterByProductCode
--- PASS: TestAccDataSourceNcloudServerProduct_vpc_FilterByProductCode (2.12s)
=== RUN   TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType
=== PAUSE TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType
=== CONT  TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType
--- PASS: TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType (1.36s)
=== RUN   TestAccDataSourceNcloudServerProduct_vpc_FilterByProductNameProductType
=== PAUSE TestAccDataSourceNcloudServerProduct_vpc_FilterByProductNameProductType
=== CONT  TestAccDataSourceNcloudServerProduct_vpc_FilterByProductNameProductType
--- PASS: TestAccDataSourceNcloudServerProduct_vpc_FilterByProductNameProductType (2.15s)
PASS
```
##### ncloud_server_products
```
=== RUN   TestAccDataSourceNcloudServerProducts_classic_basic
=== PAUSE TestAccDataSourceNcloudServerProducts_classic_basic
=== CONT  TestAccDataSourceNcloudServerProducts_classic_basic
--- PASS: TestAccDataSourceNcloudServerProducts_classic_basic (0.85s)
=== RUN   TestAccDataSourceNcloudServerProducts_vpc_basic
=== PAUSE TestAccDataSourceNcloudServerProducts_vpc_basic
=== CONT  TestAccDataSourceNcloudServerProducts_vpc_basic
--- PASS: TestAccDataSourceNcloudServerProducts_vpc_basic (1.21s)
PASS
```
##### ncloud_server_images
```
=== RUN   TestAccDataSourceNcloudServerImages_classic_basic
=== PAUSE TestAccDataSourceNcloudServerImages_classic_basic
=== CONT  TestAccDataSourceNcloudServerImages_classic_basic
--- PASS: TestAccDataSourceNcloudServerImages_classic_basic (2.52s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_basic
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_basic
=== CONT  TestAccDataSourceNcloudServerImages_vpc_basic
--- PASS: TestAccDataSourceNcloudServerImages_vpc_basic (2.47s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_linux
=== PAUSE TestAccDataSourceNcloudServerImages_classic_linux
=== CONT  TestAccDataSourceNcloudServerImages_classic_linux
--- PASS: TestAccDataSourceNcloudServerImages_classic_linux (2.07s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_linux
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_linux
=== CONT  TestAccDataSourceNcloudServerImages_vpc_linux
--- PASS: TestAccDataSourceNcloudServerImages_vpc_linux (2.29s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_windows
=== PAUSE TestAccDataSourceNcloudServerImages_classic_windows
=== CONT  TestAccDataSourceNcloudServerImages_classic_windows
--- PASS: TestAccDataSourceNcloudServerImages_classic_windows (2.37s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_windows
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_windows
=== CONT  TestAccDataSourceNcloudServerImages_vpc_windows
--- PASS: TestAccDataSourceNcloudServerImages_vpc_windows (2.55s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_bareMetal
=== PAUSE TestAccDataSourceNcloudServerImages_classic_bareMetal
=== CONT  TestAccDataSourceNcloudServerImages_classic_bareMetal
--- PASS: TestAccDataSourceNcloudServerImages_classic_bareMetal (2.28s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_bareMetal
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_bareMetal
=== CONT  TestAccDataSourceNcloudServerImages_vpc_bareMetal
--- PASS: TestAccDataSourceNcloudServerImages_vpc_bareMetal (2.48s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_blockStorageSize
=== PAUSE TestAccDataSourceNcloudServerImages_classic_blockStorageSize
=== CONT  TestAccDataSourceNcloudServerImages_classic_blockStorageSize
--- PASS: TestAccDataSourceNcloudServerImages_classic_blockStorageSize (2.55s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_blockStorageSize
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_blockStorageSize
=== CONT  TestAccDataSourceNcloudServerImages_vpc_blockStorageSize
--- PASS: TestAccDataSourceNcloudServerImages_vpc_blockStorageSize (2.30s)
PASS
```
#####  ncloud_server_image
```
=== RUN   TestAccDataSourceNcloudServerImage_classic_byCode
=== PAUSE TestAccDataSourceNcloudServerImage_classic_byCode
=== CONT  TestAccDataSourceNcloudServerImage_classic_byCode
--- PASS: TestAccDataSourceNcloudServerImage_classic_byCode (0.77s)
=== RUN   TestAccDataSourceNcloudServerImage_vpc_byCode
=== PAUSE TestAccDataSourceNcloudServerImage_vpc_byCode
=== CONT  TestAccDataSourceNcloudServerImage_vpc_byCode
--- PASS: TestAccDataSourceNcloudServerImage_vpc_byCode (2.67s)
=== RUN   TestAccDataSourceNcloudServerImage_classic_byFilterProductCode
=== PAUSE TestAccDataSourceNcloudServerImage_classic_byFilterProductCode
=== CONT  TestAccDataSourceNcloudServerImage_classic_byFilterProductCode
--- PASS: TestAccDataSourceNcloudServerImage_classic_byFilterProductCode (1.44s)
=== RUN   TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode
=== PAUSE TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode
=== CONT  TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode
--- PASS: TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode (2.79s)
=== RUN   TestAccDataSourceNcloudServerImage_classic_byFilterProductName
=== PAUSE TestAccDataSourceNcloudServerImage_classic_byFilterProductName
=== CONT  TestAccDataSourceNcloudServerImage_classic_byFilterProductName
--- PASS: TestAccDataSourceNcloudServerImage_classic_byFilterProductName (1.37s)
=== RUN   TestAccDataSourceNcloudServerImage_vpc_byFilterProductName
=== PAUSE TestAccDataSourceNcloudServerImage_vpc_byFilterProductName
=== CONT  TestAccDataSourceNcloudServerImage_vpc_byFilterProductName
--- PASS: TestAccDataSourceNcloudServerImage_vpc_byFilterProductName (2.70s)
=== RUN   TestAccDataSourceNcloudServerImage_classic_byBlockStorageSize
=== PAUSE TestAccDataSourceNcloudServerImage_classic_byBlockStorageSize
=== CONT  TestAccDataSourceNcloudServerImage_classic_byBlockStorageSize
--- PASS: TestAccDataSourceNcloudServerImage_classic_byBlockStorageSize (1.47s)
=== RUN   TestAccDataSourceNcloudServerImage_vpc_byBlockStorageSize
=== PAUSE TestAccDataSourceNcloudServerImage_vpc_byBlockStorageSize
=== CONT  TestAccDataSourceNcloudServerImage_vpc_byBlockStorageSize
--- PASS: TestAccDataSourceNcloudServerImage_vpc_byBlockStorageSize (2.81s)
PASS
```