### PR TITLE
#195 nacl deny allow group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ website/node_modules
 *.iml
 *.test
 *.iml
+binary/
+test/
+
 
 website/vendor
 

--- a/docs/data-sources/network_acl_deny_allow_groups.md
+++ b/docs/data-sources/network_acl_deny_allow_groups.md
@@ -7,11 +7,11 @@ This resource is useful for look up the list of Network ACL Deny-Allow Group in 
 ### Retrieve by Deny-Allow Group ID
 
 ```hcl
-data "ncloud_network_acl_deny_allow_groups" "nacl_deny_allow_groups" {
-  network_acl_deny_allow_group_no_list = [ncloud_network_acl_deny_allow_group.allow_group.id]
+data "ncloud_network_acl_deny_allow_groups" "deny_allow_groups" {
+  network_acl_deny_allow_group_no_list = [ncloud_network_acl_deny_allow_group.deny_allow_group.id]
 }
 
-resource "ncloud_network_acl_deny_allow_group" "allow_group" {
+resource "ncloud_network_acl_deny_allow_group" "deny_allow_group" {
   vpc_no         = ncloud_vpc.vpc.id
   ip_list = ["10.0.0.1", "10.0.0.2"]
 }
@@ -20,19 +20,19 @@ resource "ncloud_network_acl_deny_allow_group" "allow_group" {
 ### Retrieve by Specific VPC and name
 
 ```hcl
