### PR TITLE
Add disconnect block storage from server

### DIFF
--- a/ncloud/resource_ncloud_block_storage.go
+++ b/ncloud/resource_ncloud_block_storage.go
@@ -19,6 +19,12 @@ func init() {
 	RegisterResource("ncloud_block_storage", resourceNcloudBlockStorage())
 }
 
+const (
+	BlockStorageStatusCodeCreate = "CREAT"
+	BlockStorageStatusCodeInit   = "INIT"
+	BlockStorageStatusCodeAttach = "ATTAC"
+)
+
 func resourceNcloudBlockStorage() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceNcloudBlockStorageCreate,
@@ -361,7 +367,7 @@ func deleteBlockStorage(d *schema.ResourceData, config *ProviderConfig, id strin
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"INIT", "ATTAC"},
+		Pending: []string{BlockStorageStatusCodeInit, BlockStorageStatusCodeAttach},
 		Target:  []string{"TERMINATED"},
 		Refresh: func() (interface{}, string, error) {
 			instance, err := getBlockStorage(config, id)
@@ -505,8 +511,8 @@ func detachVpcBlockStorage(config *ProviderConfig, id string) error {
 
 func waitForBlockStorageDetachment(config *ProviderConfig, id string) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"ATTAC"},
-		Target:  []string{"CREAT"},
+		Pending: []string{BlockStorageStatusCodeAttach},
+		Target:  []string{BlockStorageStatusCodeCreate},
 		Refresh: func() (interface{}, string, error) {
 			instance, err := getBlockStorage(config, id)
 			if err != nil {
@@ -584,8 +590,8 @@ func attachVpcBlockStorage(d *schema.ResourceData, config *ProviderConfig) error
 
 func waitForBlockStorageAttachment(config *ProviderConfig, id string) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{"INIT", "CREAT"},
-		Target:  []string{"ATTAC"},
+		Pending: []string{BlockStorageStatusCodeInit, BlockStorageStatusCodeCreate},
+		Target:  []string{BlockStorageStatusCodeAttach},
 		Refresh: func() (interface{}, string, error) {
 			instance, err := getBlockStorage(config, id)
 			if err != nil {


### PR DESCRIPTION
When block storage is connected to a server, an error occurs if you delete server.

```text
Error: Status: 400 Bad Request, Body: {"responseError": {
  "returnCode": "10501",
  "returnMessage": "After deleting additional storage, please try again. Check the storage added to the server, and return it from the [Storage] menu in person."
}}
```