### PR TITLE
Deprecate internet_line_type_code field

### DIFF
--- a/docs/data-sources/port_forwarding_rule.md
+++ b/docs/data-sources/port_forwarding_rule.md
@@ -15,7 +15,6 @@ ncloud_nas_volume
 
 The following arguments are supported:
 
-* `internet_line_type_code` - (Optional) Internet line code. PUBLC(Public), GLBL(Global)
 * `region` - (Optional) Region code. Get available values using the data source `ncloud_regions`.
     Default: KR region.
 * `zone` - (Optional) Zone code. You can decide a zone where servers are created. You can decide which zone the product list will be requested in. Default : Select the first Zone in the specific region

--- a/docs/data-sources/port_forwarding_rules.md
+++ b/docs/data-sources/port_forwarding_rules.md
@@ -15,7 +15,6 @@ data "ncloud_port_forwarding_rules" "rules" {
 
 The following arguments are supported:
 
-* `internet_line_type_code` - (Optional) Internet line code. PUBLC(Public), GLBL(Global)
 * `region` - (Optional) Region code. Get available values using the data source `ncloud_regions`.
     Default: KR region.
 * `zone` - (Optional) Zone code. You can decide a zone where servers are created. You can decide which zone the product list will be requested in. Default : Select the first Zone in the specific region

--- a/docs/data-sources/public_ip.md
+++ b/docs/data-sources/public_ip.md
@@ -21,7 +21,6 @@ The following arguments are supported:
 
 ~> **NOTE:** Below arguments only support Classic environment.
 
-* `internet_line_type` - (Optional) Internet line type code. `PUBLC` (Public), `GLBL` (Global)
 * `zone` - (Optional) Zone code. You can filter the list of public IP instances by zone. All the public IP addresses in the zone of the region will be selected if the filter is not specified.
     Get available values using the data source `ncloud_zones`.
 

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -67,7 +67,6 @@ The following arguments are supported:
 * `port_forwarding_public_ip` - Port forwarding public ip
 * `port_forwarding_external_port` - Port forwarding external port
 * `port_forwarding_internal_port` - Port forwarding internal port
-* `internet_line_type` - Internet line identification code. PUBLC(Public), GLBL(Global).
 
 ~> **NOTE:** Below attributes only provide VPC environment.
 

--- a/docs/data-sources/server_product.md
+++ b/docs/data-sources/server_product.md
@@ -46,7 +46,6 @@ The following arguments are supported:
 * `product_code` - (Optional) Enter a product code to search from the list. Use it for a single search.
 * `zone` - (Optional) Zone code. You can decide a zone where servers are created. You can decide which zone the product list will be requested in. default : Select the first Zone in the specific region.
     Get available values using the data source `ncloud_zones`.
-* `internet_line_type_code` - (Optional) Internet line code. PUBLC(Public), GLBL(Global)
 * `filter` - (Optional) Custom filter block as described below.
   * `name` - (Required) The name of the field to filter by
   * `values` - (Required) Set of values that are accepted for the given field.

--- a/docs/data-sources/server_products.md
+++ b/docs/data-sources/server_products.md
@@ -62,7 +62,6 @@ The following arguments are supported:
 * `product_code` - (Optional) Enter a product code to search from the list. Use it for a single search.
 * `zone` - (Optional) Zone code. You can decide a zone where servers are created. You can decide which zone the product list will be requested in. default : Select the first Zone in the specific region.
     Get available values using the data source `ncloud_zones`.
-* `internet_line_type_code` - (Optional) Internet line code. PUBLC(Public), GLBL(Global)
 * `filter` - (Optional) Custom filter block as described below.
   * `name` - (Required) The name of the field to filter by
   * `values` - (Required) Set of values that are accepted for the given field.

--- a/docs/resources/load_balancer.md
+++ b/docs/resources/load_balancer.md
@@ -25,7 +25,6 @@ resource "ncloud_load_balancer" "lb" {
   }
   
   server_instance_no_list = ["812345", "812346"]
-  internet_line_type      = "PUBLC"
   network_usage_type      = "PBLIP"
 
   region = "KR"
@@ -47,7 +46,6 @@ The following arguments are supported:
 * `algorithm_type` - (Optional) Load balancer algorithm type code. The available algorithms are as follows: [ROUND ROBIN (RR) | LEAST_CONNECTION (LC)]. Default: ROUND ROBIN (RR)
 * `description` - (Optional) Description of a load balancer instance.
 * `server_instance_no_list` - (Optional) List of server instance numbers to be bound to the load balancer
-* `internet_line_type` - (Optional) Internet line identification code. PUBLC(Public), GLBL(Global). default : PUBLC(Public)
 * `network_usage_type` - (Optional) Network usage identification code. PBLIP(PublicIP), PRVT(PrivateIP). default : PBLIP(PublicIP)
 * `region` - (Optional) Region code. Get available values using the data source `ncloud_regions`.
     Default: KR region.

--- a/docs/resources/public_ip.md
+++ b/docs/resources/public_ip.md
@@ -19,7 +19,6 @@ The following arguments are supported:
 
 ~> **NOTE:** Below arguments only support Classic environment.
 
-* `internet_line_type` - (Optional) Internet line code. PUBLC(Public), GLBL(Global)
 * `zone` - (Optional) Zone code. You can decide a zone where servers are created. You can decide in which zone the product list will be requested. default : Select the first Zone in the specific region
     Get available values using the data source `ncloud_zones`.
 

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -69,7 +69,6 @@ The following arguments are supported:
 
 ~> **NOTE:** Below arguments only support Classic environment.
 
-* `internet_line_type` - (Optional) Internet line identification code. PUBLC(Public), GLBL(Global). default : PUBLC(Public)
 * `access_control_group_configuration_no_list` - (Optional) You can set the ACG created when creating the server. ACG setting number can be obtained through the getAccessControlGroupList action. Default : Default ACG number
 * `user_data` - (Optional) The server will execute the user data script set by the user at first boot. To view the column, it is returned only when viewing the server instance.
 * `raid_type_name` - (Optional) Raid Type Name.

--- a/examples/bare_metal_server/linux/main.tf
+++ b/examples/bare_metal_server/linux/main.tf
@@ -70,7 +70,6 @@ resource "ncloud_load_balancer" "lb" {
   }
 
   server_instance_no_list = [ncloud_server.bm.id]
-  internet_line_type      = "PUBLC"
   network_usage_type      = "PBLIP"
 }
 

