### PR TITLE
fix: create empty target group name

### DIFF
--- a/ncloud/resource_ncloud_lb_target_group.go
+++ b/ncloud/resource_ncloud_lb_target_group.go
@@ -164,7 +164,7 @@ func resourceNcloudTargetGroupCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	if err := validateVpcTargetGroupDuplicateName(config, *reqParams.TargetGroupName); err != nil {
+	if err := validateVpcTargetGroupDuplicateName(config, ncloud.StringValue(reqParams.TargetGroupName)); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
### Issue
If you request without the `targetGroupName` attribute, an error occurs.

### Test
```text
=== RUN   TestAccResourceNcloudLbTargetGroup_emptyTargetGroupName
=== PAUSE TestAccResourceNcloudLbTargetGroup_emptyTargetGroupName
=== CONT  TestAccResourceNcloudLbTargetGroup_emptyTargetGroupName
--- PASS: TestAccResourceNcloudLbTargetGroup_emptyTargetGroupName (85.65s)
PASS
```