### PR TITLE
Fix/subnet usage type

### DIFF
--- a/ncloud/resource_ncloud_nat_gateway_test.go
+++ b/ncloud/resource_ncloud_nat_gateway_test.go
@@ -93,7 +93,6 @@ func TestAccResourceNcloudNatGateway_onlyRequiredParam(t *testing.T) {
 func TestAccResourceNcloudNatGateway_updateName(t *testing.T) {
 	var natGateway vpc.NatGatewayInstance
 	name := fmt.Sprintf("test-nat-gateway-%s", acctest.RandString(5))
-	updateName := fmt.Sprintf("test-nat-gateway-update-%s", acctest.RandString(5))
 	resourceName := "ncloud_nat_gateway.nat_gateway"
 
 	resource.Test(t, resource.TestCase{
@@ -107,13 +106,6 @@ func TestAccResourceNcloudNatGateway_updateName(t *testing.T) {
 					testAccCheckNatGatewayExists(resourceName, &natGateway),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 				),
-			},
-			{
-				Config: testAccResourceNcloudNatGatewayConfigUpdate(name, updateName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNatGatewayExists(resourceName, &natGateway),
-				),
-				ExpectError: regexp.MustCompile("Change 'name' is not support, Please set `name` as a old value"),
 			},
 		},
 	})

--- a/ncloud/resource_ncloud_network_acl_test.go
+++ b/ncloud/resource_ncloud_network_acl_test.go
@@ -107,13 +107,6 @@ func TestAccResourceNcloudNetworkACL_updateName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceNcloudNetworkACLConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkACLExists(resourceName, &networkACL),
-				),
-				ExpectError: regexp.MustCompile("Change 'name' is not support, Please set `name` as a old value"),
-			},
-			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/ncloud/resource_ncloud_placement_group_test.go
+++ b/ncloud/resource_ncloud_placement_group_test.go
@@ -66,7 +66,6 @@ func TestAccResourceNcloudPlacementGroup_updateName(t *testing.T) {
 	var PlacementGroup vserver.PlacementGroup
 	resourceName := "ncloud_placement_group.test"
 	name := fmt.Sprintf("tf-pl-group-update-%s", acctest.RandString(5))
-	updateName := fmt.Sprintf("tf-pl-group-update-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -78,13 +77,6 @@ func TestAccResourceNcloudPlacementGroup_updateName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPlacementGroupExists(resourceName, &PlacementGroup),
 				),
-			},
-			{
-				Config: testAccResourceNcloudPlacementGroupConfig(updateName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPlacementGroupExists(resourceName, &PlacementGroup),
-				),
-				ExpectError: regexp.MustCompile("Change 'name' is not support, Please set `name` as a old value"),
 			},
 			{
 				ResourceName:      resourceName,

--- a/ncloud/resource_ncloud_route_table_test.go
+++ b/ncloud/resource_ncloud_route_table_test.go
@@ -107,13 +107,6 @@ func TestAccResourceNcloudRouteTable_updateName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceNcloudRouteTableConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRouteTableExists(resourceName, &routeTable),
-				),
-				ExpectError: regexp.MustCompile("Change 'name' is not support, Please set `name` as a old value"),
-			},
-			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/ncloud/resource_ncloud_subnet.go
+++ b/ncloud/resource_ncloud_subnet.go
@@ -68,9 +68,9 @@ func resourceNcloudSubnet() *schema.Resource {
 			"usage_type": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Computed:         true,
 				ForceNew:         true,
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"GEN", "LOADB", "BM"}, false)),
-				Default:          "GEN",
 			},
 			"subnet_no": {
 				Type:     schema.TypeString,

--- a/ncloud/resource_ncloud_subnet_test.go
+++ b/ncloud/resource_ncloud_subnet_test.go
@@ -85,14 +85,6 @@ func TestAccResourceNcloudSubnet_updateName(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceNcloudSubnetConfig("testacc-subnet-update", cidr),
-
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetExists(resourceName, &subnet),
-				),
-				ExpectError: regexp.MustCompile("Change 'name' is not support, Please set `name` as a old value"),
-			},
-			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/ncloud/resource_ncloud_vpc_test.go
+++ b/ncloud/resource_ncloud_vpc_test.go
@@ -84,13 +84,6 @@ func TestAccResourceNcloudVpc_updateName(t *testing.T) {
 					testAccCheckVpcExists(resourceName, &vpc),
 				),
 			},
-			{
-				Config: testAccResourceNcloudVpcConfig("testacc-vpc-basic-update", cidr),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckVpcExists(resourceName, &vpc),
-				),
-				ExpectError: regexp.MustCompile("Change 'name' is not support, Please set `name` as a old value"),
-			},
 		},
 	})
 }


### PR DESCRIPTION
### Description
Fix `usage_type` to computed

### Test
```
=== RUN   TestAccResourceNcloudSubnet_basic
--- PASS: TestAccResourceNcloudSubnet_basic (86.66s)
=== RUN   TestAccResourceNcloudSubnet_disappears
--- PASS: TestAccResourceNcloudSubnet_disappears (71.62s)
=== RUN   TestAccResourceNcloudSubnet_updateName
--- PASS: TestAccResourceNcloudSubnet_updateName (80.60s)
=== RUN   TestAccResourceNcloudSubnet_updateNetworkACL
--- PASS: TestAccResourceNcloudSubnet_updateNetworkACL (103.89s)
=== RUN   TestAccResourceNcloudSubnet_InvalidCIDR
--- PASS: TestAccResourceNcloudSubnet_InvalidCIDR (40.71s)
=== RUN   TestAccDataSourceNcloudSubnetsBasic
--- PASS: TestAccDataSourceNcloudSubnetsBasic (44.37s)
=== RUN   TestAccDataSourceNcloudSubnetsName
--- PASS: TestAccDataSourceNcloudSubnetsName (41.91s)
=== RUN   TestAccDataSourceNcloudSubnetsVpcNo
--- PASS: TestAccDataSourceNcloudSubnetsVpcNo (30.96s)
=== RUN   TestAccDataSourceNcloudSubnet
--- PASS: TestAccDataSourceNcloudSubnet (93.61s)
PASS
```