--- a/examples/load_balancer/main.tf
+++ b/examples/load_balancer/main.tf
@@ -30,7 +30,6 @@ resource "ncloud_load_balancer" "lb" {
   }
 
   server_instance_no_list = [ncloud_server.server.id]
-  internet_line_type      = "PUBLC"
   network_usage_type      = "PBLIP"
   region                  = "KR"
 }

--- a/ncloud/data_source_ncloud_port_forwarding_rule.go
+++ b/ncloud/data_source_ncloud_port_forwarding_rule.go
@@ -19,12 +19,14 @@ func dataSourceNcloudPortForwardingRule() *schema.Resource {
 		Read: dataSourceNcloudPortForwardingRuleRead,
 
 		Schema: map[string]*schema.Schema{
+			// Deprecated
 			"internet_line_type_code": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"PUBLC", "GLBL"}, false)),
 				Description:      "Internet line code. PUBLC(Public), GLBL(Global)",
+				Deprecated:       "This parameter is no longer used.",
 			},
 			"region": {
 				Type:        schema.TypeString,
@@ -85,9 +87,8 @@ func dataSourceNcloudPortForwardingRuleRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 	reqParams := &server.GetPortForwardingRuleListRequest{
-		InternetLineTypeCode: StringPtrOrNil(d.GetOk("internet_line_type_code")),
-		RegionNo:             regionNo,
-		ZoneNo:               zoneNo,
+		RegionNo: regionNo,
+		ZoneNo:   zoneNo,
 	}
 
 	logCommonRequest("GetPortForwardingRuleList", reqParams)

--- a/ncloud/data_source_ncloud_port_forwarding_rules.go
+++ b/ncloud/data_source_ncloud_port_forwarding_rules.go
@@ -19,12 +19,14 @@ func dataSourceNcloudPortForwardingRules() *schema.Resource {
 		Read: dataSourceNcloudPortForwardingRulesRead,
 
 		Schema: map[string]*schema.Schema{
+			// Deprecated
 			"internet_line_type_code": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"PUBLC", "GLBL"}, false)),
 				Description:      "Internet line code. PUBLC(Public), GLBL(Global)",
