### PR TITLE
Fix `ncloud_network_acl_deny_allow_group` property

### DIFF
--- a/docs/data-sources/network_acl_deny_allow_groups.md
+++ b/docs/data-sources/network_acl_deny_allow_groups.md
@@ -64,6 +64,6 @@ supports the following:
 * `id` - The ID of Deny-Allow Group.
 * `network_acl_deny_allow_group_no` - The ID of Deny-Allow Group. (It is the same result as `id`)
 * `vpc_no` - The ID of the associated VPC.
+* `ip_list` - list of IP address that registered in the Deny-Allow Group.
 * `name` - The name of Deny-Allow Group.
 * `description` - Description of Deny-Allow Group.
-* `ip_list` - list of IP address that registered in the Deny-Allow Group.

--- a/docs/resources/network_acl_deny_allow_group.md
+++ b/docs/resources/network_acl_deny_allow_group.md
@@ -43,10 +43,10 @@ resource "ncloud_network_acl_rule" "nacl_rule" {
 The following arguments are supported:
 
 * `vpc_no` - (Required) The ID of the associated VPC.
+* `ip_list` - (Required) Enter the IP addresses as list to be registered in the Deny-Allow Group.
+  Up to 100 IPs can be registered. Duplicate IP addresses are not allowed.
 * `name` - (Optional) The name to create. If omitted, terraform will assign a random, unique name.
 * `description` - (Optional) Description to create
-* `ip_list` - (Optional) Enter the IP addresses as list to be registered in the Deny-Allow Group. 
-  Up to 100 IPs can be registered. Duplicate IP addresses are not allowed.
 
 ## Attributes Reference
 

--- a/ncloud/convert_types.go
+++ b/ncloud/convert_types.go
@@ -3,6 +3,7 @@ package ncloud
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"reflect"
 	"strings"
 
@@ -254,4 +255,21 @@ func ConvertToArrayMap(i interface{}) []map[string]interface{} {
 	json.Unmarshal(b, &m)
 
 	return m
+}
+
+//ExpandStringSet Takes the result of schema.Set of strings and returns a []*string
+func ExpandStringSet(configured *schema.Set) []*string {
+	return ExpandStringList(configured.List())
+}
+
+//ExpandStringList Takes the result of flatmap.Expand for an array of strings and returns a []*string
+func ExpandStringList(configured []interface{}) []*string {
+	vs := make([]*string, 0, len(configured))
+	for _, v := range configured {
+		val, ok := v.(string)
+		if ok && val != "" {
+			vs = append(vs, ncloud.String(v.(string)))
+		}
+	}
+	return vs
 }

--- a/ncloud/resource_ncloud_network_acl_deny_allow_group.go
+++ b/ncloud/resource_ncloud_network_acl_deny_allow_group.go
@@ -49,11 +49,11 @@ func resourceNcloudNetworkACLDenyAllowGroup() *schema.Resource {
 				ValidateDiagFunc: ToDiagFunc(validation.StringLenBetween(0, 1000)),
 			},
 			"ip_list": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 				MaxItems: 100,
-				Optional: true,
-				Computed: true,
+				Required: true,
 			},
 		},
 	}
@@ -244,7 +244,7 @@ func setNetworkAclDenyAllowGroupIpList(d *schema.ResourceData, config *ProviderC
 	reqParams := &vpc.SetNetworkAclDenyAllowGroupIpListRequest{
 		RegionCode:                 &config.RegionCode,
 		NetworkAclDenyAllowGroupNo: ncloud.String(d.Id()),
-		IpList:                     ncloud.StringInterfaceList(d.Get("ip_list").([]interface{})),
+		IpList:                     ExpandStringSet(d.Get("ip_list").(*schema.Set)),
 	}
 
 	logCommonRequest("SetNetworkAclDenyAllowGroupIpList", reqParams)


### PR DESCRIPTION
- change `ip_list` type to `schema.TypeSet` and `Required`

#### Test results
```
=== RUN   TestAccResourceNcloudNetworkACLDenyAllowGroup_basic
--- PASS: TestAccResourceNcloudNetworkACLDenyAllowGroup_basic (49.18s)
=== RUN   TestAccResourceNcloudNetworkACLDenyAllowGroup_disappears
--- PASS: TestAccResourceNcloudNetworkACLDenyAllowGroup_disappears (46.59s)
=== RUN   TestAccResourceNcloudNetworkACLDenyAllowGroup_update
--- PASS: TestAccResourceNcloudNetworkACLDenyAllowGroup_update (66.28s)
=== RUN   TestAccResourceNcloudNetworkACLDenyAllowGroup_description
--- PASS: TestAccResourceNcloudNetworkACLDenyAllowGroup_description (57.07s)
PASS

```