### PR TITLE
#119 change size storage

### DIFF
--- a/ncloud/resource_ncloud_block_storage.go
+++ b/ncloud/resource_ncloud_block_storage.go
@@ -2,8 +2,9 @@ package ncloud
 
 import (
 	"fmt"
-	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
 	"time"
+
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
 
 	"log"
 
@@ -163,6 +164,18 @@ func resourceNcloudBlockStorageUpdate(d *schema.ResourceData, meta interface{}) 
 			if err := attachBlockStorage(d, config); err != nil {
 				return err
 			}
+		}
+	}
+
+	if d.HasChange("size") {
+		o, n := d.GetChange("size")
+
+		if o.(int) >= n.(int) {
+			return fmt.Errorf("The storage size is only expandable, not shrinking. new size(%d) must be greater than the existing size(%d)", n, o)
+		}
+
+		if err := changeBlockStorageSize(d, config); err != nil {
+			return err
 		}
 	}
 
@@ -584,6 +597,84 @@ func waitForBlockStorageAttachment(config *ProviderConfig, id string) error {
 	return nil
 }
 
+func changeBlockStorageSize(d *schema.ResourceData, config *ProviderConfig) error {
+	var err error
+	if config.SupportVPC {
+		err = changeVpcBlockStorageSize(d, config)
+	} else {
+		err = changeClassicBlockStorageSize(d, config)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if err = waitForBlockStorageOperationIsNull(config, d.Id()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func changeVpcBlockStorageSize(d *schema.ResourceData, config *ProviderConfig) error {
+	reqParams := &vserver.ChangeBlockStorageVolumeSizeRequest{
+		RegionCode:             &config.RegionCode,
+		BlockStorageInstanceNo: ncloud.String(d.Id()),
+		BlockStorageSize:       ncloud.Int32(int32(d.Get("size").(int))),
+	}
+
+	logCommonRequest("changeVpcBlockStorageSize", reqParams)
+	resp, err := config.Client.vserver.V2Api.ChangeBlockStorageVolumeSize(reqParams)
+	if err != nil {
+		logErrorResponse("changeVpcBlockStorageSize", err, reqParams)
+		return err
+	}
+	logResponse("changeVpcBlockStorageSize", resp)
+
+	return nil
+}
+
+func changeClassicBlockStorageSize(d *schema.ResourceData, config *ProviderConfig) error {
+	reqParams := &server.ChangeBlockStorageVolumeSizeRequest{
+		BlockStorageInstanceNo: ncloud.String(d.Id()),
+		BlockStorageSize:       ncloud.Int64(int64(d.Get("size").(int))),
+	}
+
+	logCommonRequest("changeClassicBlockStorageSize", reqParams)
+	resp, err := config.Client.server.V2Api.ChangeBlockStorageVolumeSize(reqParams)
+	if err != nil {
+		logErrorResponse("changeClassicBlockStorageSize", err, reqParams)
+		return err
+	}
+	logResponse("changeClassicBlockStorageSize", resp)
+
+	return nil
+}
+
+func waitForBlockStorageOperationIsNull(config *ProviderConfig, id string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"CHNG"},
+		Target:  []string{"NULL"},
+		Refresh: func() (interface{}, string, error) {
+			instance, err := getBlockStorage(config, id)
+			if err != nil {
+				return 0, "", err
+			}
+			return instance, ncloud.StringValue(instance.Operation), nil
+		},
+		Timeout:    DefaultUpdateTimeout,
+		Delay:      2 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for BlockStorageInstance operation to be \"NULL\": %s", err)
+	}
+
+	return nil
+}
+
 //BlockStorage Dto for block storage
 type BlockStorage struct {
 	BlockStorageInstanceNo  *string `json:"block_storage_no,omitempty"`
@@ -595,6 +686,7 @@ type BlockStorage struct {
 	DeviceName              *string `json:"device_name,omitempty"`
 	BlockStorageProductCode *string `json:"product_code,omitempty"`
 	Status                  *string `json:"status,omitempty"`
+	Operation               *string `json:"operation,omitempty"`
 	Description             *string `json:"description,omitempty"`
 	DiskType                *string `json:"disk_type,omitempty"`
 	DiskDetailType          *string `json:"disk_detail_type,omitempty"`

--- a/ncloud/resource_ncloud_block_storage_test.go
+++ b/ncloud/resource_ncloud_block_storage_test.go
@@ -2,9 +2,10 @@ package ncloud
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -145,6 +146,80 @@ func TestAccResourceNcloudBlockStorage_vpc_ChangeServerInstance(t *testing.T) {
 	})
 }
 