+				Deprecated:       "This parameter is no longer used.",
 			},
 			"region": {
 				Type:        schema.TypeString,
@@ -100,9 +102,8 @@ func dataSourceNcloudPortForwardingRulesRead(d *schema.ResourceData, meta interf
 		return err
 	}
 	reqParams := &server.GetPortForwardingRuleListRequest{
-		InternetLineTypeCode: StringPtrOrNil(d.GetOk("internet_line_type_code")),
-		RegionNo:             regionNo,
-		ZoneNo:               zoneNo,
+		RegionNo: regionNo,
+		ZoneNo:   zoneNo,
 	}
 
 	logCommonRequest("GetPortForwardingRuleList", reqParams)

--- a/ncloud/data_source_ncloud_public_ip.go
+++ b/ncloud/data_source_ncloud_public_ip.go
@@ -22,11 +22,13 @@ func dataSourceNcloudPublicIp() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			// Deprecated
 			"internet_line_type": {
 				Type:             schema.TypeString,
 				Computed:         true,
 				Optional:         true,
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"PUBLC", "GLBL"}, false)),
+				Deprecated:       "This parameter is no longer used.",
 			},
 			"is_associated": {
 				Type:     schema.TypeBool,
@@ -143,9 +145,8 @@ func getClassicPublicIpList(d *schema.ResourceData, config *ProviderConfig) ([]m
 	regionNo := config.RegionNo
 
 	reqParams := &server.GetPublicIpInstanceListRequest{
-		RegionNo:             &regionNo,
-		ZoneNo:               StringPtrOrNil(d.GetOk("zone")),
-		InternetLineTypeCode: StringPtrOrNil(d.GetOk("internet_line_type")),
+		RegionNo: &regionNo,
+		ZoneNo:   StringPtrOrNil(d.GetOk("zone")),
 	}
 
 	if isAssociated, ok := d.GetOk("is_associated"); ok {
@@ -175,10 +176,6 @@ func getClassicPublicIpList(d *schema.ResourceData, config *ProviderConfig) ([]m
 			"description":        *r.PublicIpDescription,
 			"server_instance_no": nil,
 			"server_name":        nil,
-		}
-
-		if m := flattenCommonCode(r.InternetLineType); m["code"] != nil {
-			instance["internet_line_type"] = m["code"]
 		}
 
 		if m := flattenCommonCode(r.PublicIpInstanceStatus); m["code"] != nil {

--- a/ncloud/data_source_ncloud_public_ip_test.go
+++ b/ncloud/data_source_ncloud_public_ip_test.go
@@ -111,7 +111,7 @@ resource "ncloud_login_key" "loginkey" {
 
 resource "ncloud_server" "server" {
 	name = "%[1]s"
-	server_image_product_code = "SPSW0LINUX000032"
+	server_image_product_code = "SPSW0LINUX000045"
 	server_product_code = "SPSVRSTAND000004"
 	login_key_name = "${ncloud_login_key.loginkey.key_name}"
 }

--- a/ncloud/data_source_ncloud_public_ip_test.go
+++ b/ncloud/data_source_ncloud_public_ip_test.go
@@ -30,7 +30,6 @@ func TestAccDataSourceNcloudPublicIp_classic_basic(t *testing.T) {
 
 					// Classic only
 					resource.TestCheckResourceAttrPair(dataName, "zone", resourceName, "zone"),
-					resource.TestCheckResourceAttrPair(dataName, "internet_line_type", resourceName, "internet_line_type"),
 					resource.TestCheckResourceAttrPair(dataName, "kind_type", resourceName, "kind_type"),
 				),
 			},

--- a/ncloud/data_source_ncloud_server_product.go
+++ b/ncloud/data_source_ncloud_server_product.go
@@ -31,10 +31,12 @@ func dataSourceNcloudServerProduct() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			// Deprecated
 			"internet_line_type_code": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"PUBLC", "GLBL"}, false)),
+				Deprecated:       "This parameter is no longer used.",
 			},
 			"filter": dataSourceFiltersSchema(),
 
