### PR TITLE
#116 #121 fix missing computed and change result type products and images

### DIFF
--- a/docs/data-sources/server_images.md
+++ b/docs/data-sources/server_images.md
@@ -5,13 +5,31 @@ To create a server instance (VM), you should select a server image. This data so
 ## Example Usage
 
 ```hcl
-data "ncloud_server_images" "all" {
+data "ncloud_server_images" "images" {
   filter {
     name = "product_name"
     values = ["CentOS 7.3 (64-bit)"]
   }
 
-  output_file = "server_images.json"
+  output_file = "image.json" 
+}
+
+output "list_image" {
+  value = {
+    for image in data.ncloud_server_images.images.server_images:
+    image.id => image.product_name
+  }
+}
+```
+
+Outputs: 
+```hcl
+list_image = {
+  "SW.VSVR.APP.LNX64.CNTOS.0703.PINPT.173.B050" = "Pinpoint(1.7.3)-centos-7.3-64"
+  "SW.VSVR.OS.LNX64.CNTOS.0703.B050" = "centos-7.3-64"
+  "SW.VSVR.OS.LNX64.CNTOS.0708.B050" = "CentOS 7.8 (64-bit)"
+  "SW.VSVR.OS.LNX64.UBNTU.SVR1604.B050" = "ubuntu-16.04-64-server"
+  "SW.VSVR.OS.WND64.WND.SVR2016EN.B100" = "Windows Server 2016 (64-bit) English Edition"
 }
 ```
 

--- a/docs/data-sources/server_products.md
+++ b/docs/data-sources/server_products.md
@@ -6,8 +6,7 @@ To this end, we provide data source by which you can search a server product.
 ## Example Usage
 
 ```hcl
-# Classic
-data "ncloud_server_products" "product_ids" {
+data "ncloud_server_products" "products" {
   server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"  // Search by 'CentOS 7.3 (64-bit)' image vpc
   // server_image_product_code = "SPSW0LINUX000032"  // Search by 'CentOS 7.3 (64-bit)' image classic
   
@@ -36,6 +35,22 @@ data "ncloud_server_products" "product_ids" {
     name   = "product_type"
     values = ["STAND"]
   }
+
+  output_file = "product.json"
+}
+
+output "products" {
+  value = {
+    for product in data.ncloud_server_products.products.server_products:
+    product.id => product.product_name
+  }
+}
+```
+
+Outputs: 
+```hcl
+products = {
+  "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002" = "vCPU 2EA, Memory 8GB, [SSD]Disk 50GB"
 }
 ```
 

--- a/ncloud/data_source_ncloud_server_images.go
+++ b/ncloud/data_source_ncloud_server_images.go
@@ -42,6 +42,11 @@ func dataSourceNcloudServerImages() *schema.Resource {
 				Computed: true,
 				Elem:     GetDataSourceItemSchema(dataSourceNcloudServerImage()),
 			},
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			// Deprecated
 			"product_name_regex": {
 				Type:         schema.TypeString,
@@ -96,7 +101,8 @@ func serverImagesAttributes(d *schema.ResourceData, resources []map[string]inter
 	}
 
 	d.SetId(dataResourceIdHash(ids))
-	d.Set("server_images", ids)
+	d.Set("ids", ids)
+	d.Set("server_images", resources)
 
 	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
 		return writeToFile(output.(string), d.Get("server_images"))

--- a/ncloud/data_source_ncloud_server_products.go
+++ b/ncloud/data_source_ncloud_server_products.go
@@ -36,7 +36,12 @@ func dataSourceNcloudServerProducts() *schema.Resource {
 			},
 			"server_products": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
+				Elem:     GetDataSourceItemSchema(dataSourceNcloudServerProduct()),
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"filter": dataSourceFiltersSchema(),
@@ -98,7 +103,8 @@ func serverProductsAttributes(d *schema.ResourceData, serverProduct []map[string
 	}
 
 	d.SetId(dataResourceIdHash(ids))
-	d.Set("server_products", ids)
+	d.Set("ids", ids)
+	d.Set("server_products", serverProduct)
 
 	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
 		return writeToFile(output.(string), d.Get("server_products"))

--- a/ncloud/helpers.go
+++ b/ncloud/helpers.go
@@ -56,7 +56,9 @@ func GetSingularDataSourceItemSchema(resourceSchema *schema.Resource, addFieldMa
 // This is mainly used to ensure that fields of a datasource item are compliant with Terraform schema validation
 // All datasource return items should have computed-only fields; and not require Diff, Validation, or Default settings.
 func convertResourceFieldsToDatasourceFields(resourceSchema *schema.Resource) *schema.Resource {
-	for _, fieldSchema := range resourceSchema.Schema {
+	resultSchema := map[string]*schema.Schema{}
+	for k, fieldSchema := range resourceSchema.Schema {
+		isComputed := fieldSchema.Required || fieldSchema.Computed
 		fieldSchema.Computed = true
 		fieldSchema.Required = false
 		fieldSchema.Optional = false
@@ -74,8 +76,13 @@ func convertResourceFieldsToDatasourceFields(resourceSchema *schema.Resource) *s
 				fieldSchema.Elem = convertResourceFieldsToDatasourceFields(resource)
 			}
 		}
+
+		if isComputed {
+			resultSchema[k] = fieldSchema
+		}
 	}
 
+	resourceSchema.Schema = resultSchema
 	return resourceSchema
 }
 

--- a/ncloud/resource_ncloud_access_control_group.go
+++ b/ncloud/resource_ncloud_access_control_group.go
@@ -41,6 +41,7 @@ func resourceNcloudAccessControlGroup() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(0, 1000),
 			},
 

--- a/ncloud/resource_ncloud_init_script.go
+++ b/ncloud/resource_ncloud_init_script.go
@@ -37,6 +37,7 @@ func resourceNcloudInitScript() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(0, 1000),
 			},
 			"os_type": {

--- a/ncloud/resource_ncloud_nat_gateway.go
+++ b/ncloud/resource_ncloud_nat_gateway.go
@@ -36,6 +36,7 @@ func resourceNcloudNatGateway() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(0, 1000),
 			},
 			"vpc_no": {

--- a/ncloud/resource_ncloud_network_acl.go
+++ b/ncloud/resource_ncloud_network_acl.go
@@ -36,6 +36,7 @@ func resourceNcloudNetworkACL() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(0, 1000),
 			},
 			"vpc_no": {

--- a/ncloud/resource_ncloud_network_interface.go
+++ b/ncloud/resource_ncloud_network_interface.go
@@ -58,6 +58,7 @@ func resourceNcloudNetworkInterface() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(0, 1000),
 			},
 

