### PR TITLE
`ncloud_network_interface` can change `access_control_…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-ncloud
 go 1.16
 
 require (
-	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.3.3
+	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.4.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.3.3 h1:FwqQQizEIJEy1EPfB9WdxBITAJx7kuo+FE1W97djV+4=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.3.3/go.mod h1:7+Hx3TCfPW8HE0ycOH4UJqkTEq7uZeYyk+N1FCDR4LA=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.4.0 h1:maRRO1Rg9XqbVR9a6qyn8hLY2a7UW+ze+4+TpsuBPnU=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.4.0/go.mod h1:7+Hx3TCfPW8HE0ycOH4UJqkTEq7uZeYyk+N1FCDR4LA=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=

--- a/ncloud/common.go
+++ b/ncloud/common.go
@@ -22,6 +22,8 @@ const (
 
 	ApiErrorDetachingMountedStorage = "24002"
 
+	ApiErrorNetworkInterfaceAtLeastOneAcgMustRemain = "1002035"
+
 	ApiErrorAcgCantChangeSameTime           = "1007009"
 	ApiErrorNetworkAclCantAccessaApropriate = "1011002"
 	ApiErrorNetworkAclRuleChangeIngRules    = "1012005"

--- a/ncloud/data_source_ncloud_port_forwarding_rule.go
+++ b/ncloud/data_source_ncloud_port_forwarding_rule.go
@@ -1,7 +1,7 @@
 package ncloud
 
 import (
-	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
@@ -97,7 +97,7 @@ func dataSourceNcloudPortForwardingRuleRead(d *schema.ResourceData, meta interfa
 		logErrorResponse("GetPortForwardingRuleList", err, reqParams)
 		return err
 	}
-	logCommonResponse("GetPortForwardingRuleList", GetCommonResponse(resp), fmt.Sprintf("TotalRows: %d", ncloud.Int32Value(resp.TotalRows)))
+	logResponse("GetPortForwardingRuleList", resp)
 
 	allPortForwardingRules := resp.PortForwardingRuleList
 	var filteredPortForwardingRuleList []*server.PortForwardingRule
@@ -125,16 +125,17 @@ func dataSourceNcloudPortForwardingRuleRead(d *schema.ResourceData, meta interfa
 	}
 	portForwardingRule = filteredPortForwardingRuleList[0]
 
-	return portForwardingRuleAttributes(d, resp.PortForwardingConfigurationNo, portForwardingRule)
+	return portForwardingRuleAttributes(d, resp.PortForwardingRuleList[0].PortForwardingConfigurationNo, portForwardingRule)
 }
 
 func portForwardingRuleAttributes(d *schema.ResourceData, portForwardingConfigurationNo *string, rule *server.PortForwardingRule) error {
+	log.Printf("rule: %+v", rule.PortForwardingExternalPort)
 	d.SetId(ncloud.StringValue(portForwardingConfigurationNo))
 	d.Set("port_forwarding_configuration_no", portForwardingConfigurationNo)
 	d.Set("port_forwarding_public_ip", rule.ServerInstance.PortForwardingPublicIp)
 	d.Set("server_instance_no", rule.ServerInstance.ServerInstanceNo)
-	d.Set("port_forwarding_external_port", rule.PortForwardingExternalPort)
-	d.Set("port_forwarding_internal_port", rule.PortForwardingInternalPort)
+	d.Set("port_forwarding_external_port", strconv.Itoa(int(ncloud.Int32Value(rule.PortForwardingExternalPort))))
+	d.Set("port_forwarding_internal_port", strconv.Itoa(int(ncloud.Int32Value(rule.PortForwardingInternalPort))))
 
 	return nil
 }

--- a/ncloud/data_source_ncloud_port_forwarding_rules.go
+++ b/ncloud/data_source_ncloud_port_forwarding_rules.go
@@ -131,7 +131,7 @@ func dataSourceNcloudPortForwardingRulesRead(d *schema.ResourceData, meta interf
 	if len(filteredPortForwardingRuleList) < 1 {
 		return fmt.Errorf("no results. please change search criteria and try again")
 	}
-	return portForwardingRulesAttributes(d, resp.PortForwardingConfigurationNo, filteredPortForwardingRuleList)
+	return portForwardingRulesAttributes(d, resp.PortForwardingRuleList[0].PortForwardingConfigurationNo, filteredPortForwardingRuleList)
 }
 
 func portForwardingRulesAttributes(d *schema.ResourceData, portForwardingConfigurationNo *string, portForwardingRuleList []*server.PortForwardingRule) error {

--- a/ncloud/resource_ncloud_network_interface.go
+++ b/ncloud/resource_ncloud_network_interface.go
@@ -46,9 +46,8 @@ func resourceNcloudNetworkInterface() *schema.Resource {
 				ValidateDiagFunc: ToDiagFunc(validation.IsIPv4Address),
 			},
 			"access_control_groups": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
-				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"server_instance_no": {
@@ -152,7 +151,98 @@ func resourceNcloudNetworkInterfaceUpdate(d *schema.ResourceData, meta interface
 			}
 		}
 	}
+
+	if d.HasChange("access_control_groups") {
+		o, n := d.GetChange("access_control_groups")
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+
+		add := ns.Difference(os).List()
+		remove := os.Difference(ns).List()
+
+		removeAcgList := expandStringInterfaceList(remove)
+		addAcgList := expandStringInterfaceList(add)
+
+		// First do add ACG prevent error '[1002035] At least one Acg must remain on the network interface.'
+		if len(addAcgList) > 0 {
+			if err := addNetworkInterfaceAccessControlGroup(d, config, addAcgList); err != nil {
+				return err
+			}
+		}
+
+		if len(removeAcgList) > 0 {
+			if err := removeNetworkInterfaceAccessControlGroup(d, config, removeAcgList); err != nil {
+				return err
+			}
+		}
+	}
+
 	return resourceNcloudNetworkInterfaceRead(d, meta)
+}
+
+func removeNetworkInterfaceAccessControlGroup(d *schema.ResourceData, config *ProviderConfig, accessControlGroupNoList []*string) error {
+	var resp *vserver.RemoveNetworkInterfaceAccessControlGroupResponse
+	var reqParams *vserver.RemoveNetworkInterfaceAccessControlGroupRequest
+
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		var err error
+		reqParams = &vserver.RemoveNetworkInterfaceAccessControlGroupRequest{
+			RegionCode:               &config.RegionCode,
+			AccessControlGroupNoList: accessControlGroupNoList,
+			NetworkInterfaceNo:       ncloud.String(d.Id()),
+		}
+
+		logCommonRequest("RemoveNetworkInterfaceAccessControlGroup", reqParams)
+		resp, err = config.Client.vserver.V2Api.RemoveNetworkInterfaceAccessControlGroup(reqParams)
+
+		if err != nil {
+			errBody, _ := GetCommonErrorBody(err)
+			if errBody.ReturnCode == ApiErrorNetworkInterfaceAtLeastOneAcgMustRemain {
+				logErrorResponse("retry RemoveNetworkInterfaceAccessControlGroup", err, reqParams)
+				time.Sleep(time.Second * 5)
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		logErrorResponse("RemoveNetworkInterfaceAccessControlGroup", err, reqParams)
+		return err
+	}
+
+	logResponse("RemoveNetworkInterfaceAccessControlGroup", resp)
+
+	if err = waitForNetworkInterfaceAttachment(config, d.Id()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addNetworkInterfaceAccessControlGroup(d *schema.ResourceData, config *ProviderConfig, accessControlGroupNoList []*string) error {
+	reqParams := &vserver.AddNetworkInterfaceAccessControlGroupRequest{
+		RegionCode:               &config.RegionCode,
+		AccessControlGroupNoList: accessControlGroupNoList,
+		NetworkInterfaceNo:       ncloud.String(d.Id()),
+	}
+
+	logCommonRequest("AddNetworkInterfaceAccessControlGroup", reqParams)
+	resp, err := config.Client.vserver.V2Api.AddNetworkInterfaceAccessControlGroup(reqParams)
+
+	if err != nil {
+		logErrorResponse("AddNetworkInterfaceAccessControlGroup", err, reqParams)
+		return err
+	}
+
+	logResponse("AddNetworkInterfaceAccessControlGroup", resp)
+
+	if err = waitForNetworkInterfaceAttachment(config, d.Id()); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func resourceNcloudNetworkInterfaceDelete(d *schema.ResourceData, meta interface{}) error {
@@ -222,7 +312,7 @@ func createVpcNetworkInterface(d *schema.ResourceData, config *ProviderConfig) (
 
 	reqParams := &vserver.CreateNetworkInterfaceRequest{
 		RegionCode:                  &config.RegionCode,
-		AccessControlGroupNoList:    expandStringInterfaceList(d.Get("access_control_groups").([]interface{})),
+		AccessControlGroupNoList:    expandStringInterfaceList(d.Get("access_control_groups").(*schema.Set).List()),
 		SubnetNo:                    ncloud.String(d.Get("subnet_no").(string)),
 		VpcNo:                       subnet.VpcNo,
 		NetworkInterfaceName:        StringPtrOrNil(d.GetOk("name")),

--- a/ncloud/structures_test.go
+++ b/ncloud/structures_test.go
@@ -327,12 +327,8 @@ func TestFlattenNasVolumeInstances(t *testing.T) {
 			VolumeName:                       ncloud.String("n003666_aaa"),
 			VolumeTotalSize:                  ncloud.Int64(536870912000),
 			VolumeSize:                       ncloud.Int64(536870912000),
-			VolumeUseSize:                    ncloud.Int64(1314816),
-			VolumeUseRatio:                   ncloud.Float32(0.0),
 			SnapshotVolumeConfigurationRatio: ncloud.Float32(0.0),
 			SnapshotVolumeSize:               ncloud.Int64(0),
-			SnapshotVolumeUseSize:            ncloud.Int64(0),
-			SnapshotVolumeUseRatio:           ncloud.Float32(0.0),
 			IsSnapshotConfiguration:          ncloud.Bool(false),
 			IsEventConfiguration:             ncloud.Bool(false),
 			Region: &server.Region{


### PR DESCRIPTION
#### Overview
- resolve #190 
- `access_control_groups` changes schemas
  - `schema.TypeList` to `schema.TypeSet`
  - remove `ForceNew` attribute
- upgrade ncloud-sdk-go-v2 to v1.4.0

#### Test results
```
=== RUN   TestAccresourceNcloudNetworkInterface_basic
--- PASS: TestAccresourceNcloudNetworkInterface_basic (70.86s)
=== RUN   TestAccresourceNcloudNetworkInterface_update
--- PASS: TestAccresourceNcloudNetworkInterface_update (377.55s)
=== RUN   TestAccresourceNcloudNetworkInterface_disappears
--- PASS: TestAccresourceNcloudNetworkInterface_disappears (67.70s)
```