@@ -142,7 +144,6 @@ func getClassicServerProductList(d *schema.ResourceData, config *ProviderConfig)
 		ProductCode:            StringPtrOrNil(d.GetOk("product_code")),
 		RegionNo:               &regionNo,
 		ZoneNo:                 zoneNo,
-		InternetLineTypeCode:   StringPtrOrNil(d.GetOk("internet_line_type_code")),
 	}
 
 	logCommonRequest("getClassicServerProductList", reqParams)

--- a/ncloud/data_source_ncloud_server_product_test.go
+++ b/ncloud/data_source_ncloud_server_product_test.go
@@ -14,16 +14,16 @@ func TestAccDataSourceNcloudServerProduct_classic_basic(t *testing.T) {
 		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductConfig("SPSW0LINUX000032", "SPSVRSTAND000056"),
+				Config: testAccDataSourceNcloudServerProductConfig("SPSW0LINUX000045", "SPSVRSTAND000004"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
-					resource.TestCheckResourceAttr(dataName, "server_image_product_code", "SPSW0LINUX000032"),
-					resource.TestCheckResourceAttr(dataName, "product_code", "SPSVRSTAND000056"),
-					resource.TestCheckResourceAttr(dataName, "product_name", "vCPU 1EA, Memory 1GB, Disk 50GB"),
-					resource.TestCheckResourceAttr(dataName, "product_description", "vCPU 1EA, Memory 1GB, Disk 50GB"),
+					resource.TestCheckResourceAttr(dataName, "server_image_product_code", "SPSW0LINUX000045"),
+					resource.TestCheckResourceAttr(dataName, "product_code", "SPSVRSTAND000004"),
+					resource.TestCheckResourceAttr(dataName, "product_name", "vCPU 2EA, Memory 4GB, Disk 50GB"),
+					resource.TestCheckResourceAttr(dataName, "product_description", "vCPU 2개, 메모리 4GB, 디스크 50GB"),
 					resource.TestCheckResourceAttr(dataName, "infra_resource_type", "SVR"),
-					resource.TestCheckResourceAttr(dataName, "cpu_count", "1"),
-					resource.TestCheckResourceAttr(dataName, "memory_size", "1GB"),
+					resource.TestCheckResourceAttr(dataName, "cpu_count", "2"),
+					resource.TestCheckResourceAttr(dataName, "memory_size", "4GB"),
 					resource.TestCheckResourceAttr(dataName, "disk_type", "NET"),
 					resource.TestCheckResourceAttr(dataName, "generation_code", "G1"),
 					resource.TestCheckResourceAttr(dataName, "base_block_storage_size", "50GB"),
@@ -66,7 +66,7 @@ func TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode(t *testing
 		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductFilterByProductCodeConfig("SPSW0LINUX000032", "SPSVRSTAND000056"),
+				Config: testAccDataSourceNcloudServerProductFilterByProductCodeConfig("SPSW0LINUX000045", "SPSVRSTAND000056"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_server_product.test2"),
 				),
@@ -96,7 +96,7 @@ func TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType
 		Providers: testAccClassicProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig("SPSW0LINUX000032", "G1"),
+				Config: testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig("SPSW0LINUX000045", "G1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_server_product.test3"),
 				),

--- a/ncloud/data_source_ncloud_server_products.go
+++ b/ncloud/data_source_ncloud_server_products.go
@@ -29,10 +29,12 @@ func dataSourceNcloudServerProducts() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			// Deprecated
 			"internet_line_type_code": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"PUBLC", "GLBL"}, false)),