-data "ncloud_network_acl_deny_allow_groups" "nacl_deny_allow_groups" {
+data "ncloud_network_acl_deny_allow_groups" "deny_allow_groups" {
   vpc_no = ncloud_vpc.vpc.id
-  name   = "allow-test"
+  name   = "deny-allow-test"
 }
 ```
 
 ### Retrieve by filter
 
 ```hcl
-data "ncloud_network_acl_deny_allow_groups" "nacl_deny_allow_groups" {
+data "ncloud_network_acl_deny_allow_groups" "deny_allow_groups" {
   filter {
     name = "name"
-    values = ["allow-test"]
+    values = ["deny-allow-test"]
     regex = false
   }
 }

--- a/docs/data-sources/network_acl_deny_allow_groups.md
+++ b/docs/data-sources/network_acl_deny_allow_groups.md
@@ -1,0 +1,69 @@
+# Data Source: ncloud_network_acl_deny_allow_groups
+
+This resource is useful for look up the list of Network ACL Deny-Allow Group in the region.
+
+## Example Usage
+
+### Retrieve by Deny-Allow Group ID
+
+```hcl
+data "ncloud_network_acl_deny_allow_groups" "nacl_deny_allow_groups" {
+  network_acl_deny_allow_group_no_list = [ncloud_network_acl_deny_allow_group.allow_group.id]
+}
+
+resource "ncloud_network_acl_deny_allow_group" "allow_group" {
+  vpc_no         = ncloud_vpc.vpc.id
+  ip_list = ["10.0.0.1", "10.0.0.2"]
+}
+```
+
+### Retrieve by Specific VPC and name
+
+```hcl
+data "ncloud_network_acl_deny_allow_groups" "nacl_deny_allow_groups" {
+  vpc_no = ncloud_vpc.vpc.id
+  name   = "allow-test"
+}
+```
+
+### Retrieve by filter
+
+```hcl
+data "ncloud_network_acl_deny_allow_groups" "nacl_deny_allow_groups" {
+  filter {
+    name = "name"
+    values = ["allow-test"]
+    regex = false
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `network_acl_deny_allow_group_no_list` - (Optional) List of Deny-Allow Group ID to retrieve.
+* `vpc_no` - (Optional) The ID of the specific VPC to retrieve.
+* `name` - (Optional) name of the specific Deny-Allow Group to retrieve.
+* `filter` - (Optional) Custom filter block as described below.
+    * `name` - (Required) The name of the field to filter by
+    * `values` - (Required) Set of values that are accepted for the given field.
+    * `regex` - (Optional) is `values` treated as a regular expression.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `network_acl_deny_allow_groups` - The list of Deny-Allow Group
+
+### Network ACL Deny Allow Group Reference
+
+`network_acl_deny_allow_groups` are also exported with the following attributes, where are relevant: Each element
+supports the following:
+
+* `id` - The ID of Deny-Allow Group.
+* `network_acl_deny_allow_group_no` - The ID of Deny-Allow Group. (It is the same result as `id`)
+* `vpc_no` - The ID of the associated VPC.
+* `name` - The name of Deny-Allow Group.
+* `description` - Description of Deny-Allow Group.
+* `ip_list` - list of IP address that registered in the Deny-Allow Group.

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,7 +113,7 @@ The following arguments are supported:
   it can also be sourced from the `NCLOUD_SECRET_KEY` environment variable.
 
 * `region` - (Required) Ncloud region.
-  it can also be sourced from the `NCLOUD_REGION` environment variables.
+  it can also be sourced from the `NCLOUD_REGION` environment variables. You can specify only the following value: "KR", "SGN",
 
 * `site` - (Optional) Ncloud site. By default, the value is "public". You can specify only the following value: "public", "gov", "fin". "public" is for `www.ncloud.com`. "gov" is for `www.gov-ncloud.com`. "fin" is for `www.fin-ncloud.com`.
 

--- a/docs/resources/network_acl_deny_allow_group.md
+++ b/docs/resources/network_acl_deny_allow_group.md
@@ -1,0 +1,56 @@
+# Resource: ncloud_network_acl_deny_allow_group
+
+Provides a rule of Network ACL Deny-Allow Group resource. You can manage list of IP using this resource, \
+Network ACL Deny Allow Group can be added to the Network ACL rule(ncloud_network_acl_rule) using `deny_allow_group_no`.
+
+## Example Usage
+
+### Basic Usage
+
+```hcl
+resource "ncloud_network_acl_deny_allow_group" "allow_group" {
+  vpc_no         = ncloud_vpc.vpc.id
+  // below fields is optional
+  name      = "allow-group-test" 
+  description = "by terraform"
+  ip_list = ["10.0.0.1", "10.0.0.2"]
+}
+
+resource "ncloud_vpc" "vpc" {
+   ipv4_cidr_block = "10.0.0.0/16"
+ }
+ 
+resource "ncloud_network_acl" "nacl" {
+   vpc_no      = ncloud_vpc.vpc.id
+}
+ 
+resource "ncloud_network_acl_rule" "nacl_rule" {
+  network_acl_no    = ncloud_network_acl.nacl.id
+
+  inbound {
+    priority    = 110
+    protocol    = "TCP"
+    rule_action = "ALLOW"
+    deny_allow_group_no = ncloud_network_acl_deny_allow_group.allow_group.id
+    port_range  = "22"
+  }
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_no` - (Required) The ID of the associated VPC.
+* `name` - (Optional) The name to create. If omitted, Terraform will assign a random, unique name.
+* `description` - (Optional) description to create
+* `ip_list` - (Optional) Enter the IP address to be registered in the Deny-Allow Group. Up to 100 IPs can be registered
+  and duplicate IP addresses are not allowed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the Deny-Allow Group.
+* `network_acl_deny_allow_group_no` - The ID of the Deny-Allow Group. (It is the same result as `id`)

--- a/docs/resources/network_acl_deny_allow_group.md
+++ b/docs/resources/network_acl_deny_allow_group.md
@@ -1,19 +1,19 @@
 # Resource: ncloud_network_acl_deny_allow_group
 
 Provides a rule of Network ACL Deny-Allow Group resource. You can manage list of IP using this resource, \
-Network ACL Deny Allow Group can be added to the Network ACL rule(ncloud_network_acl_rule) using `deny_allow_group_no`.
+Network ACL Deny-Allow Group can be added to the Network ACL Rule(`ncloud_network_acl_rule`) using `deny_allow_group_no`.
 
 ## Example Usage
 
 ### Basic Usage
 
 ```hcl
-resource "ncloud_network_acl_deny_allow_group" "allow_group" {
-  vpc_no         = ncloud_vpc.vpc.id
+resource "ncloud_network_acl_deny_allow_group" "deny_allow_group" {
+  vpc_no      = ncloud_vpc.vpc.id
   // below fields is optional
-  name      = "allow-group-test" 
+  name        = "deny-allow-group-test" 
   description = "by terraform"
-  ip_list = ["10.0.0.1", "10.0.0.2"]
+  ip_list     = ["10.0.0.1", "10.0.0.2"]
 }
 
 resource "ncloud_vpc" "vpc" {
@@ -28,11 +28,11 @@ resource "ncloud_network_acl_rule" "nacl_rule" {
   network_acl_no    = ncloud_network_acl.nacl.id
 
   inbound {
-    priority    = 110
-    protocol    = "TCP"
-    rule_action = "ALLOW"
-    deny_allow_group_no = ncloud_network_acl_deny_allow_group.allow_group.id
-    port_range  = "22"
+    priority            = 110
+    protocol            = "TCP"
+    rule_action         = "ALLOW"
+    deny_allow_group_no = ncloud_network_acl_deny_allow_group.deny_allow_group.id
+    port_range          = "22"
   }
 }
 
@@ -43,10 +43,10 @@ resource "ncloud_network_acl_rule" "nacl_rule" {
 The following arguments are supported:
 
 * `vpc_no` - (Required) The ID of the associated VPC.
-* `name` - (Optional) The name to create. If omitted, Terraform will assign a random, unique name.
-* `description` - (Optional) description to create
-* `ip_list` - (Optional) Enter the IP address to be registered in the Deny-Allow Group. Up to 100 IPs can be registered
-  and duplicate IP addresses are not allowed.
+* `name` - (Optional) The name to create. If omitted, terraform will assign a random, unique name.
+* `description` - (Optional) Description to create
+* `ip_list` - (Optional) Enter the IP addresses as list to be registered in the Deny-Allow Group. 
+  Up to 100 IPs can be registered. Duplicate IP addresses are not allowed.
 
 ## Attributes Reference
 

--- a/docs/resources/network_acl_rule.md
+++ b/docs/resources/network_acl_rule.md
@@ -6,7 +6,7 @@ Provides a rule of Network ACL  resource.
 
 ## Example Usage
 
-### Basic Usage
+### Basic
 
 ```hcl
 resource "ncloud_vpc" "vpc" {
@@ -48,13 +48,48 @@ resource "ncloud_network_acl_rule" "nacl_rule" {
 }
 ```
 
+### Network ACL Deny Allow Group
+
+```hcl
+resource "ncloud_network_acl_deny_allow_group" "allow_group" {
+  vpc_no         = ncloud_vpc.vpc.id
+  // below fields is optional
+  name      = "allow-group-test" 
+  description = "by terraform"
+  ip_list = ["10.0.0.1", "10.0.0.2"]
+}
+
+resource "ncloud_vpc" "vpc" {
+   ipv4_cidr_block = "10.0.0.0/16"
+ }
+ 
+resource "ncloud_network_acl" "nacl" {
+   vpc_no      = ncloud_vpc.vpc.id
+}
+ 
+resource "ncloud_network_acl_rule" "nacl_rule" {
+  network_acl_no    = ncloud_network_acl.nacl.id
+
+  inbound {
+    priority    = 110
+    protocol    = "TCP"
+    rule_action = "ALLOW"
+    deny_allow_group_no = ncloud_network_acl_deny_allow_group.allow_group.id
+    port_range  = "22"
+  }
+}
+
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `network_acl_no` - (Required) The ID of the Network ACL.
-* `inbound` - (Optional) Specifies an Inbound(ingress) rules. Parameters defined below. This argument is processed in [attriutbe-as-blocks](https://www.terraform.io/docs/configuration/attr-as-blocks.html) mode.
-* `outbound` - (Optional) Specifies an Outbound(egress) rules. Parameters defined below. This argument is processed in [attriutbe-as-blocks](https://www.terraform.io/docs/configuration/attr-as-blocks.html) mode.
+* `inbound` - (Optional) Specifies an Inbound(ingress) rules. Parameters defined below. This argument is processed
+  in [attriutbe-as-blocks](https://www.terraform.io/docs/configuration/attr-as-blocks.html) mode.
+* `outbound` - (Optional) Specifies an Outbound(egress) rules. Parameters defined below. This argument is processed
+  in [attriutbe-as-blocks](https://www.terraform.io/docs/configuration/attr-as-blocks.html) mode.
 
 ### Network ACL Rule Reference
 
@@ -63,8 +98,13 @@ Both `inbound` and `outbound` support  following attributes:
 * `priority` - (Required) Priority for rules, Used for ordering. Can be an integer from `1` to `199`.
 * `protocol` - (Required) Select between TCP, UDP, and ICMP. Accepted values: `TCP` | `UDP` | `ICMP`
 * `rule_action` - (Required) The action to take. Accepted values: `ALLOW` | `DROP`
-* `ip_block` - (Required) The CIDR block to match. This must be a valid network mask.
-* `port_range` - (Optional) Range of ports to apply. You can enter from `1` to `65535`. e.g. set single port: `22` or set range port : `8000-9000`
+* `ip_block` - (Optional, Required if `deny_allow_group_no` is not provided) The CIDR block to match. This must be a
+  valid network mask.
+* `deny_allow_group_no` - (Optional, Required if `ip_block` is not provided) The access source Deny-Allow Group number
+  of network ACL rules. You can specify a Deny-Allow group instead of an IP address block as the access
+  source. `deny_allow_group_no` can be obtained through the Data source `ncloud_network_acl_deny_allow_group`
+* `port_range` - (Optional) Range of ports to apply. You can enter from `1` to `65535`. e.g. set single port: `22` or
+  set range port : `8000-9000`
 
 ~> **NOTE:** If the value of protocol is `ICMP`, the `port_range` values will be ignored and the rule will apply to all ports.
 

--- a/docs/resources/network_acl_rule.md
+++ b/docs/resources/network_acl_rule.md
@@ -48,13 +48,13 @@ resource "ncloud_network_acl_rule" "nacl_rule" {
 }
 ```
 
-### Network ACL Deny Allow Group
+### Network ACL Deny-Allow Group
 
 ```hcl
-resource "ncloud_network_acl_deny_allow_group" "allow_group" {
+resource "ncloud_network_acl_deny_allow_group" "deny_allow_group" {
   vpc_no         = ncloud_vpc.vpc.id
   // below fields is optional
-  name      = "allow-group-test" 
+  name      = "deny-allow-group-test" 
   description = "by terraform"
   ip_list = ["10.0.0.1", "10.0.0.2"]
 }
@@ -74,7 +74,7 @@ resource "ncloud_network_acl_rule" "nacl_rule" {
     priority    = 110
     protocol    = "TCP"
     rule_action = "ALLOW"
-    deny_allow_group_no = ncloud_network_acl_deny_allow_group.allow_group.id
+    deny_allow_group_no = ncloud_network_acl_deny_allow_group.deny_allow_group.id
     port_range  = "22"
   }
 }
@@ -101,7 +101,7 @@ Both `inbound` and `outbound` support  following attributes:
 * `ip_block` - (Optional, Required if `deny_allow_group_no` is not provided) The CIDR block to match. This must be a
   valid network mask.
 * `deny_allow_group_no` - (Optional, Required if `ip_block` is not provided) The access source Deny-Allow Group number
-  of network ACL rules. You can specify a Deny-Allow group instead of an IP address block as the access
+  of network ACL rules. You can specify a Deny-Allow Group instead of an IP address block as the access
   source. `deny_allow_group_no` can be obtained through the Data source `ncloud_network_acl_deny_allow_group`
 * `port_range` - (Optional) Range of ports to apply. You can enter from `1` to `65535`. e.g. set single port: `22` or
   set range port : `8000-9000`

--- a/ncloud/common.go
+++ b/ncloud/common.go
@@ -34,6 +34,15 @@ const (
 )
 
 const (
+	InstanceStatusInit        = "INIT"
+	InstanceStatusCreate      = "CREATING"
+	InstanceStatusRunning     = "RUN"
+	InstanceStatusSetting     = "SET"
+	InstanceStatusTerminating = "TERMTING"
+	InstanceStatusTerminated  = "TERMINATED"
+)
+
+const (
 	BYTE = 1 << (10 * iota)
 	KILOBYTE
 	MEGABYTE

--- a/ncloud/data_source_ncloud_network_deny_allow_groups.go
+++ b/ncloud/data_source_ncloud_network_deny_allow_groups.go
@@ -1,0 +1,111 @@
+package ncloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func init() {
+	RegisterDataSource("ncloud_network_acl_deny_allow_groups", dataSourceNcloudNetworkACLDenyAllowGroups())
+}
+
+func dataSourceNcloudNetworkACLDenyAllowGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNcloudNetworkACLDenyAllowGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"network_acl_deny_allow_group_no_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_no": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter": dataSourceFiltersSchema(),
+			"network_acl_deny_allow_groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     GetDataSourceItemSchema(resourceNcloudNetworkACLDenyAllowGroup()),
+			},
+		},
+	}
+}
+
+func dataSourceNcloudNetworkACLDenyAllowGroupsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*ProviderConfig)
+
+	if !config.SupportVPC {
+		return NotSupportClassic("data source `ncloud_network_acl_deny_allow_groups`")
+	}
+
+	reqParams := &vpc.GetNetworkAclDenyAllowGroupListRequest{
+		RegionCode: &config.RegionCode,
+	}
+
+	if v, ok := d.GetOk("network_acl_deny_allow_group_no_list"); ok {
+		reqParams.NetworkAclDenyAllowGroupNoList = expandStringInterfaceList(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		reqParams.NetworkAclDenyAllowGroupName = ncloud.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("vpc_no"); ok {
+		reqParams.VpcNo = ncloud.String(v.(string))
+	}
+
+	logCommonRequest("GetNetworkAclDenyAllowGroupList", reqParams)
+	resp, err := config.Client.vpc.V2Api.GetNetworkAclDenyAllowGroupList(reqParams)
+
+	if err != nil {
+		logErrorResponse("GetNetworkAclDenyAllowGroupList", err, reqParams)
+		return err
+	}
+	logResponse("GetNetworkAclDenyAllowGroupList", resp)
+
+	if resp == nil || len(resp.NetworkAclDenyAllowGroupList) == 0 {
+		return fmt.Errorf("no matching NetworkAclDenyAllowGroup found")
+	}
+
+	var resources []map[string]interface{}
+
+	for _, r := range resp.NetworkAclDenyAllowGroupList {
+		m := map[string]interface{}{
+			"id":                              *r.NetworkAclDenyAllowGroupNo,
+			"network_acl_deny_allow_group_no": *r.NetworkAclDenyAllowGroupNo,
+			"vpc_no":                          *r.VpcNo,
+			"name":                            *r.NetworkAclDenyAllowGroupName,
+			"description":                     *r.NetworkAclDenyAllowGroupDescription,
+		}
+
+		// only can get `ip_list` data from `getNetworkAclDenyAllowGroupDetail`
+		if g, err := getNetworkAclDenyAllowGroupDetail(config, *r.NetworkAclDenyAllowGroupNo); err != nil {
+			return err
+		} else {
+			m["ip_list"] = g.IpList
+		}
+
+		resources = append(resources, m)
+	}
+
+	if f, ok := d.GetOk("filter"); ok {
+		resources = ApplyFilters(f.(*schema.Set), resources, resourceNcloudNetworkACLDenyAllowGroup().Schema)
+	}
+
+	d.SetId(time.Now().UTC().String())
+	if err := d.Set("network_acl_deny_allow_groups", resources); err != nil {
+		return fmt.Errorf("error setting NetworkAclDenyAllowGroups: %s", err)
+	}
+
+	return nil
+}

--- a/ncloud/data_source_ncloud_network_deny_allow_groups_test.go
+++ b/ncloud/data_source_ncloud_network_deny_allow_groups_test.go
@@ -1,0 +1,52 @@
+package ncloud
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccDataSourceNcloudNetworkACLDenyAllowGroups_basic(t *testing.T) {
+	name := fmt.Sprintf("tf-ds-nacl-allow-basic-%s", acctest.RandString(5))
+	resourceName := "ncloud_network_acl_deny_allow_group.this"
+	dataName := "data.ncloud_network_acl_deny_allow_groups.by_id"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudNetworkACLDenyAllowGroupsConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceID(dataName),
+					resource.TestCheckResourceAttrPair(dataName, "network_acl_deny_allow_groups.0.id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataName, "network_acl_deny_allow_groups.0.network_acl_deny_allow_group_no", resourceName, "network_acl_deny_allow_group_no"),
+					resource.TestCheckResourceAttrPair(dataName, "network_acl_deny_allow_groups.0.name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataName, "network_acl_deny_allow_groups.0.description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataName, "network_acl_deny_allow_groups.0.vpc_no", resourceName, "vpc_no"),
+					resource.TestCheckResourceAttrPair(dataName, "network_acl_deny_allow_groups.0.ip_list", resourceName, "ip_list"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceNcloudNetworkACLDenyAllowGroupsConfig(name string) string {
+	return fmt.Sprintf(`
+resource "ncloud_vpc" "this" {
+	name               = "%[1]s"
+	ipv4_cidr_block    = "10.4.0.0/16"
+}
+
+resource "ncloud_network_acl_deny_allow_group" "this" {
+  vpc_no = ncloud_vpc.this.id
+  name        = "%[1]s"
+  ip_list     = ["10.0.0.1", "10.0.0.2"]
+}
+
+data "ncloud_network_acl_deny_allow_groups" "by_id" {
+  network_acl_deny_allow_group_no_list = [ncloud_network_acl_deny_allow_group.this.id]
+}
+`, name)
+}

--- a/ncloud/resource_ncloud_network_acl_deny_allow_group.go
+++ b/ncloud/resource_ncloud_network_acl_deny_allow_group.go
@@ -51,6 +51,7 @@ func resourceNcloudNetworkACLDenyAllowGroup() *schema.Resource {
 			"ip_list": {
 				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				MaxItems: 100,
 				Optional: true,
 				Computed: true,
 			},

--- a/ncloud/resource_ncloud_network_acl_deny_allow_group.go
+++ b/ncloud/resource_ncloud_network_acl_deny_allow_group.go
@@ -1,0 +1,258 @@
+package ncloud
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"log"
+	"time"
+
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func init() {
+	RegisterResource("ncloud_network_acl_deny_allow_group", resourceNcloudNetworkACLDenyAllowGroup())
+}
+
+func resourceNcloudNetworkACLDenyAllowGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNcloudNetworkACLDenyAllowGroupCreate,
+		Read:   resourceNcloudNetworkACLDenyAllowGroupRead,
+		Update: resourceNcloudNetworkACLDenyAllowGroupUpdate,
+		Delete: resourceNcloudNetworkACLDenyAllowGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"network_acl_deny_allow_group_no": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_no": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Optional:         true,
+				Computed:         true,
+				ValidateDiagFunc: ToDiagFunc(validateInstanceName),
+			},
+			"description": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateDiagFunc: ToDiagFunc(validation.StringLenBetween(0, 1000)),
+			},
+			"ip_list": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNcloudNetworkACLDenyAllowGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*ProviderConfig)
+
+	if !config.SupportVPC {
+		return NotSupportClassic("resource `ncloud_network_acl_deny_allow_group`")
+	}
+
+	reqParams := &vpc.CreateNetworkAclDenyAllowGroupRequest{
+		RegionCode: &config.RegionCode,
+		VpcNo:      ncloud.String(d.Get("vpc_no").(string))}
+
+	if v, ok := d.GetOk("name"); ok {
+		reqParams.NetworkAclDenyAllowGroupName = ncloud.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		reqParams.NetworkAclDenyAllowGroupDescription = ncloud.String(v.(string))
+	}
+
+	logCommonRequest("CreateNetworkAclDenyAllowGroup", reqParams)
+	resp, err := config.Client.vpc.V2Api.CreateNetworkAclDenyAllowGroup(reqParams)
+	if err != nil {
+		logErrorResponse("CreateNetworkAclDenyAllowGroup", err, reqParams)
+		return err
+	}
+
+	logResponse("CreateNetworkAclDenyAllowGroup", resp)
+
+	instance := resp.NetworkAclDenyAllowGroupList[0]
+	d.SetId(*instance.NetworkAclDenyAllowGroupNo)
+	log.Printf("[INFO] Network ACL DenyAllowGroup ID: %s", d.Id())
+
+	if err := waitForVpcNetworkAclDenyAllowGroupState(config, d.Id(), []string{InstanceStatusInit, InstanceStatusCreate}, []string{InstanceStatusRunning}, DefaultCreateTimeout); err != nil {
+		return err
+	}
+
+	if err := setNetworkAclDenyAllowGroupIpList(d, config); err != nil {
+		return err
+	}
+
+	if err := waitForVpcNetworkAclDenyAllowGroupState(config, d.Id(), []string{InstanceStatusSetting}, []string{InstanceStatusRunning}, DefaultCreateTimeout); err != nil {
+		return err
+	}
+
+	return resourceNcloudNetworkACLDenyAllowGroupRead(d, meta)
+}
+
+func resourceNcloudNetworkACLDenyAllowGroupRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*ProviderConfig)
+
+	instance, err := getNetworkAclDenyAllowGroupDetail(config, d.Id())
+	if err != nil {
+		return err
+	}
+
+	if instance == nil {
+		d.SetId("")
+		return nil
+	}
+
+	m := map[string]interface{}{
+		"id":                              *instance.NetworkAclDenyAllowGroupNo,
+		"network_acl_deny_allow_group_no": *instance.NetworkAclDenyAllowGroupNo,
+		"vpc_no":                          *instance.VpcNo,
+		"name":                            *instance.NetworkAclDenyAllowGroupName,
+		"description":                     *instance.NetworkAclDenyAllowGroupDescription,
+		"ip_list":                         instance.IpList,
+	}
+
+	SetSingularResourceDataFromMapSchema(resourceNcloudNetworkACLDenyAllowGroup(), d, m)
+
+	return nil
+}
+
+func resourceNcloudNetworkACLDenyAllowGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*ProviderConfig)
+
+	if d.HasChange("ip_list") {
+		if err := setNetworkAclDenyAllowGroupIpList(d, config); err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("description") {
+		if err := setNetworkAclDenyAllowGroupDescription(d, config); err != nil {
+			return err
+		}
+	}
+
+	if err := waitForVpcNetworkAclDenyAllowGroupState(config, d.Id(), []string{InstanceStatusSetting}, []string{InstanceStatusRunning}, DefaultTimeout); err != nil {
+		return err
+	}
+
+	return resourceNcloudNetworkACLDenyAllowGroupRead(d, meta)
+}
+
+func resourceNcloudNetworkACLDenyAllowGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*ProviderConfig)
+
+	reqParams := &vpc.DeleteNetworkAclDenyAllowGroupRequest{
+		RegionCode:                 &config.RegionCode,
+		NetworkAclDenyAllowGroupNo: ncloud.String(d.Id()),
+	}
+
+	logCommonRequest("DeleteNetworkAclDenyAllowGroup", reqParams)
+	resp, err := config.Client.vpc.V2Api.DeleteNetworkAclDenyAllowGroup(reqParams)
+	if err != nil {
+		logErrorResponse("DeleteNetworkAclDenyAllowGroup", err, reqParams)
+		return err
+	}
+
+	logResponse("DeleteNetworkAclDenyAllowGroup", resp)
+
+	if err := waitForVpcNetworkAclDenyAllowGroupState(config, d.Id(), []string{InstanceStatusRunning, InstanceStatusTerminating}, []string{InstanceStatusTerminated}, DefaultTimeout); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func waitForVpcNetworkAclDenyAllowGroupState(config *ProviderConfig, id string, pending []string, target []string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: pending,
+		Target:  target,
+		Refresh: func() (interface{}, string, error) {
+			instance, err := getNetworkAclDenyAllowGroupDetail(config, id)
+			return VpcCommonStateRefreshFunc(instance, err, "NetworkAclDenyAllowGroupStatus")
+		},
+		Timeout:    timeout,
+		Delay:      2 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("error waiting for NetworkAclDenyAllowGroupStatus (%s) to become (%v): %s", id, target, err)
+	}
+
+	return nil
+}
+
+func getNetworkAclDenyAllowGroupDetail(config *ProviderConfig, id string) (*vpc.NetworkAclDenyAllowGroup, error) {
+	reqParams := &vpc.GetNetworkAclDenyAllowGroupDetailRequest{
+		RegionCode:                 &config.RegionCode,
+		NetworkAclDenyAllowGroupNo: &id,
+	}
+
+	logCommonRequest("GetNetworkAclDenyAllowGroupDetail", reqParams)
+	resp, err := config.Client.vpc.V2Api.GetNetworkAclDenyAllowGroupDetail(reqParams)
+	if err != nil {
+		logErrorResponse("GetNetworkAclDenyAllowGroupDetail", err, reqParams)
+		return nil, err
+	}
+	logResponse("GetNetworkAclDenyAllowGroupDetail", resp)
+
+	if len(resp.NetworkAclDenyAllowGroupList) > 0 {
+		instance := resp.NetworkAclDenyAllowGroupList[0]
+		return instance, nil
+	}
+
+	return nil, nil
+}
+
+func setNetworkAclDenyAllowGroupDescription(d *schema.ResourceData, config *ProviderConfig) error {
+	reqParams := &vpc.SetNetworkAclDenyAllowGroupDescriptionRequest{
+		RegionCode:                          &config.RegionCode,
+		NetworkAclDenyAllowGroupNo:          ncloud.String(d.Id()),
+		NetworkAclDenyAllowGroupDescription: StringPtrOrNil(d.GetOk("description")),
+	}
+
+	logCommonRequest("SetNetworkAclDenyAllowGroupDescription", reqParams)
+	resp, err := config.Client.vpc.V2Api.SetNetworkAclDenyAllowGroupDescription(reqParams)
+	if err != nil {
+		logErrorResponse("SetNetworkAclDenyAllowGroupDescription", err, reqParams)
+		return err
+	}
+	logResponse("SetNetworkAclDenyAllowGroupDescription", resp)
+
+	return nil
+}
+
+func setNetworkAclDenyAllowGroupIpList(d *schema.ResourceData, config *ProviderConfig) error {
+	reqParams := &vpc.SetNetworkAclDenyAllowGroupIpListRequest{
+		RegionCode:                 &config.RegionCode,
+		NetworkAclDenyAllowGroupNo: ncloud.String(d.Id()),
+		IpList:                     ncloud.StringInterfaceList(d.Get("ip_list").([]interface{})),
+	}
+
+	logCommonRequest("SetNetworkAclDenyAllowGroupIpList", reqParams)
+	resp, err := config.Client.vpc.V2Api.SetNetworkAclDenyAllowGroupIpList(reqParams)
+	if err != nil {
+		logErrorResponse("SetNetworkAclDenyAllowGroupIpList", err, reqParams)
+		return err
+	}
+	logResponse("SetNetworkAclDenyAllowGroupIpList", resp)
+
+	return nil
+}

--- a/ncloud/resource_ncloud_network_acl_deny_allow_group_test.go
+++ b/ncloud/resource_ncloud_network_acl_deny_allow_group_test.go
@@ -1,0 +1,230 @@
+package ncloud
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccResourceNcloudNetworkACLDenyAllowGroup_basic(t *testing.T) {
+	var networkAclDenyAllowGroup vpc.NetworkAclDenyAllowGroup
+	name := fmt.Sprintf("tf-nacl-allow-basic-%s", acctest.RandString(5))
+	resourceName := "ncloud_network_acl_deny_allow_group.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkACLDenyAllowGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNcloudNetworkACLDenyAllowGroupConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLDenyAllowGroupExists(resourceName, &networkAclDenyAllowGroup),
+					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchResourceAttr(resourceName, "network_acl_deny_allow_group_no", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "ip_list.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceNcloudNetworkACLDenyAllowGroup_disappears(t *testing.T) {
+	var networkAclDenyAllowGroup vpc.NetworkAclDenyAllowGroup
+	name := fmt.Sprintf("tf-nacl-allow-ds-%s", acctest.RandString(5))
+	resourceName := "ncloud_network_acl_deny_allow_group.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkACLDenyAllowGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNcloudNetworkACLDenyAllowGroupConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLDenyAllowGroupExists(resourceName, &networkAclDenyAllowGroup),
+					testAccCheckNetworkACLDenyAllowGroupDisappears(&networkAclDenyAllowGroup),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceNcloudNetworkACLDenyAllowGroup_update(t *testing.T) {
+	var networkAclDenyAllowGroup vpc.NetworkAclDenyAllowGroup
+	name := fmt.Sprintf("tf-nacl-allow-update-%s", acctest.RandString(5))
+	resourceName := "ncloud_network_acl_deny_allow_group.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkACLDenyAllowGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNcloudNetworkACLDenyAllowGroupConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLDenyAllowGroupExists(resourceName, &networkAclDenyAllowGroup),
+					resource.TestCheckResourceAttr(resourceName, "ip_list.#", "2"),
+				),
+			},
+			{
+				Config: testAccResourceNcloudNetworkACLDenyAllowGroupConfigUpdateIpList(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLDenyAllowGroupExists(resourceName, &networkAclDenyAllowGroup),
+					resource.TestCheckResourceAttr(resourceName, "ip_list.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceNcloudNetworkACLDenyAllowGroup_description(t *testing.T) {
+	var networkAclDenyAllowGroup vpc.NetworkAclDenyAllowGroup
+	name := fmt.Sprintf("tf-nacl-allow-desc-%s", acctest.RandString(5))
+	resourceName := "ncloud_network_acl_deny_allow_group.this"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkACLDenyAllowGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNcloudNetworkACLDenyAllowGroupConfigDescription(name, "foo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLDenyAllowGroupExists(resourceName, &networkAclDenyAllowGroup),
+					resource.TestCheckResourceAttr(resourceName, "description", "foo"),
+				),
+			},
+			{
+				Config: testAccResourceNcloudNetworkACLDenyAllowGroupConfigDescription(name, "bar"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkACLDenyAllowGroupExists(resourceName, &networkAclDenyAllowGroup),
+					resource.TestCheckResourceAttr(resourceName, "description", "bar"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccResourceNcloudNetworkACLDenyAllowGroupConfig(name string) string {
+	return testAccResourceNcloudNetworkACLDenyAllowGroupConfigDescription(name, "for test acc")
+}
+
+func testAccResourceNcloudNetworkACLDenyAllowGroupConfigDescription(name, description string) string {
+	return fmt.Sprintf(`
+resource "ncloud_vpc" "vpc" {
+	name            = "%[1]s"
+	ipv4_cidr_block = "10.3.0.0/16"
+}
+
+resource "ncloud_network_acl_deny_allow_group" "this" {
+	vpc_no      = ncloud_vpc.vpc.vpc_no
+	name        = "%[1]s"
+	description = "%[2]s"
+	ip_list     = ["10.0.0.1", "10.0.0.2"]
+}
+`, name, description)
+}
+
+func testAccResourceNcloudNetworkACLDenyAllowGroupConfigUpdateIpList(name string) string {
+	return fmt.Sprintf(`
+resource "ncloud_vpc" "vpc" {
+	name            = "%[1]s"
+	ipv4_cidr_block = "10.3.0.0/16"
+}
+
+resource "ncloud_network_acl_deny_allow_group" "this" {
+	vpc_no      = ncloud_vpc.vpc.vpc_no
+	name        = "%[1]s"
+	description = "for test acc"
+	ip_list     = ["10.0.0.1"]
+}
+`, name)
+}
+
+func testAccCheckNetworkACLDenyAllowGroupExists(n string, networkACL *vpc.NetworkAclDenyAllowGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No NetworkAclDenyAllowGroup id is set: %s", n)
+		}
+
+		config := testAccProvider.Meta().(*ProviderConfig)
+		instance, err := getNetworkAclDenyAllowGroupDetail(config, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*networkACL = *instance
+
+		return nil
+	}
+}
+
+func testAccCheckNetworkACLDenyAllowGroupDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*ProviderConfig)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ncloud_network_acl" {
+			continue
+		}
+
+		instance, err := getNetworkAclDenyAllowGroupDetail(config, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if instance != nil {
+			return errors.New("NetworkAclDenyAllowGroup still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckNetworkACLDenyAllowGroupDisappears(instance *vpc.NetworkAclDenyAllowGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*ProviderConfig)
+
+		reqParams := &vpc.DeleteNetworkAclDenyAllowGroupRequest{
+			RegionCode:                 &config.RegionCode,
+			NetworkAclDenyAllowGroupNo: instance.NetworkAclDenyAllowGroupNo,
+		}
+
+		_, err := config.Client.vpc.V2Api.DeleteNetworkAclDenyAllowGroup(reqParams)
+
+		if err := waitForNcloudNetworkACLDeletion(config, *instance.NetworkAclDenyAllowGroupNo); err != nil {
+			return err
+		}
+
+		return err
+	}
+}

--- a/ncloud/resource_ncloud_network_acl_rule.go
+++ b/ncloud/resource_ncloud_network_acl_rule.go
@@ -2,9 +2,10 @@ package ncloud
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
@@ -46,8 +47,12 @@ func resourceNcloudNetworkACLRule() *schema.Resource {
 						},
 						"ip_block": {
 							Type:             schema.TypeString,
-							Required:         true,
+							Optional:         true,
 							ValidateDiagFunc: ToDiagFunc(validation.IsCIDRNetwork(0, 32)),
+						},
+						"deny_allow_group_no": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"rule_action": {
 							Type:             schema.TypeString,
@@ -87,8 +92,12 @@ func resourceNcloudNetworkACLRule() *schema.Resource {
 						},
 						"ip_block": {
 							Type:             schema.TypeString,
-							Required:         true,
+							Optional:         true,
 							ValidateDiagFunc: ToDiagFunc(validation.IsCIDRNetwork(0, 32)),
+						},
+						"deny_allow_group_no": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"rule_action": {
 							Type:             schema.TypeString,
@@ -155,12 +164,13 @@ func resourceNcloudNetworkACLRuleRead(d *schema.ResourceData, meta interface{}) 
 
 	for _, r := range rules {
 		m := map[string]interface{}{
-			"priority":    int(*r.Priority),
-			"protocol":    *r.ProtocolType.Code,
-			"port_range":  *r.PortRange,
-			"rule_action": *r.RuleAction.Code,
-			"ip_block":    *r.IpBlock,
-			"description": *r.NetworkAclRuleDescription,
+			"priority":            int(*r.Priority),
+			"protocol":            *r.ProtocolType.Code,
+			"port_range":          *r.PortRange,
+			"rule_action":         *r.RuleAction.Code,
+			"ip_block":            *r.IpBlock,
+			"deny_allow_group_no": *r.DenyAllowGroupNo,
+			"description":         *r.NetworkAclRuleDescription,
 		}
 
 		if *r.NetworkAclRuleType.Code == "INBND" {
@@ -405,6 +415,7 @@ func expandAddNetworkAclRule(rules []interface{}) []*vpc.AddNetworkAclRuleParame
 		m := vi.(map[string]interface{})
 		networkACLRule := &vpc.AddNetworkAclRuleParameter{
 			IpBlock:                   ncloud.String(m["ip_block"].(string)),
+			DenyAllowGroupNo:          ncloud.String(m["deny_allow_group_no"].(string)),
 			RuleActionCode:            ncloud.String(m["rule_action"].(string)),
 			Priority:                  ncloud.Int32(int32(m["priority"].(int))),
 			ProtocolTypeCode:          ncloud.String(m["protocol"].(string)),
@@ -425,6 +436,7 @@ func expandRemoveNetworkAclRule(rules []interface{}) []*vpc.RemoveNetworkAclRule
 		m := vi.(map[string]interface{})
 		networkACLRule := &vpc.RemoveNetworkAclRuleParameter{
 			IpBlock:          ncloud.String(m["ip_block"].(string)),
+			DenyAllowGroupNo: ncloud.String(m["deny_allow_group_no"].(string)),
 			RuleActionCode:   ncloud.String(m["rule_action"].(string)),
 			Priority:         ncloud.Int32(int32(m["priority"].(int))),
 			ProtocolTypeCode: ncloud.String(m["protocol"].(string)),


### PR DESCRIPTION
### Overview
Implement Deny-Allow Group

#### Examples
```hcl
resource "ncloud_network_acl_deny_allow_group" "allow_group" {
  vpc_no         = ncloud_vpc.vpc.id
  // below fields is optional
  name      = "allow-group-test" 
  description = "by terraform"
  ip_list = ["10.0.0.1", "10.0.0.2"]
}

resource "ncloud_vpc" "vpc" {
   ipv4_cidr_block = "10.0.0.0/16"
 }
 
resource "ncloud_network_acl" "nacl" {
   vpc_no      = ncloud_vpc.vpc.id
}
 
resource "ncloud_network_acl_rule" "nacl_rule" {
  network_acl_no    = ncloud_network_acl.nacl.id

  inbound {
    priority    = 110
    protocol    = "TCP"
    rule_action = "ALLOW"
    deny_allow_group_no = ncloud_network_acl_deny_allow_group.allow_group.id
    port_range  = "22"
  }
}
```

### Issues
- resolve #195 

### Test results
#### Resources
```
=== RUN   TestAccResourceNcloudNetworkACLDenyAllowGroup_basic
--- PASS: TestAccResourceNcloudNetworkACLDenyAllowGroup_basic (49.74s)
=== RUN   TestAccResourceNcloudNetworkACLDenyAllowGroup_disappears
--- PASS: TestAccResourceNcloudNetworkACLDenyAllowGroup_disappears (47.23s)
=== RUN   TestAccResourceNcloudNetworkACLDenyAllowGroup_update
--- PASS: TestAccResourceNcloudNetworkACLDenyAllowGroup_update (76.40s)
=== RUN   TestAccResourceNcloudNetworkACLDenyAllowGroup_description
--- PASS: TestAccResourceNcloudNetworkACLDenyAllowGroup_description (57.19s)
PASS
```

#### Data source
```
=== RUN   TestAccDataSourceNcloudNetworkACLDenyAllowGroups_basic
--- PASS: TestAccDataSourceNcloudNetworkACLDenyAllowGroups_basic (48.28s)
PASS
```