--- a/ncloud/resource_ncloud_route_table.go
+++ b/ncloud/resource_ncloud_route_table.go
@@ -47,6 +47,7 @@ func resourceNcloudRouteTable() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(0, 1000),
 			},
 			"route_table_no": {

--- a/ncloud/resource_ncloud_vpc.go
+++ b/ncloud/resource_ncloud_vpc.go
@@ -31,6 +31,7 @@ func resourceNcloudVpc() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validateInstanceName,
 				Description:  "Subnet name to create. default: Assigned by NAVER CLOUD PLATFORM.",
 			},


### PR DESCRIPTION
### Issue
- FIx missing computed in some modules (resolve #121)

### Improvement
- Improve result type to structs (resolve #116)
  -  https://github.com/NaverCloudPlatform/terraform-provider-ncloud/issues/116#issuecomment-726699403

#### Test results
```
=== RUN   TestAccDataSourceNcloudServerProducts_classic_basic
=== PAUSE TestAccDataSourceNcloudServerProducts_classic_basic
=== CONT  TestAccDataSourceNcloudServerProducts_classic_basic
--- PASS: TestAccDataSourceNcloudServerProducts_classic_basic (1.49s)
=== RUN   TestAccDataSourceNcloudServerProducts_vpc_basic
=== PAUSE TestAccDataSourceNcloudServerProducts_vpc_basic
=== CONT  TestAccDataSourceNcloudServerProducts_vpc_basic
--- PASS: TestAccDataSourceNcloudServerProducts_vpc_basic (1.76s)
PASS

=== RUN   TestAccDataSourceNcloudServerImages_classic_basic
=== PAUSE TestAccDataSourceNcloudServerImages_classic_basic
=== CONT  TestAccDataSourceNcloudServerImages_classic_basic
--- PASS: TestAccDataSourceNcloudServerImages_classic_basic (1.94s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_basic
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_basic
=== CONT  TestAccDataSourceNcloudServerImages_vpc_basic
--- PASS: TestAccDataSourceNcloudServerImages_vpc_basic (1.75s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_linux
=== PAUSE TestAccDataSourceNcloudServerImages_classic_linux
=== CONT  TestAccDataSourceNcloudServerImages_classic_linux
--- PASS: TestAccDataSourceNcloudServerImages_classic_linux (1.93s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_linux
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_linux
=== CONT  TestAccDataSourceNcloudServerImages_vpc_linux
--- PASS: TestAccDataSourceNcloudServerImages_vpc_linux (1.95s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_windows
=== PAUSE TestAccDataSourceNcloudServerImages_classic_windows
=== CONT  TestAccDataSourceNcloudServerImages_classic_windows
--- PASS: TestAccDataSourceNcloudServerImages_classic_windows (1.84s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_windows
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_windows
=== CONT  TestAccDataSourceNcloudServerImages_vpc_windows
--- PASS: TestAccDataSourceNcloudServerImages_vpc_windows (1.93s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_bareMetal
=== PAUSE TestAccDataSourceNcloudServerImages_classic_bareMetal
=== CONT  TestAccDataSourceNcloudServerImages_classic_bareMetal
--- PASS: TestAccDataSourceNcloudServerImages_classic_bareMetal (1.96s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_bareMetal
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_bareMetal
=== CONT  TestAccDataSourceNcloudServerImages_vpc_bareMetal
--- PASS: TestAccDataSourceNcloudServerImages_vpc_bareMetal (1.97s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_blockStorageSize
=== PAUSE TestAccDataSourceNcloudServerImages_classic_blockStorageSize
=== CONT  TestAccDataSourceNcloudServerImages_classic_blockStorageSize
--- PASS: TestAccDataSourceNcloudServerImages_classic_blockStorageSize (1.80s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_blockStorageSize
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_blockStorageSize
=== CONT  TestAccDataSourceNcloudServerImages_vpc_blockStorageSize
--- PASS: TestAccDataSourceNcloudServerImages_vpc_blockStorageSize (1.77s)
PASS
```