+				Deprecated:       "This parameter is no longer used.",
 			},
 			"server_products": {
 				Type:     schema.TypeList,

--- a/ncloud/data_source_ncloud_server_products_test.go
+++ b/ncloud/data_source_ncloud_server_products_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNcloudServerProducts_classic_basic(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductsConfig("SPSW0LINUX000032"),
+				Config: testAccDataSourceNcloudServerProductsConfig("SPSW0LINUX000045"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_server_products.all"),
 				),

--- a/ncloud/resource_ncloud_load_balancer.go
+++ b/ncloud/resource_ncloud_load_balancer.go
@@ -62,12 +62,14 @@ func resourceNcloudLoadBalancer() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "List of server instance numbers to be bound to the load balancer",
 			},
+			// Deprecated
 			"internet_line_type": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"PUBLC", "GLBL"}, false)),
 				Description:      "Internet line identification code. PUBLC(Public), GLBL(Global). default : PUBLC(Public)",
+				Deprecated:       "This parameter is no longer used.",
 			},
 			"network_usage_type": {
 				Type:             schema.TypeString,
@@ -197,10 +199,6 @@ func resourceNcloudLoadBalancerRead(d *schema.ResourceData, meta interface{}) er
 
 		if algorithmType := flattenCommonCode(lb.LoadBalancerAlgorithmType); algorithmType["code"] != nil {
 			d.Set("algorithm_type", algorithmType["code"])
-		}
-
-		if internetLineType := flattenCommonCode(lb.InternetLineType); internetLineType["code"] != nil {
-			d.Set("internet_line_type", internetLineType["code"])
 		}
 
 		if instanceStatus := flattenCommonCode(lb.LoadBalancerInstanceStatus); instanceStatus["code"] != nil {
@@ -356,8 +354,7 @@ func buildCreateLoadBalancerInstanceParams(d *schema.ResourceData) (*loadbalance
 	}
 
 	reqParams := &loadbalancer.CreateLoadBalancerInstanceRequest{
-		InternetLineTypeCode: StringPtrOrNil(d.GetOk("internet_line_type")),
-		RegionNo:             regionNo,
+		RegionNo: regionNo,
 	}
 
 	if loadBalancerName, ok := d.GetOk("name"); ok {

--- a/ncloud/resource_ncloud_load_balancer_test.go
+++ b/ncloud/resource_ncloud_load_balancer_test.go
@@ -159,7 +159,6 @@ func testAccLoadBalancerConfig(lbName string) string {
     		l7_health_check_path = "/monitor/l7check"
   		}
 
-			internet_line_type = "PUBLC"
 			network_usage_type = "PBLIP"
 			region             = "KR"
 		}
@@ -180,7 +179,6 @@ func testAccLoadBalancerChangedConfig(lbName string) string {
     		l7_health_check_path = "/monitor/l7check"
   		}
 
-			internet_line_type = "PUBLC"
 			network_usage_type = "PBLIP"
 			region             = "KR"
 		}

--- a/ncloud/resource_ncloud_public_ip.go
+++ b/ncloud/resource_ncloud_public_ip.go
@@ -46,12 +46,14 @@ func resourceNcloudPublicIpInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			// Deprecated
 			"internet_line_type": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
 				ForceNew:         true,
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"PUBLC", "GLBL"}, false)),
+				Deprecated:       "This parameter is no longer used.",
 			},
 			"zone": {
 				Type:     schema.TypeString,
@@ -179,11 +181,10 @@ func createClassicPublicIp(d *schema.ResourceData, config *ProviderConfig) (*str
 	}
 
 	reqParams := &server.CreatePublicIpInstanceRequest{
-		RegionNo:             &config.RegionNo,
-		ZoneNo:               zoneNo,
-		InternetLineTypeCode: StringPtrOrNil(d.GetOk("internet_line_type")),
-		ServerInstanceNo:     StringPtrOrNil(d.GetOk("server_instance_no")),
-		PublicIpDescription:  StringPtrOrNil(d.GetOk("description")),
+		RegionNo:            &config.RegionNo,
+		ZoneNo:              zoneNo,
+		ServerInstanceNo:    StringPtrOrNil(d.GetOk("server_instance_no")),
+		PublicIpDescription: StringPtrOrNil(d.GetOk("description")),
 	}
 
 	logCommonRequest("createClassicPublicIp", reqParams)
@@ -315,10 +316,6 @@ func getClassicPublicIp(config *ProviderConfig, id string) (map[string]interface
 		"zone":               *r.Zone.ZoneCode,
 		"instance_no":        *r.PublicIpInstanceNo, // Deprecated
 		"server_instance_no": nil,
-	}
-
-	if m := flattenCommonCode(r.InternetLineType); m["code"] != nil {
-		instance["internet_line_type"] = m["code"]
 	}
 
 	if m := flattenCommonCode(r.PublicIpInstanceStatus); m["code"] != nil {
@@ -565,10 +562,6 @@ func resourceNcloudPublicIpCustomizeDiff(_ context.Context, diff *schema.Resourc
 		if v, ok := diff.GetOk("zone"); ok {
 			diff.Clear("zone")
 			return fmt.Errorf("You don't use 'zone' if SupportVPC is true. Please remove this value [%s]", v)
-		}
-
-		if v, ok := diff.GetOk("internet_line_type"); ok {
-			return fmt.Errorf("You don't use 'internet_line_type' if SupportVPC is true. Please remove this value [%s]", v)
 		}
 	}
 	return nil

--- a/ncloud/resource_ncloud_public_ip_test.go
+++ b/ncloud/resource_ncloud_public_ip_test.go
@@ -206,7 +206,7 @@ resource "ncloud_login_key" "loginkey" {
 
 resource "ncloud_server" "server" {
 	name = "%[1]s"
-	server_image_product_code = "SPSW0LINUX000032"
+	server_image_product_code = "SPSW0LINUX000045"
 	server_product_code = "SPSVRSTAND000004"
 	login_key_name = "${ncloud_login_key.loginkey.key_name}"
 }
@@ -260,14 +260,14 @@ resource "ncloud_login_key" "loginkey" {
 
 resource "ncloud_server" "foo" {
 	name = "%[1]s"
-	server_image_product_code = "SPSW0LINUX000032"
+	server_image_product_code = "SPSW0LINUX000045"
 	server_product_code = "SPSVRSTAND000004"
 	login_key_name = "${ncloud_login_key.loginkey.key_name}"
 }
 
 resource "ncloud_server" "bar" {
 	name = "%[2]s"
-	server_image_product_code = "SPSW0LINUX000032"
+	server_image_product_code = "SPSW0LINUX000045"
 	server_product_code = "SPSVRSTAND000004"
 	login_key_name = "${ncloud_login_key.loginkey.key_name}"
 }

--- a/ncloud/resource_ncloud_server.go
+++ b/ncloud/resource_ncloud_server.go
@@ -80,12 +80,14 @@ func resourceNcloudServer() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			// Deprecated
 			"internet_line_type": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
 				ForceNew:         true,
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"PUBLC", "GLBL"}, false)),
+				Deprecated:       "This parameter is no longer used.",
 			},
 			"fee_system_type_code": {
 				Type:     schema.TypeString,
@@ -366,7 +368,6 @@ func createClassicServerInstance(d *schema.ResourceData, config *ProviderConfig)
 		ServerDescription:          StringPtrOrNil(d.GetOk("description")),
 		LoginKeyName:               StringPtrOrNil(d.GetOk("login_key_name")),
 		IsProtectServerTermination: BoolPtrOrNil(d.GetOk("is_protect_server_termination")),
-		InternetLineTypeCode:       StringPtrOrNil(d.GetOk("internet_line_type")),
 		FeeSystemTypeCode:          StringPtrOrNil(d.GetOk("fee_system_type_code")),
 		UserData:                   StringPtrOrNil(d.GetOk("user_data")),
 		RaidTypeName:               StringPtrOrNil(d.GetOk("raid_type_name")),
@@ -751,7 +752,6 @@ func convertClassicServerInstance(r *server.ServerInstance) *ServerInstance {
 		Zone:                           r.Zone.ZoneCode,
 		BaseBlockStorageDiskType:       r.BaseBlockStorageDiskType.Code,
 		BaseBlockStorageDiskDetailType: flattenMapByKey(r.BaseBlockStorageDiskDetailType, "code"),
-		InternetLineType:               r.InternetLineType.Code,
 		InstanceTagList:                r.InstanceTagList,
 	}
 }