+func TestAccResourceNcloudBlockStorage_classic_size(t *testing.T) {
+	var storageInstance BlockStorage
+	name := fmt.Sprintf("tf-storage-size-%s", acctest.RandString(5))
+	resourceName := "ncloud_block_storage.storage"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccClassicProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccCheckBlockStorageDestroyWithProvider(state, testAccClassicProvider)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBlockStorageClassicConfigWithSize(name, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccClassicProvider),
+					resource.TestCheckResourceAttr(resourceName, "size", "10"),
+				),
+			},
+			{
+				Config: testAccBlockStorageClassicConfigWithSize(name, 20),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccClassicProvider),
+					resource.TestCheckResourceAttr(resourceName, "size", "20"),
+				),
+			},
+			{
+				Config: testAccBlockStorageClassicConfigWithSize(name, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccClassicProvider),
+				),
+				ExpectError: regexp.MustCompile("The storage size is only expandable, not shrinking. new size(\\d+) must be greater than the existing size(\\d+)"),
+			},
+		},
+	})
+}
+
+func TestAccResourceNcloudBlockStorage_vpc_size(t *testing.T) {
+	var storageInstance BlockStorage
+	name := fmt.Sprintf("tf-storage-size-%s", acctest.RandString(5))
+	resourceName := "ncloud_block_storage.storage"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			return testAccCheckBlockStorageDestroyWithProvider(state, testAccProvider)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBlockStorageVpcConfigWithSize(name, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccProvider),
+					resource.TestCheckResourceAttr(resourceName, "size", "10"),
+				),
+			},
+			{
+				Config: testAccBlockStorageVpcConfigWithSize(name, 20),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccProvider),
+					resource.TestCheckResourceAttr(resourceName, "size", "20"),
+				),
+			},
+			{
+				Config: testAccBlockStorageVpcConfigWithSize(name, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccClassicProvider),
+				),
+				ExpectError: regexp.MustCompile("new size(\\d+) must be greater than the existing size(\\d+)"),
+			},
+		},
+	})
+}
+
 func testAccCheckBlockStorageExistsWithProvider(n string, i *BlockStorage, provider *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -194,7 +269,7 @@ func testAccCheckBlockStorageDestroyWithProvider(s *terraform.State, provider *s
 	return nil
 }
 
-func testAccBlockStorageClassicConfig(name string) string {
+func testAccBlockStorageClassicConfigWithSize(name string, size int) string {
 	return fmt.Sprintf(`
 resource "ncloud_login_key" "loginkey" {
 	key_name = "%[1]s-key"
@@ -210,12 +285,16 @@ resource "ncloud_server" "server" {
 resource "ncloud_block_storage" "storage" {
 	server_instance_no = ncloud_server.server.id
 	name = "%[1]s"
-	size = "10"
+	size = "%[2]d"
 }
-`, name)
+`, name, size)
 }
 
-func testAccBlockStorageVpcConfig(name string) string {
+func testAccBlockStorageClassicConfig(name string) string {
+	return testAccBlockStorageClassicConfigWithSize(name, 10)
+}
+
+func testAccBlockStorageVpcConfigWithSize(name string, size int) string {
 	return fmt.Sprintf(`
 resource "ncloud_login_key" "loginkey" {
 	key_name = "%[1]s-key"
@@ -247,11 +326,14 @@ resource "ncloud_server" "server" {
 resource "ncloud_block_storage" "storage" {
 	server_instance_no = ncloud_server.server.id
 	name = "%[1]s"
-	size = "10"
+	size = "%[2]d"
 }
-`, name)
+`, name, size)
 }
 
+func testAccBlockStorageVpcConfig(name string) string {
+	return testAccBlockStorageVpcConfigWithSize(name, 10)
+}
 func testAccBlockStorageClassicConfigUpdate(name, serverInstanceNo string) string {
 	return fmt.Sprintf(`
 resource "ncloud_login_key" "loginkey" {

--- a/ncloud/resource_ncloud_block_storage_test.go
+++ b/ncloud/resource_ncloud_block_storage_test.go
@@ -177,7 +177,7 @@ func TestAccResourceNcloudBlockStorage_classic_size(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccClassicProvider),
 				),
-				ExpectError: regexp.MustCompile("The storage size is only expandable, not shrinking. new size(\\d+) must be greater than the existing size(\\d+)"),
+				ExpectError: regexp.MustCompile("The storage size is only expandable, not shrinking."),
 			},
 		},
 	})
@@ -214,7 +214,7 @@ func TestAccResourceNcloudBlockStorage_vpc_size(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, testAccClassicProvider),
 				),
-				ExpectError: regexp.MustCompile("new size(\\d+) must be greater than the existing size(\\d+)"),
+				ExpectError: regexp.MustCompile("The storage size is only expandable, not shrinking."),
 			},
 		},
 	})


### PR DESCRIPTION
#### Features
- Support change `size` in block storage #119 

##### Test Results
```
=== RUN   TestAccResourceNcloudBlockStorage_vpc_size
--- PASS: TestAccResourceNcloudBlockStorage_vpc_size (101.14s)
PASS

Process finished with exit code 0


=== RUN   TestAccResourceNcloudBlockStorage_classic_size
--- PASS: TestAccResourceNcloudBlockStorage_classic_size (45.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ncloud/ncloud	47.630s
```
