### PR TITLE
Fix server image

### DIFF
--- a/docs/data-sources/server_image.md
+++ b/docs/data-sources/server_image.md
@@ -43,7 +43,6 @@ data "ncloud_server_image" "image_by_filter" {
 The following arguments are supported:
 
 * `product_code` - (Optional) Product code you want to view on the list. Use this when searching for 1 product.
-* `product_type` - (Optional) Product type code.
 * `platform_type` - (Optional) Values required for identifying platform.
     The available values are as follows: Linux 32Bit(LNX32) | Linux 64Bit(LNX64) | Windows 32Bit(WND32) | Windows 64Bit(WND64) | Ubuntu Desktop 64Bit(UBD64) | Ubuntu Server 64Bit(UBS64)
 * `infra_resource_detail_type_code` - (Optional) infra resource detail type code.
@@ -56,6 +55,7 @@ The following arguments are supported:
 
 * `id` - The ID of server image product.
 * `product_name` - Product name
+* `product_type` - Product type code.
 * `product_description` - Product description.
 * `infra_resource_type` - Infra resource type code.
 * `base_block_storage_size` - Base block storage size.

--- a/docs/data-sources/server_images.md
+++ b/docs/data-sources/server_images.md
@@ -38,8 +38,8 @@ list_image = {
 The following arguments are supported:
 
 * `product_code` - (Optional) Product code you want to view on the list. Use this when searching for 1 product.
-* `platform_type_code_list` - (Optional) Values required for identifying platforms in list-type.
-    The available values are as follows: Linux 32Bit(LNX32) | Linux 64Bit(LNX64) | Windows 32Bit(WND32) | Windows 64Bit(WND64) | Ubuntu Desktop 64Bit(UBD64) | Ubuntu Server 64Bit(UBS64)
+* `platform_type` - (Optional) Values required for identifying platform.
+  The available values are as follows: Linux 32Bit(LNX32) | Linux 64Bit(LNX64) | Windows 32Bit(WND32) | Windows 64Bit(WND64) | Ubuntu Desktop 64Bit(UBD64) | Ubuntu Server 64Bit(UBS64)
 * `infra_resource_detail_type_code` - (Optional) infra resource detail type code.
 * `output_file` - (Optional) The name of file that can save data source after running `terraform plan`.
 * `filter` - (Optional) Custom filter block as described below.

--- a/ncloud/data_source_ncloud_server_image.go
+++ b/ncloud/data_source_ncloud_server_image.go
@@ -2,7 +2,6 @@ package ncloud
 
 import (
 	"fmt"
-	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -124,16 +123,15 @@ func getClassicServerImageProductList(d *schema.ResourceData, config *ProviderCo
 	regionNo := config.RegionNo
 
 	reqParams := &server.GetServerImageProductListRequest{
-		RegionNo:    &regionNo,
-		ProductCode: StringPtrOrNil(d.GetOk("product_code")),
+		ProductCode:                 StringPtrOrNil(d.GetOk("product_code")),
+		RegionNo:                    &regionNo,
+		ExclusionProductCode:        StringPtrOrNil(d.GetOk("exclusion_product_code")),
+		BlockStorageSize:            Int32PtrOrNil(d.GetOk("block_storage_size")),
+		InfraResourceDetailTypeCode: StringPtrOrNil(d.GetOk("infra_resource_detail_type_code")),
 	}
 
-	if v, ok := d.GetOk("platform_type"); ok {
-		reqParams.PlatformTypeCodeList = []*string{ncloud.String(v.(string))}
-	}
-
-	if d.HasChange("block_storage_size") {
-		reqParams.BlockStorageSize = ncloud.Int32(int32(d.Get("block_storage_size").(int)))
+	if v, ok := d.GetOk("platform_type_code_list"); ok {
+		reqParams.PlatformTypeCodeList = expandStringInterfaceList(v.([]interface{}))
 	}
 
 	logCommonRequest("GetServerImageProductList", reqParams)
@@ -174,16 +172,14 @@ func getVpcServerImageProductList(d *schema.ResourceData, config *ProviderConfig
 	regionCode := config.RegionCode
 
 	reqParams := &vserver.GetServerImageProductListRequest{
-		ProductCode: StringPtrOrNil(d.GetOk("product_code")),
-		RegionCode:  &regionCode,
+		ProductCode:          StringPtrOrNil(d.GetOk("product_code")),
+		RegionCode:           &regionCode,
+		ExclusionProductCode: StringPtrOrNil(d.GetOk("exclusion_product_code")),
+		BlockStorageSize:     Int32PtrOrNil(d.GetOk("block_storage_size")),
 	}
 
-	if platformTypeCodeList, ok := d.GetOk("platform_type_code_list"); ok {
-		reqParams.PlatformTypeCodeList = expandStringInterfaceList(platformTypeCodeList.([]interface{}))
-	}
-
-	if d.HasChange("block_storage_size") {
-		reqParams.BlockStorageSize = ncloud.Int32(int32(d.Get("block_storage_size").(int)))
+	if v, ok := d.GetOk("platform_type_code_list"); ok {
+		reqParams.PlatformTypeCodeList = expandStringInterfaceList(v.([]interface{}))
 	}
 
 	logCommonRequest("GetServerImageProductList", reqParams)
@@ -207,10 +203,6 @@ func getVpcServerImageProductList(d *schema.ResourceData, config *ProviderConfig
 			"base_block_storage_size": fmt.Sprintf("%dGB", *r.BaseBlockStorageSize/GIGABYTE),
 			"platform_type":           *r.PlatformType.Code,
 			"os_information":          *r.OsInformation,
-		}
-
-		if r.InfraResourceDetailType != nil {
-			instance["infra_resource_detail_type_code"] = *r.InfraResourceDetailType.Code
 		}
 
 		resources = append(resources, instance)

--- a/ncloud/data_source_ncloud_server_image.go
+++ b/ncloud/data_source_ncloud_server_image.go
@@ -22,11 +22,6 @@ func dataSourceNcloudServerImage() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"product_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"platform_type": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -40,6 +35,10 @@ func dataSourceNcloudServerImage() *schema.Resource {
 			"filter": dataSourceFiltersSchema(),
 
 			"product_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"product_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -75,7 +74,7 @@ func dataSourceNcloudServerImage() *schema.Resource {
 				Type:       schema.TypeList,
 				Optional:   true,
 				Elem:       &schema.Schema{Type: schema.TypeString},
-				Deprecated: "use `filter` or `product_type` instead",
+				Deprecated: "use `filter` or `platform_type` instead",
 			},
 		},
 	}
@@ -125,12 +124,10 @@ func getClassicServerImageProductList(d *schema.ResourceData, config *ProviderCo
 	reqParams := &server.GetServerImageProductListRequest{
 		ProductCode:                 StringPtrOrNil(d.GetOk("product_code")),
 		RegionNo:                    &regionNo,
-		ExclusionProductCode:        StringPtrOrNil(d.GetOk("exclusion_product_code")),
-		BlockStorageSize:            Int32PtrOrNil(d.GetOk("block_storage_size")),
 		InfraResourceDetailTypeCode: StringPtrOrNil(d.GetOk("infra_resource_detail_type_code")),
 	}
 
-	if v, ok := d.GetOk("platform_type_code_list"); ok {
+	if v, ok := d.GetOk("platform_type"); ok {
 		reqParams.PlatformTypeCodeList = expandStringInterfaceList(v.([]interface{}))
 	}
 
@@ -172,13 +169,11 @@ func getVpcServerImageProductList(d *schema.ResourceData, config *ProviderConfig
 	regionCode := config.RegionCode
 
 	reqParams := &vserver.GetServerImageProductListRequest{
-		ProductCode:          StringPtrOrNil(d.GetOk("product_code")),
-		RegionCode:           &regionCode,
-		ExclusionProductCode: StringPtrOrNil(d.GetOk("exclusion_product_code")),
-		BlockStorageSize:     Int32PtrOrNil(d.GetOk("block_storage_size")),
+		ProductCode: StringPtrOrNil(d.GetOk("product_code")),
+		RegionCode:  &regionCode,
 	}
 
-	if v, ok := d.GetOk("platform_type_code_list"); ok {
+	if v, ok := d.GetOk("platform_type"); ok {
 		reqParams.PlatformTypeCodeList = expandStringInterfaceList(v.([]interface{}))
 	}
 
@@ -205,6 +200,9 @@ func getVpcServerImageProductList(d *schema.ResourceData, config *ProviderConfig
 			"os_information":          *r.OsInformation,
 		}
 
+		if r.InfraResourceDetailType != nil {
+			instance["infra_resource_detail_type_code"] = *r.InfraResourceDetailType.Code
+		}
 		resources = append(resources, instance)
 	}
 

--- a/ncloud/data_source_ncloud_server_image_test.go
+++ b/ncloud/data_source_ncloud_server_image_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceNcloudServerImage_classic_byCode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttr(dataName, "product_code", "SPSW0LINUX000046"),
-					resource.TestCheckResourceAttr(dataName, "product_name", "CentOS 7.3 (64-bit)"),
+					resource.TestCheckResourceAttr(dataName, "product_name", "centos-7.3-64"),
 					resource.TestCheckResourceAttr(dataName, "product_description", "CentOS 7.3 (64-bit)"),
 					resource.TestCheckResourceAttr(dataName, "infra_resource_type", "SW"),
 					resource.TestCheckResourceAttr(dataName, "os_information", "CentOS 7.3 (64-bit)"),
@@ -43,7 +43,7 @@ func TestAccDataSourceNcloudServerImage_vpc_byCode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttr(dataName, "product_code", "SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
-					resource.TestCheckResourceAttr(dataName, "product_name", "CentOS 7.3 (64-bit)"),
+					resource.TestCheckResourceAttr(dataName, "product_name", "centos-7.3-64"),
 					resource.TestCheckResourceAttr(dataName, "product_description", "CentOS 7.3 (64-bit)"),
 					resource.TestCheckResourceAttr(dataName, "infra_resource_type", "SW"),
 					resource.TestCheckResourceAttr(dataName, "os_information", "CentOS 7.3 (64-bit)"),
@@ -154,7 +154,7 @@ var testAccDataSourceNcloudServerImageByFilterProductNameConfig = `
 data "ncloud_server_image" "test3" {
   filter {
     name = "product_name"
-    values = ["CentOS 7.3 (64-bit)"]
+    values = ["centos-7.3-64"]
   }
 }
 `
@@ -163,7 +163,7 @@ var testAccDataSourceNcloudServerImageByBlockStorageSizeConfig = `
 data "ncloud_server_image" "test4" {
 	filter {
 		name = "product_name"
-		values = ["CentOS 7.3 (64-bit)"]
+		values = ["centos-7.3-64"]
 	}
 
 	filter {

--- a/ncloud/data_source_ncloud_server_images.go
+++ b/ncloud/data_source_ncloud_server_images.go
@@ -21,10 +21,10 @@ func dataSourceNcloudServerImages() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"platform_type_code_list": {
-				Type:     schema.TypeList,
+			"platform_type": {
+				Type:     schema.TypeString,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
 			},
 			"infra_resource_detail_type_code": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
### Description
- Update invalid argument handling
### Examples
#### 1 ) Basic Usage
**main.tf**
```hcl
data "ncloud_server_images" "images" {
  infra_resource_detail_type_code = "BM"      // Bare Metal Image
  platform_type_code_list         = ["LNX64"] // Linux 64bit
}

output "images-output" {
  value = data.ncloud_server_images.images
}
```
**Output**
```hcl
Outputs:

images-output = {
  "id" = "4157062241"
  "ids" = [
    "SPSWBMLINUX00001",
    "SPSWBMLINUX00002",
    "SPSWBMLINUX00005",
    "SPSWBMLINUX00003",
    "SPSWBMLINUX00004",
  ]
  "infra_resource_detail_type_code" = "BM"
  "platform_type_code_list" = [
    "LNX64",
  ]
  "server_images" = [
    {
      "base_block_storage_size" = "0GB"
      "id" = "SPSWBMLINUX00001"
      "infra_resource_detail_type_code" = "BM"
      "infra_resource_type" = "SW"
      "os_information" = "CentOS 6.9(64bit)"
      "platform_type" = "LNX64"
      "product_code" = "SPSWBMLINUX00001"
      "product_description" = "CentOS 6.9(64bit)"
      "product_name" = "centos-6.9-64"
      "product_type" = "LINUX"
    },
    {
      "base_block_storage_size" = "0GB"
      "id" = "SPSWBMLINUX00002"
      "infra_resource_detail_type_code" = "BM"
      "infra_resource_type" = "SW"
      "os_information" = "CentOS 7.4(64bit)"
      "platform_type" = "LNX64"
      "product_code" = "SPSWBMLINUX00002"
      "product_description" = "CentOS 7.4(64bit)"
      "product_name" = "centos-7.4-64"
      "product_type" = "LINUX"
    },
    {
      "base_block_storage_size" = "0GB"
      "id" = "SPSWBMLINUX00005"
      "infra_resource_detail_type_code" = "BM"
      "infra_resource_type" = "SW"
      "os_information" = "CentOS 7.8(64bit)"
      "platform_type" = "LNX64"
      "product_code" = "SPSWBMLINUX00005"
      "product_description" = "CentOS 7.8(64bit)"
      "product_name" = "centos-7.8-64"
      "product_type" = "LINUX"
    },
    {
      "base_block_storage_size" = "0GB"
      "id" = "SPSWBMLINUX00003"
      "infra_resource_detail_type_code" = "BM"
      "infra_resource_type" = "SW"
      "os_information" = "Oracle Linux 6.9(64bit)"
      "platform_type" = "LNX64"
      "product_code" = "SPSWBMLINUX00003"
      "product_description" = "Oracle Linux 6.9(64bit)"
      "product_name" = "oracle-linux-6.9-64"
      "product_type" = "LINUX"
    },
    {
      "base_block_storage_size" = "0GB"
      "id" = "SPSWBMLINUX00004"
      "infra_resource_detail_type_code" = "BM"
      "infra_resource_type" = "SW"
      "os_information" = "Oracle Linux 7.4(64bit)"
      "platform_type" = "LNX64"
      "product_code" = "SPSWBMLINUX00004"
      "product_description" = "Oracle Linux 7.4(64bit)"
      "product_name" = "oracle-linux-7.4-64"
      "product_type" = "LINUX"
    },
  ]
}
```
#### 2 ) Usage of using filter
**main.tf**
```hcl
data "ncloud_server_images" "images" {
  infra_resource_detail_type_code = "BM"      // Bare Metal Image
  platform_type_code_list         = ["LNX64"] // Linux 64bit
  filter {
    name = "product_code"
    values = [ "SPSWBMLINUX00005" ]
  }
}

output "images-output" {
  value = data.ncloud_server_images.images
}
```
**Output**
```hcl
Outputs:

images-output = {
  "filter" = [
    {
      "name" = "product_code"
      "regex" = false
      "values" = [
        "SPSWBMLINUX00005",
      ]
    },
  ]
  "id" = "2241919552"
  "ids" = [
    "SPSWBMLINUX00005",
  ]
  "infra_resource_detail_type_code" = "BM"
  "platform_type_code_list" = [
    "LNX64",
  ]
  "server_images" = [
    {
      "base_block_storage_size" = "0GB"
      "id" = "SPSWBMLINUX00005"
      "infra_resource_detail_type_code" = "BM"
      "infra_resource_type" = "SW"
      "os_information" = "CentOS 7.8(64bit)"
      "platform_type" = "LNX64"
      "product_code" = "SPSWBMLINUX00005"
      "product_description" = "CentOS 7.8(64bit)"
      "product_name" = "centos-7.8-64"
      "product_type" = "LINUX"
    },
  ]
}
```
### Test Result
**data_source_server_image_test.go**
```
=== RUN   TestAccDataSourceNcloudServerImage_classic_byCode
=== PAUSE TestAccDataSourceNcloudServerImage_classic_byCode
=== CONT  TestAccDataSourceNcloudServerImage_classic_byCode
--- PASS: TestAccDataSourceNcloudServerImage_classic_byCode (0.49s)
=== RUN   TestAccDataSourceNcloudServerImage_vpc_byCode
=== PAUSE TestAccDataSourceNcloudServerImage_vpc_byCode
=== CONT  TestAccDataSourceNcloudServerImage_vpc_byCode
--- PASS: TestAccDataSourceNcloudServerImage_vpc_byCode (1.38s)
=== RUN   TestAccDataSourceNcloudServerImage_classic_byFilterProductCode
=== PAUSE TestAccDataSourceNcloudServerImage_classic_byFilterProductCode
=== CONT  TestAccDataSourceNcloudServerImage_classic_byFilterProductCode
--- PASS: TestAccDataSourceNcloudServerImage_classic_byFilterProductCode (1.40s)
=== RUN   TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode
=== PAUSE TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode
=== CONT  TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode
--- PASS: TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode (2.00s)
=== RUN   TestAccDataSourceNcloudServerImage_classic_byFilterProductName
=== PAUSE TestAccDataSourceNcloudServerImage_classic_byFilterProductName
=== CONT  TestAccDataSourceNcloudServerImage_classic_byFilterProductName
--- PASS: TestAccDataSourceNcloudServerImage_classic_byFilterProductName (1.41s)
=== RUN   TestAccDataSourceNcloudServerImage_vpc_byFilterProductName
=== PAUSE TestAccDataSourceNcloudServerImage_vpc_byFilterProductName
=== CONT  TestAccDataSourceNcloudServerImage_vpc_byFilterProductName
--- PASS: TestAccDataSourceNcloudServerImage_vpc_byFilterProductName (2.07s)
=== RUN   TestAccDataSourceNcloudServerImage_classic_byBlockStorageSize
=== PAUSE TestAccDataSourceNcloudServerImage_classic_byBlockStorageSize
=== CONT  TestAccDataSourceNcloudServerImage_classic_byBlockStorageSize
--- PASS: TestAccDataSourceNcloudServerImage_classic_byBlockStorageSize (1.38s)
=== RUN   TestAccDataSourceNcloudServerImage_vpc_byBlockStorageSize
=== PAUSE TestAccDataSourceNcloudServerImage_vpc_byBlockStorageSize
=== CONT  TestAccDataSourceNcloudServerImage_vpc_byBlockStorageSize
--- PASS: TestAccDataSourceNcloudServerImage_vpc_byBlockStorageSize (2.12s)
PASS
```

**data_source_server_images_test.go**
```
=== RUN   TestAccDataSourceNcloudServerImages_classic_basic
=== PAUSE TestAccDataSourceNcloudServerImages_classic_basic
=== CONT  TestAccDataSourceNcloudServerImages_classic_basic
--- PASS: TestAccDataSourceNcloudServerImages_classic_basic (1.86s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_basic
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_basic
=== CONT  TestAccDataSourceNcloudServerImages_vpc_basic
--- PASS: TestAccDataSourceNcloudServerImages_vpc_basic (1.71s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_linux
=== PAUSE TestAccDataSourceNcloudServerImages_classic_linux
=== CONT  TestAccDataSourceNcloudServerImages_classic_linux
--- PASS: TestAccDataSourceNcloudServerImages_classic_linux (1.43s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_linux
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_linux
=== CONT  TestAccDataSourceNcloudServerImages_vpc_linux
--- PASS: TestAccDataSourceNcloudServerImages_vpc_linux (1.49s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_windows
=== PAUSE TestAccDataSourceNcloudServerImages_classic_windows
=== CONT  TestAccDataSourceNcloudServerImages_classic_windows
--- PASS: TestAccDataSourceNcloudServerImages_classic_windows (1.23s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_windows
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_windows
=== CONT  TestAccDataSourceNcloudServerImages_vpc_windows
--- PASS: TestAccDataSourceNcloudServerImages_vpc_windows (1.16s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_bareMetal
=== PAUSE TestAccDataSourceNcloudServerImages_classic_bareMetal
=== CONT  TestAccDataSourceNcloudServerImages_classic_bareMetal
--- PASS: TestAccDataSourceNcloudServerImages_classic_bareMetal (1.18s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_bareMetal
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_bareMetal
=== CONT  TestAccDataSourceNcloudServerImages_vpc_bareMetal
--- PASS: TestAccDataSourceNcloudServerImages_vpc_bareMetal (1.26s)
=== RUN   TestAccDataSourceNcloudServerImages_classic_blockStorageSize
=== PAUSE TestAccDataSourceNcloudServerImages_classic_blockStorageSize
=== CONT  TestAccDataSourceNcloudServerImages_classic_blockStorageSize
--- PASS: TestAccDataSourceNcloudServerImages_classic_blockStorageSize (1.61s)
=== RUN   TestAccDataSourceNcloudServerImages_vpc_blockStorageSize
=== PAUSE TestAccDataSourceNcloudServerImages_vpc_blockStorageSize
=== CONT  TestAccDataSourceNcloudServerImages_vpc_blockStorageSize
--- PASS: TestAccDataSourceNcloudServerImages_vpc_blockStorageSize (1.59s)
PASS
```