@@ -1202,7 +1202,6 @@ type ServerInstance struct {
 	Zone                           *string               `json:"zone,omitempty"`
 	BaseBlockStorageDiskType       *string               `json:"base_block_storage_disk_type,omitempty"`
 	BaseBlockStorageDiskDetailType *string               `json:"base_block_storage_disk_detail_type,omitempty"`
-	InternetLineType               *string               `json:"internet_line_type,omitempty"`
 	InstanceTagList                []*server.InstanceTag `json:"tag_list,omitempty"`
 	// VPC
 	VpcNo                *string                           `json:"vpc_no,omitempty"`

--- a/ncloud/resource_ncloud_server_test.go
+++ b/ncloud/resource_ncloud_server_test.go
@@ -43,7 +43,6 @@ func TestAccResourceNcloudServer_classic_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "server_product_code", productCode),
 					resource.TestCheckResourceAttr(resourceName, "name", testServerName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "internet_line_type", "PUBLC"),
 					resource.TestMatchResourceAttr(resourceName, "zone", regexp.MustCompile(`^\w+.*$`)),
 					resource.TestCheckResourceAttr(resourceName, "base_block_storage_disk_type", "NET"),
 					resource.TestCheckResourceAttr(resourceName, "base_block_storage_size", "53687091200"),

--- a/ncloud/resource_ncloud_server_test.go
+++ b/ncloud/resource_ncloud_server_test.go
@@ -39,7 +39,7 @@ func TestAccResourceNcloudServer_classic_basic(t *testing.T) {
 					testAccCheckServerExistsWithProvider(resourceName, &serverInstance, testAccClassicProvider),
 					testCheck(),
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
-					resource.TestCheckResourceAttr(resourceName, "server_image_product_code", "SPSW0LINUX000032"),
+					resource.TestCheckResourceAttr(resourceName, "server_image_product_code", "SPSW0LINUX000045"),
 					resource.TestCheckResourceAttr(resourceName, "server_product_code", productCode),
 					resource.TestCheckResourceAttr(resourceName, "name", testServerName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -49,9 +49,9 @@ func TestAccResourceNcloudServer_classic_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cpu_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "memory_size", "4294967296"),
 					resource.TestMatchResourceAttr(resourceName, "instance_no", regexp.MustCompile(`^\d+$`)),
-					resource.TestCheckResourceAttr(resourceName, "platform_type", "LNX32"),
+					resource.TestCheckResourceAttr(resourceName, "platform_type", "LNX64"),
 					resource.TestCheckResourceAttr(resourceName, "is_protect_server_termination", "false"),
-					resource.TestCheckResourceAttr(resourceName, "server_image_name", "centos-6.3-32"),
+					resource.TestCheckResourceAttr(resourceName, "server_image_name", "centos-7.2-64"),
 					resource.TestCheckResourceAttr(resourceName, "login_key_name", fmt.Sprintf("%s-key", testServerName)),
 					resource.TestMatchResourceAttr(resourceName, "instance_no", regexp.MustCompile(`^\d+$`)),
 					resource.TestMatchResourceAttr(resourceName, "port_forwarding_public_ip", regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`)),
@@ -408,7 +408,7 @@ resource "ncloud_login_key" "loginkey" {
 
 resource "ncloud_server" "server" {
 	name = "%[1]s"
-	server_image_product_code = "SPSW0LINUX000032"
+	server_image_product_code = "SPSW0LINUX000045"
 	server_product_code = "%[2]s"
 	login_key_name = "${ncloud_login_key.loginkey.key_name}"
 }


### PR DESCRIPTION
resolve #178 

- Remove logic related to the deprecated `internet_line_type_code` field
- Modify deprecated server image product code `SPSW0LINUX000032` to `SPSW0LINUX000045` in test codes


### TEST
```text
$ make testacc TESTARGS="TestAccResourceNcloudServer_classic|TestAccDataSourceNcloudServerProducts_classic|TestAccDataSourceNcloudServerProduct_classic|TestAccResourceNcloudPublicIpInstance_classic|TestAccDataSourceNcloudPublicIp_classic|TestAccDataSourceNcloudPortForwardingRulesBasic|TestAccDataSourceNcloudPortForwardingRuleBasic"

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run='TestAccResourceNcloudServer_classic|TestAccDataSourceNcloudServerProducts_classic|TestAccDataSourceNcloudServerProduct_classic|TestAccResourceNcloudPublicIpInstance_classic|TestAccDataSourceNcloudPublicIp_classic|TestAccDataSourceNcloudPortForwardingRulesBasic|TestAccDataSourceNcloudPortForwardingRuleBasic' -timeout 120m
?       github.com/terraform-providers/terraform-provider-ncloud        [no test files]
=== RUN   TestAccDataSourceNcloudPortForwardingRuleBasic
=== PAUSE TestAccDataSourceNcloudPortForwardingRuleBasic
=== RUN   TestAccDataSourceNcloudPortForwardingRulesBasic
=== PAUSE TestAccDataSourceNcloudPortForwardingRulesBasic
=== RUN   TestAccDataSourceNcloudPublicIp_classic_basic
--- PASS: TestAccDataSourceNcloudPublicIp_classic_basic (351.24s)
=== RUN   TestAccDataSourceNcloudServerProduct_classic_basic
=== PAUSE TestAccDataSourceNcloudServerProduct_classic_basic
=== RUN   TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode
=== PAUSE TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode
=== RUN   TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType
=== PAUSE TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType
=== RUN   TestAccDataSourceNcloudServerProducts_classic_basic
=== PAUSE TestAccDataSourceNcloudServerProducts_classic_basic
=== RUN   TestAccResourceNcloudPublicIpInstance_classic_basic
--- PASS: TestAccResourceNcloudPublicIpInstance_classic_basic (324.11s)
=== RUN   TestAccResourceNcloudPublicIpInstance_classic_updateServerInstanceNo
--- PASS: TestAccResourceNcloudPublicIpInstance_classic_updateServerInstanceNo (418.65s)
=== RUN   TestAccResourceNcloudServer_classic_basic
--- PASS: TestAccResourceNcloudServer_classic_basic (333.39s)
=== RUN   TestAccResourceNcloudServer_classic_changeSpec
--- PASS: TestAccResourceNcloudServer_classic_changeSpec (443.74s)
=== CONT  TestAccDataSourceNcloudPortForwardingRuleBasic
=== CONT  TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType
=== CONT  TestAccDataSourceNcloudServerProducts_classic_basic
=== CONT  TestAccDataSourceNcloudServerProduct_classic_basic
=== CONT  TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode
=== CONT  TestAccDataSourceNcloudPortForwardingRulesBasic
--- PASS: TestAccDataSourceNcloudPortForwardingRulesBasic (5.13s)
--- PASS: TestAccDataSourceNcloudPortForwardingRuleBasic (5.14s)
--- PASS: TestAccDataSourceNcloudServerProduct_classic_basic (16.79s)
--- FAIL: TestAccDataSourceNcloudServerProduct_classic_basic (13.55s)
--- PASS: TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType (20.50s)
--- PASS: TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode (20.61s)
--- PASS: TestAccDataSourceNcloudServerProducts_classic_basic (20.89s)
PASS
```