### PR TITLE
update: nks public subnet support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-ncloud
 go 1.16
 
 require (
-	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.4.0
+	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.4.5
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.4.0 h1:maRRO1Rg9XqbVR9a6qyn8hLY2a7UW+ze+4+TpsuBPnU=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.4.0/go.mod h1:7+Hx3TCfPW8HE0ycOH4UJqkTEq7uZeYyk+N1FCDR4LA=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.4.5 h1:xEdtdMqIsMa6HZKq2c5VQkXpQh9jm7cDXzIMU8x9eWo=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.4.5/go.mod h1:KWd9AT+YSM6qgsMzPnE23h2/r0bsPSIdJzZIg3BUcfI=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
@@ -51,6 +51,7 @@ github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXva
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+kXDxro6ErPXBRTJ/ro2mf0SsFG8s7doP9kJE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=

--- a/ncloud/data_source_ncloud_nks_cluster.go
+++ b/ncloud/data_source_ncloud_nks_cluster.go
@@ -49,6 +49,10 @@ func dataSourceNcloudNKSCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"public_network": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"subnet_no_list": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -115,7 +119,12 @@ func dataSourceNcloudNKSClusterRead(ctx context.Context, d *schema.ResourceData,
 	if cluster.LbPublicSubnetNo != nil {
 		d.Set("lb_public_subnet_no", strconv.Itoa(int(ncloud.Int32Value(cluster.LbPublicSubnetNo))))
 	}
-
+	if cluster.PublicNetwork != nil {
+		d.Set("public_network", cluster.PublicNetwork)
+	}
+	if err := d.Set("log", flattenNKSClusterLogInput(cluster.Log)); err != nil {
+		log.Printf("[WARN] Error setting cluster log for (%s): %s", d.Id(), err)
+	}
 	if err := d.Set("subnet_no_list", flattenInt32ListToStringList(cluster.SubnetNoList)); err != nil {
 		log.Printf("[WARN] Error setting subet no list set for (%s): %s", d.Id(), err)
 	}

--- a/ncloud/data_source_ncloud_nks_cluster_test.go
+++ b/ncloud/data_source_ncloud_nks_cluster_test.go
@@ -12,15 +12,15 @@ func TestAccDataSourceNcloudNKSCluster(t *testing.T) {
 	dataName := "data.ncloud_nks_cluster.cluster"
 	resourceName := "ncloud_nks_cluster.cluster"
 	testClusterName := getTestClusterName()
-	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
 	k8sVersion := "1.21"
+	region, clusterType, _ := getRegionAndNKSType()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNKSClusterConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
+				Config: testAccDataSourceNKSClusterConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "id", resourceName, "id"),
@@ -44,7 +44,7 @@ func TestAccDataSourceNcloudNKSCluster(t *testing.T) {
 	})
 }
 
-func testAccDataSourceNKSClusterConfig(testClusterName string, clusterType string, loginKey string, version string) string {
+func testAccDataSourceNKSClusterConfig(testClusterName string, clusterType string, loginKey string, version string, region string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -55,7 +55,7 @@ resource "ncloud_subnet" "subnet1" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-1"
 	subnet             = "10.2.1.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -65,7 +65,7 @@ resource "ncloud_subnet" "subnet2" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-2"
 	subnet             = "10.2.2.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -75,7 +75,7 @@ resource "ncloud_subnet" "subnet_lb" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-lb"
 	subnet             = "10.2.100.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "LOADB"
@@ -101,7 +101,7 @@ resource "ncloud_nks_cluster" "cluster" {
     ncloud_subnet.subnet2.id,
   ]
   vpc_no                      = ncloud_vpc.vpc.vpc_no
-  zone                     	  = "KR-1"
+  zone                     	  = "%[5]s-1"
 }
 
 data "ncloud_nks_cluster" "cluster" {
@@ -109,5 +109,5 @@ data "ncloud_nks_cluster" "cluster" {
 }
 
 
-`, testClusterName, clusterType, loginKey, version)
+`, testClusterName, clusterType, loginKey, version, region)
 }

--- a/ncloud/data_source_ncloud_nks_kube_config_test.go
+++ b/ncloud/data_source_ncloud_nks_kube_config_test.go
@@ -13,13 +13,14 @@ func TestAccDataSourceNcloudNKSKubeConfig(t *testing.T) {
 	resourceName := "ncloud_nks_cluster.cluster"
 	testClusterName := getTestClusterName()
 	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
+	k8sVersion := "1.21"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNKSKubeConfigConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY),
+				Config: testAccDataSourceNKSKubeConfigConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "cluster_uuid", resourceName, "uuid"),
@@ -30,7 +31,7 @@ func TestAccDataSourceNcloudNKSKubeConfig(t *testing.T) {
 	})
 }
 
-func testAccDataSourceNKSKubeConfigConfig(testClusterName string, clusterType string, loginKey string) string {
+func testAccDataSourceNKSKubeConfigConfig(testClusterName string, clusterType string, loginKey string, version string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -67,8 +68,13 @@ resource "ncloud_subnet" "subnet_lb" {
 	usage_type         = "LOADB"
 }
 
-data "ncloud_nks_versions" "version" {
 
+data "ncloud_nks_versions" "version" {
+  filter {
+    name = "value"
+    values = ["%[4]s"]
+    regex = true
+  }
 }
 
 resource "ncloud_nks_cluster" "cluster" {
@@ -90,5 +96,5 @@ data "ncloud_nks_kube_config" "kube_config" {
 }
 
 
-`, testClusterName, clusterType, loginKey)
+`, testClusterName, clusterType, loginKey, version)
 }

--- a/ncloud/data_source_ncloud_nks_node_pool_test.go
+++ b/ncloud/data_source_ncloud_nks_node_pool_test.go
@@ -13,13 +13,14 @@ func TestAccDataSourceNcloudNKSNodePool(t *testing.T) {
 	resourceName := "ncloud_nks_node_pool.node_pool"
 	testClusterName := getTestClusterName()
 	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
+	k8sVersion := "1.21"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNKSNodePoolConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY),
+				Config: testAccDataSourceNKSNodePoolConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "cluster_uuid", resourceName, "cluster_uuid"),
@@ -38,7 +39,7 @@ func TestAccDataSourceNcloudNKSNodePool(t *testing.T) {
 	})
 }
 
-func testAccDataSourceNKSNodePoolConfig(testClusterName string, clusterType string, loginKey string) string {
+func testAccDataSourceNKSNodePoolConfig(testClusterName string, clusterType string, loginKey string, version string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -66,7 +67,11 @@ resource "ncloud_subnet" "subnet_lb" {
 }
 
 data "ncloud_nks_versions" "version" {
-
+  filter {
+    name = "value"
+    values = ["%[4]s"]
+    regex = true
+  }
 }
 
 resource "ncloud_nks_cluster" "cluster" {
@@ -99,5 +104,5 @@ data "ncloud_nks_node_pool" "node_pool"{
   cluster_uuid   = ncloud_nks_node_pool.node_pool.cluster_uuid
   node_pool_name = ncloud_nks_node_pool.node_pool.node_pool_name
 }
-`, testClusterName, clusterType, loginKey)
+`, testClusterName, clusterType, loginKey, version)
 }

--- a/ncloud/data_source_ncloud_nks_node_pool_test.go
+++ b/ncloud/data_source_ncloud_nks_node_pool_test.go
@@ -2,7 +2,6 @@ package ncloud
 
 import (
 	"fmt"
-
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -12,15 +11,16 @@ func TestAccDataSourceNcloudNKSNodePool(t *testing.T) {
 	dataName := "data.ncloud_nks_node_pool.node_pool"
 	resourceName := "ncloud_nks_node_pool.node_pool"
 	testClusterName := getTestClusterName()
-	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
 	k8sVersion := "1.21"
+
+	region, clusterType, productType := getRegionAndNKSType()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNKSNodePoolConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
+				Config: testAccDataSourceNKSNodePoolConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region, productType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID(dataName),
 					resource.TestCheckResourceAttrPair(dataName, "cluster_uuid", resourceName, "cluster_uuid"),
@@ -39,7 +39,7 @@ func TestAccDataSourceNcloudNKSNodePool(t *testing.T) {
 	})
 }
 
-func testAccDataSourceNKSNodePoolConfig(testClusterName string, clusterType string, loginKey string, version string) string {
+func testAccDataSourceNKSNodePoolConfig(testClusterName string, clusterType string, loginKey string, version string, region string, productType string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -50,7 +50,7 @@ resource "ncloud_subnet" "subnet1" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-1"
 	subnet             = "10.2.1.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -60,7 +60,7 @@ resource "ncloud_subnet" "subnet_lb" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-lb"
 	subnet             = "10.2.100.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "LOADB"
@@ -84,14 +84,14 @@ resource "ncloud_nks_cluster" "cluster" {
     ncloud_subnet.subnet1.id
   ]
   vpc_no                      = ncloud_vpc.vpc.vpc_no
-  zone                     	  = "KR-1"
+  zone                     	  = "%[5]s-1"
 }
 
 resource "ncloud_nks_node_pool" "node_pool" {
   cluster_uuid = ncloud_nks_cluster.cluster.uuid
   node_pool_name = "%[1]s"
   node_count     = 1
-  product_code   = "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
+  product_code   = "%[6]s"
   subnet_no      = ncloud_subnet.subnet1.id 
   autoscale {
     enabled = true
@@ -104,5 +104,5 @@ data "ncloud_nks_node_pool" "node_pool"{
   cluster_uuid   = ncloud_nks_node_pool.node_pool.cluster_uuid
   node_pool_name = ncloud_nks_node_pool.node_pool.node_pool_name
 }
-`, testClusterName, clusterType, loginKey, version)
+`, testClusterName, clusterType, loginKey, version, region, productType)
 }

--- a/ncloud/data_source_ncloud_nks_node_pools_test.go
+++ b/ncloud/data_source_ncloud_nks_node_pools_test.go
@@ -10,15 +10,16 @@ import (
 func TestAccDataSourceNcloudNKSNodePools(t *testing.T) {
 
 	testClusterName := getTestClusterName()
-	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
 	k8sVersion := "1.21"
+
+	region, clusterType, productType := getRegionAndNKSType()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudNKSNodePoolsConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
+				Config: testAccDataSourceNcloudNKSNodePoolsConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region, productType),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_nks_node_pools.all"),
 				),
@@ -27,7 +28,7 @@ func TestAccDataSourceNcloudNKSNodePools(t *testing.T) {
 	})
 }
 
-func testAccDataSourceNcloudNKSNodePoolsConfig(testClusterName string, clusterType string, loginKey string, version string) string {
+func testAccDataSourceNcloudNKSNodePoolsConfig(testClusterName string, clusterType string, loginKey string, version string, region string, productType string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -38,7 +39,7 @@ resource "ncloud_subnet" "subnet1" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-1"
 	subnet             = "10.2.1.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -48,7 +49,7 @@ resource "ncloud_subnet" "subnet2" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-2"
 	subnet             = "10.2.2.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -58,7 +59,7 @@ resource "ncloud_subnet" "subnet_lb" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-lb"
 	subnet             = "10.2.100.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "LOADB"
@@ -83,14 +84,14 @@ resource "ncloud_nks_cluster" "cluster" {
     ncloud_subnet.subnet2.id,
   ]
   vpc_no                      = ncloud_vpc.vpc.vpc_no
-  zone                        = "KR-1"
+  zone                        = "%[5]s-1"
 }
 
 resource "ncloud_nks_node_pool" "node_pool" {
   cluster_uuid = ncloud_nks_cluster.cluster.uuid
   node_pool_name = "%[1]s"
   node_count     = 1
-  product_code   = "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
+  product_code   = "%[6]s"
   subnet_no      = ncloud_subnet.subnet1.id 
   autoscale {
     enabled = true
@@ -102,5 +103,5 @@ resource "ncloud_nks_node_pool" "node_pool" {
 data "ncloud_nks_node_pools" "all" {
 	cluster_uuid = ncloud_nks_cluster.cluster.uuid
 }
-`, testClusterName, clusterType, loginKey, version)
+`, testClusterName, clusterType, loginKey, version, region, productType)
 }

--- a/ncloud/data_source_ncloud_nks_node_pools_test.go
+++ b/ncloud/data_source_ncloud_nks_node_pools_test.go
@@ -11,13 +11,14 @@ func TestAccDataSourceNcloudNKSNodePools(t *testing.T) {
 
 	testClusterName := getTestClusterName()
 	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
+	k8sVersion := "1.21"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudNKSNodePoolsConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY),
+				Config: testAccDataSourceNcloudNKSNodePoolsConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceID("data.ncloud_nks_node_pools.all"),
 				),
@@ -26,7 +27,7 @@ func TestAccDataSourceNcloudNKSNodePools(t *testing.T) {
 	})
 }
 
-func testAccDataSourceNcloudNKSNodePoolsConfig(testClusterName string, clusterType string, loginKey string) string {
+func testAccDataSourceNcloudNKSNodePoolsConfig(testClusterName string, clusterType string, loginKey string, version string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -64,7 +65,13 @@ resource "ncloud_subnet" "subnet_lb" {
 }
 
 data "ncloud_nks_versions" "version" {
+  filter {
+    name = "value"
+    values = ["%[4]s"]
+    regex = true
+  }
 }
+
 resource "ncloud_nks_cluster" "cluster" {
   name                        = "%[1]s"
   cluster_type                = "%[2]s"
@@ -95,5 +102,5 @@ resource "ncloud_nks_node_pool" "node_pool" {
 data "ncloud_nks_node_pools" "all" {
 	cluster_uuid = ncloud_nks_cluster.cluster.uuid
 }
-`, testClusterName, clusterType, loginKey)
+`, testClusterName, clusterType, loginKey, version)
 }

--- a/ncloud/resource_ncloud_nks_cluster_test.go
+++ b/ncloud/resource_ncloud_nks_cluster_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vnks"
+	"os"
 	"regexp"
 	"testing"
 
@@ -19,9 +20,10 @@ const TF_TEST_NKS_LOGIN_KEY = "tf-test-nks-login-key"
 func TestAccResourceNcloudNKSCluster_basic(t *testing.T) {
 	var cluster vnks.Cluster
 	name := getTestClusterName()
-	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
 	k8sVersion := "1.21"
 	resourceName := "ncloud_nks_cluster.cluster"
+
+	region, clusterType, _ := getRegionAndNKSType()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -29,14 +31,14 @@ func TestAccResourceNcloudNKSCluster_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceNcloudNKSClusterConfig(name, clusterType, k8sVersion, TF_TEST_NKS_LOGIN_KEY),
+				Config: testAccResourceNcloudNKSClusterConfig(name, clusterType, k8sVersion, TF_TEST_NKS_LOGIN_KEY, region),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNKSClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cluster_type", clusterType),
 					resource.TestMatchResourceAttr(resourceName, "k8s_version", regexp.MustCompile(k8sVersion)),
 					resource.TestCheckResourceAttr(resourceName, "login_key_name", TF_TEST_NKS_LOGIN_KEY),
-					resource.TestCheckResourceAttr(resourceName, "zone", "KR-1"),
+					resource.TestCheckResourceAttr(resourceName, "zone", fmt.Sprintf("%s-1", region)),
 					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
 				),
 			},
@@ -52,9 +54,10 @@ func TestAccResourceNcloudNKSCluster_basic(t *testing.T) {
 func TestAccResourceNcloudNKSCluster_public_network(t *testing.T) {
 	var cluster vnks.Cluster
 	name := getTestClusterName()
-	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
 	k8sVersion := "1.21"
 	resourceName := "ncloud_nks_cluster.cluster"
+
+	region, clusterType, _ := getRegionAndNKSType()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -62,15 +65,15 @@ func TestAccResourceNcloudNKSCluster_public_network(t *testing.T) {
 		CheckDestroy: testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceNcloudNKSClusterPublicNetworkConfig(name, clusterType, k8sVersion, TF_TEST_NKS_LOGIN_KEY),
+				Config: testAccResourceNcloudNKSClusterPublicNetworkConfig(name, clusterType, k8sVersion, TF_TEST_NKS_LOGIN_KEY, region),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNKSClusterExists(resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "cluster_type", clusterType),
 					resource.TestMatchResourceAttr(resourceName, "k8s_version", regexp.MustCompile(k8sVersion)),
 					resource.TestCheckResourceAttr(resourceName, "login_key_name", TF_TEST_NKS_LOGIN_KEY),
-					resource.TestCheckResourceAttr(resourceName, "zone", "KR-1"),
 					resource.TestCheckResourceAttr(resourceName, "public_network", "true"),
+					resource.TestCheckResourceAttr(resourceName, "zone", fmt.Sprintf("%s-1", region)),
 					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
 				),
 			},
@@ -85,8 +88,9 @@ func TestAccResourceNcloudNKSCluster_public_network(t *testing.T) {
 
 func TestAccResourceNcloudNKSCluster_InvalidSubnet(t *testing.T) {
 	name := getTestClusterName()
-	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
 	k8sVersion := "1.21"
+
+	region, clusterType, _ := getRegionAndNKSType()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -94,14 +98,14 @@ func TestAccResourceNcloudNKSCluster_InvalidSubnet(t *testing.T) {
 		CheckDestroy: testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceNcloudNKSCluster_InvalidSubnetConfig(name, clusterType, k8sVersion, TF_TEST_NKS_LOGIN_KEY),
+				Config:      testAccResourceNcloudNKSCluster_InvalidSubnetConfig(name, clusterType, k8sVersion, TF_TEST_NKS_LOGIN_KEY, region),
 				ExpectError: regexp.MustCompile("중 하나여야 합니다."),
 			},
 		},
 	})
 }
 
-func testAccResourceNcloudNKSClusterConfig(name string, clusterType string, k8sVersion string, loginKeyName string) string {
+func testAccResourceNcloudNKSClusterConfig(name string, clusterType string, k8sVersion string, loginKeyName string, region string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -112,7 +116,7 @@ resource "ncloud_subnet" "subnet1" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-1"
 	subnet             = "10.2.1.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -122,7 +126,7 @@ resource "ncloud_subnet" "subnet2" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-2"
 	subnet             = "10.2.2.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -132,7 +136,7 @@ resource "ncloud_subnet" "subnet_lb" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-lb"
 	subnet             = "10.2.100.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "LOADB"
@@ -158,12 +162,12 @@ resource "ncloud_nks_cluster" "cluster" {
     ncloud_subnet.subnet2.id,
   ]
   vpc_no                      = ncloud_vpc.vpc.vpc_no
-  zone                        = "KR-1"
+  zone                        = "%[5]s-1"
 }
-`, name, clusterType, k8sVersion, loginKeyName)
+`, name, clusterType, k8sVersion, loginKeyName, region)
 }
 
-func testAccResourceNcloudNKSClusterPublicNetworkConfig(name string, clusterType string, k8sVersion string, loginKeyName string) string {
+func testAccResourceNcloudNKSClusterPublicNetworkConfig(name string, clusterType string, k8sVersion string, loginKeyName string, region string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -174,7 +178,7 @@ resource "ncloud_subnet" "subnet1" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-1"
 	subnet             = "10.2.1.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PUBLIC"
 	usage_type         = "GEN"
@@ -184,7 +188,7 @@ resource "ncloud_subnet" "subnet2" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-2"
 	subnet             = "10.2.2.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PUBLIC"
 	usage_type         = "GEN"
@@ -194,7 +198,7 @@ resource "ncloud_subnet" "subnet_lb" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-lb"
 	subnet             = "10.2.100.0/24"
-	zone               = "KR-1"
+	zone               = "%[5]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "LOADB"
@@ -221,12 +225,12 @@ resource "ncloud_nks_cluster" "cluster" {
     ncloud_subnet.subnet2.id,
   ]
   vpc_no                      = ncloud_vpc.vpc.vpc_no
-  zone                        = "KR-1"
+  zone                        = "%[5]s-1"
 }
-`, name, clusterType, k8sVersion, loginKeyName)
+`, name, clusterType, k8sVersion, loginKeyName, region)
 }
 
-func testAccResourceNcloudNKSCluster_InvalidSubnetConfig(name string, clusterType string, k8sVersion string, loginKeyName string) string {
+func testAccResourceNcloudNKSCluster_InvalidSubnetConfig(name string, clusterType string, k8sVersion string, loginKeyName string, region string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -237,7 +241,7 @@ resource "ncloud_subnet" "subnet1" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-1"
 	subnet             = "10.2.1.0/24"
-	zone               = "KR-2"
+	zone               = "%[5]s-2"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -247,7 +251,7 @@ resource "ncloud_subnet" "subnet2" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-2"
 	subnet             = "10.2.2.0/24"
-	zone               = "KR-2"
+	zone               = "%[5]s-2"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -257,7 +261,7 @@ resource "ncloud_subnet" "subnet_lb" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-lb"
 	subnet             = "10.2.100.0/24"
-	zone               = "KR-2"
+	zone               = "%[5]s-2"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "LOADB"
@@ -283,12 +287,12 @@ resource "ncloud_nks_cluster" "cluster" {
     ncloud_subnet.subnet2.id,
   ]
   vpc_no                      = ncloud_vpc.vpc.vpc_no
-  zone                        = "KR-1"
+  zone                        = "%[5]s-1"
   log {
 	audit = true
   }
 }
-`, name, clusterType, k8sVersion, loginKeyName)
+`, name, clusterType, k8sVersion, loginKeyName, region)
 }
 
 func testAccCheckNKSClusterExists(n string, cluster *vnks.Cluster) resource.TestCheckFunc {
@@ -341,4 +345,16 @@ func getTestClusterName() string {
 	rInt := acctest.RandIntRange(1, 9999)
 	testClusterName := fmt.Sprintf("tf-%d-cluster", rInt)
 	return testClusterName
+}
+
+func getRegionAndNKSType() (region string, clusterType string, productType string) {
+	region = os.Getenv("NCLOUD_REGION")
+	if region == "FKR" {
+		clusterType = "SVR.VNKS.STAND.C002.M008.NET.HDD.B050.G001"
+		productType = "SVR.VSVR.STAND.C002.M004.NET.SSD.B050.G001"
+	} else {
+		clusterType = "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
+		productType = "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
+	}
+	return
 }

--- a/ncloud/resource_ncloud_nks_node_pool_test.go
+++ b/ncloud/resource_ncloud_nks_node_pool_test.go
@@ -16,10 +16,9 @@ import (
 func TestAccResourceNcloudNKSNodePool_basic(t *testing.T) {
 	var nodePool vnks.NodePoolRes
 	clusterName := getTestClusterName()
-	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
-	productCode := "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
 	resourceName := "ncloud_nks_node_pool.node_pool"
 	k8sVersion := "1.21"
+	region, clusterType, productCode := getRegionAndNKSType()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,7 +26,7 @@ func TestAccResourceNcloudNKSNodePool_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceNcloudNKSNodePoolConfig(clusterName, clusterType, productCode, 1, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
+				Config: testAccResourceNcloudNKSNodePoolConfig(clusterName, clusterType, productCode, 1, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNKSNodePoolExists(resourceName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "node_pool_name", clusterName),
@@ -47,10 +46,9 @@ func TestAccResourceNcloudNKSNodePool_basic(t *testing.T) {
 func TestAccResourceNcloudNKSNodePool_publicNetwork(t *testing.T) {
 	var nodePool vnks.NodePoolRes
 	clusterName := getTestClusterName()
-	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
-	productCode := "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
 	resourceName := "ncloud_nks_node_pool.node_pool"
 	k8sVersion := "1.21"
+	region, clusterType, productCode := getRegionAndNKSType()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -58,7 +56,7 @@ func TestAccResourceNcloudNKSNodePool_publicNetwork(t *testing.T) {
 		CheckDestroy: testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceNcloudNKSNodePoolConfigPublicNetwork(clusterName, clusterType, productCode, 1, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
+				Config: testAccResourceNcloudNKSNodePoolConfigPublicNetwork(clusterName, clusterType, productCode, 1, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNKSNodePoolExists(resourceName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "node_pool_name", clusterName),
@@ -78,8 +76,7 @@ func TestAccResourceNcloudNKSNodePool_publicNetwork(t *testing.T) {
 func TestAccResourceNcloudNKSNodePool_updateNodeCountAndAutoScale(t *testing.T) {
 	var nodePool vnks.NodePoolRes
 	clusterName := getTestClusterName()
-	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
-	productCode := "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
+	region, clusterType, productCode := getRegionAndNKSType()
 	resourceName := "ncloud_nks_node_pool.node_pool"
 	k8sVersion := "1.21"
 
@@ -89,7 +86,7 @@ func TestAccResourceNcloudNKSNodePool_updateNodeCountAndAutoScale(t *testing.T) 
 		CheckDestroy: testAccCheckNKSNodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceNcloudNKSNodePoolConfig(clusterName, clusterType, productCode, 1, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
+				Config: testAccResourceNcloudNKSNodePoolConfig(clusterName, clusterType, productCode, 1, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNKSNodePoolExists(resourceName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "node_count", "1"),
@@ -97,7 +94,7 @@ func TestAccResourceNcloudNKSNodePool_updateNodeCountAndAutoScale(t *testing.T) 
 				Destroy: false,
 			},
 			{
-				Config: testAccResourceNcloudNKSNodePoolUpdateAutoScaleConfig(clusterName, clusterType, productCode, 2, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
+				Config: testAccResourceNcloudNKSNodePoolUpdateAutoScaleConfig(clusterName, clusterType, productCode, 2, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNKSNodePoolExists(resourceName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "node_count", "2"),
@@ -117,8 +114,7 @@ func TestAccResourceNcloudNKSNodePool_updateNodeCountAndAutoScale(t *testing.T) 
 
 func TestAccResourceNcloudNKSNodePool_invalidNodeCount(t *testing.T) {
 	clusterName := getTestClusterName()
-	clusterType := "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
-	productCode := "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
+	region, clusterType, productCode := getRegionAndNKSType()
 	k8sVersion := "1.21"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -127,14 +123,14 @@ func TestAccResourceNcloudNKSNodePool_invalidNodeCount(t *testing.T) {
 		CheckDestroy: testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceNcloudNKSNodePoolConfig(clusterName, clusterType, productCode, 0, TF_TEST_NKS_LOGIN_KEY, k8sVersion),
+				Config:      testAccResourceNcloudNKSNodePoolConfig(clusterName, clusterType, productCode, 0, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region),
 				ExpectError: regexp.MustCompile("nodeCount must not be less than 1"),
 			},
 		},
 	})
 }
 
-func testAccResourceNcloudNKSNodePoolConfig(name string, clusterType string, productCode string, nodeCount int, loginKey string, version string) string {
+func testAccResourceNcloudNKSNodePoolConfig(name string, clusterType string, productCode string, nodeCount int, loginKey string, version string, region string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -145,7 +141,7 @@ resource "ncloud_subnet" "subnet" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s"
 	subnet             = "10.2.1.0/24"
-	zone               = "KR-1"
+	zone               = "%[7]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -155,7 +151,7 @@ resource "ncloud_subnet" "subnet_lb" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-lb"
 	subnet             = "10.2.100.0/24"
-	zone               = "KR-1"
+	zone               = "%[7]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "LOADB"
@@ -179,7 +175,7 @@ resource "ncloud_nks_cluster" "cluster" {
     ncloud_subnet.subnet.id,
   ]
   vpc_no                      = ncloud_vpc.vpc.vpc_no
-  zone                        = "KR-1"
+  zone                        = "%[7]s-1"
 }
 
 resource "ncloud_nks_node_pool" "node_pool" {
@@ -195,10 +191,10 @@ resource "ncloud_nks_node_pool" "node_pool" {
   }
 }
 
-`, name, clusterType, productCode, nodeCount, loginKey, version)
+`, name, clusterType, productCode, nodeCount, loginKey, version, region)
 }
 
-func testAccResourceNcloudNKSNodePoolConfigPublicNetwork(name string, clusterType string, productCode string, nodeCount int, loginKey string, version string) string {
+func testAccResourceNcloudNKSNodePoolConfigPublicNetwork(name string, clusterType string, productCode string, nodeCount int, loginKey string, version string, region string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -209,7 +205,7 @@ resource "ncloud_subnet" "subnet" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s"
 	subnet             = "10.2.1.0/24"
-	zone               = "KR-1"
+	zone               = "%[7]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PUBLIC"
 	usage_type         = "GEN"
@@ -219,7 +215,7 @@ resource "ncloud_subnet" "subnet_lb" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-lb"
 	subnet             = "10.2.100.0/24"
-	zone               = "KR-1"
+	zone               = "%[7]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "LOADB"
@@ -243,7 +239,7 @@ resource "ncloud_nks_cluster" "cluster" {
     ncloud_subnet.subnet.id,
   ]
   vpc_no                      = ncloud_vpc.vpc.vpc_no
-  zone                        = "KR-1"
+  zone                        = "%[7]s-1"
   public_network              = true
 }
 
@@ -260,10 +256,10 @@ resource "ncloud_nks_node_pool" "node_pool" {
   }
 }
 
-`, name, clusterType, productCode, nodeCount, loginKey, version)
+`, name, clusterType, productCode, nodeCount, loginKey, version, region)
 }
 
-func testAccResourceNcloudNKSNodePoolUpdateAutoScaleConfig(name string, clusterType string, productCode string, nodeCount int, loginkey string, version string) string {
+func testAccResourceNcloudNKSNodePoolUpdateAutoScaleConfig(name string, clusterType string, productCode string, nodeCount int, loginKey string, version string, region string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {
 	name               = "%[1]s"
@@ -274,7 +270,7 @@ resource "ncloud_subnet" "subnet" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s"
 	subnet             = "10.2.1.0/24"
-	zone               = "KR-1"
+	zone               = "%[7]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "GEN"
@@ -284,7 +280,7 @@ resource "ncloud_subnet" "subnet_lb" {
 	vpc_no             = ncloud_vpc.vpc.vpc_no
 	name               = "%[1]s-lb"
 	subnet             = "10.2.100.0/24"
-	zone               = "KR-1"
+	zone               = "%[7]s-1"
 	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
 	subnet_type        = "PRIVATE"
 	usage_type         = "LOADB"
@@ -308,7 +304,7 @@ resource "ncloud_nks_cluster" "cluster" {
     ncloud_subnet.subnet.id,
   ]
   vpc_no                      = ncloud_vpc.vpc.vpc_no
-  zone                        = "KR-1"
+  zone                        = "%[7]s-1"
 }
 
 resource "ncloud_nks_node_pool" "node_pool" {
@@ -323,7 +319,7 @@ resource "ncloud_nks_node_pool" "node_pool" {
     max = 2
   }
 }
-`, name, clusterType, productCode, nodeCount, loginkey, version)
+`, name, clusterType, productCode, nodeCount, loginKey, version, region)
 }
 
 func testAccCheckNKSNodePoolExists(n string, nodePool *vnks.NodePoolRes) resource.TestCheckFunc {

--- a/ncloud/resource_ncloud_nks_node_pool_test.go
+++ b/ncloud/resource_ncloud_nks_node_pool_test.go
@@ -158,7 +158,7 @@ resource "ncloud_nks_cluster" "cluster" {
   ]
   vpc_no                      = ncloud_vpc.vpc.vpc_no
   zone                        = "KR-1"
-  public_network              = "%[6]t"
+  public_network              = "%[7]t"
 }
 
 resource "ncloud_nks_node_pool" "node_pool" {

--- a/ncloud/structures.go
+++ b/ncloud/structures.go
@@ -337,6 +337,17 @@ func flattenInt32ListToStringList(list []*int32) (res []*string) {
 	return
 }
 
+func flattenNKSClusterLogInput(logInput *vnks.ClusterLogInput) []map[string]interface{} {
+	if logInput == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"audit": ncloud.BoolValue(logInput.Audit),
+		},
+	}
+}
 func expandNKSClusterLogInput(logList []interface{}) *vnks.ClusterLogInput {
 	if len(logList) == 0 {
 		return nil

--- a/ncloud/structures_test.go
+++ b/ncloud/structures_test.go
@@ -715,6 +715,21 @@ func TestFlattenInt32ListToStringList(t *testing.T) {
 	}
 }
 
+func TestFlattenNKSClusterLogInput(t *testing.T) {
+	logInput := &vnks.ClusterLogInput{Audit: ncloud.Bool(true)}
+
+	result := flattenNKSClusterLogInput(logInput)
+
+	if result == nil {
+		t.Fatal("result was nil")
+	}
+
+	r := result[0]
+	if r["audit"].(bool) != true {
+		t.Fatalf("expected result enabled to be true, but was %v", r["enabled"])
+	}
+}
+
 func TestExpandNKSClusterLogInput(t *testing.T) {
 	log := []interface{}{
 		map[string]interface{}{


### PR DESCRIPTION
https://github.com/NaverCloudPlatform/terraform-provider-ncloud/issues/210

### Overview
Support NKS Public Subnet

#### Examples
```hcl
resource "ncloud_vpc" "vpc" {
  name            = "tf-test-vpc"
  ipv4_cidr_block = "10.0.0.0/16"
}

resource "ncloud_subnet" "subnet" {
  vpc_no         = ncloud_vpc.vpc.id
  subnet         = "10.0.1.0/24"
  zone           = "KR-1"
  network_acl_no = ncloud_vpc.vpc.default_network_acl_no
  subnet_type    = "PUBLIC"
  name           = "tf-subnet-01"
  usage_type     = "GEN" 
}

resource "ncloud_subnet" "subnet_lb_priv" {
  vpc_no         = ncloud_vpc.vpc.id
  subnet         = "10.0.100.0/24"
  zone           = "KR-1"
  network_acl_no = ncloud_vpc.vpc.default_network_acl_no
  subnet_type    = "PRIVATE"
  name           = "tf-subnet-lb-priv"
  usage_type     = "LOADB"   
}

data "ncloud_nks_versions" "version" {

}


resource "ncloud_nks_cluster" "cluster" {
  cluster_type                = "SVR.VNKS.STAND.C002.M008.NET.SSD.B050.G002"
  k8s_version                 = data.ncloud_nks_versions.version.versions.0.value
  login_key_name              = "pub"
  name                        = "tf-cluster-1"
  lb_private_subnet_no        = ncloud_subnet.subnet_lb_priv.id
  kube_network_plugin         = "cilium"
  public_network              = true
  subnet_no_list              = [ ncloud_subnet.subnet.id ]
  vpc_no                      = ncloud_vpc.vpc.id
  zone                        = "KR-1"
  log {
    audit = true
  }
}

resource "ncloud_nks_node_pool" "node_pool" {
  cluster_uuid   = ncloud_nks_cluster.cluster.uuid
  node_pool_name = "sample-nodepool"
  node_count     = 2
  product_code   = "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
  subnet_no      =  ncloud_subnet.subnet.id 
  autoscale {
    enabled = true
    min = 1
    max = 2
  }
}

```

### Issues
- resolve #210 

### Test results
```
=== RUN   TestAccDataSourceNcloudNKSCluster
=== PAUSE TestAccDataSourceNcloudNKSCluster
=== CONT  TestAccDataSourceNcloudNKSCluster
=== RUN   TestAccDataSourceNcloudNKSClusters
=== PAUSE TestAccDataSourceNcloudNKSClusters
=== RUN   TestAccDataSourceNcloudNKSKubeConfig
=== PAUSE TestAccDataSourceNcloudNKSKubeConfig
=== RUN   TestAccDataSourceNcloudNKSNodePool
=== PAUSE TestAccDataSourceNcloudNKSNodePool
=== RUN   TestAccDataSourceNcloudNKSNodePools
=== PAUSE TestAccDataSourceNcloudNKSNodePools
=== RUN   TestAccResourceNcloudNKSCluster_basic
=== PAUSE TestAccResourceNcloudNKSCluster_basic
=== RUN   TestAccResourceNcloudNKSCluster_public_network
=== PAUSE TestAccResourceNcloudNKSCluster_public_network
=== RUN   TestAccResourceNcloudNKSCluster_InvalidSubnet
=== PAUSE TestAccResourceNcloudNKSCluster_InvalidSubnet
=== RUN   TestAccResourceNcloudNKSNodePool_basic
=== PAUSE TestAccResourceNcloudNKSNodePool_basic
=== CONT  TestAccResourceNcloudNKSNodePool_basic
=== RUN   TestAccResourceNcloudNKSNodePool_publicNetwork
=== PAUSE TestAccResourceNcloudNKSNodePool_publicNetwork
=== CONT  TestAccResourceNcloudNKSNodePool_publicNetwork
=== RUN   TestAccResourceNcloudNKSNodePool_updateNodeCountAndAutoScale
=== PAUSE TestAccResourceNcloudNKSNodePool_updateNodeCountAndAutoScale
=== CONT  TestAccResourceNcloudNKSNodePool_updateNodeCountAndAutoScale
=== RUN   TestAccResourceNcloudNKSNodePool_invalidNodeCount
=== PAUSE TestAccResourceNcloudNKSNodePool_invalidNodeCount
=== CONT  TestAccResourceNcloudNKSNodePool_invalidNodeCount
=== RUN   TestFlattenNKSClusterLogInput
--- PASS: TestFlattenNKSClusterLogInput (0.00s)
=== RUN   TestExpandNKSClusterLogInput
--- PASS: TestExpandNKSClusterLogInput (0.00s)
=== RUN   TestFlattenNKSNodePoolAutoscale
--- PASS: TestFlattenNKSNodePoolAutoscale (0.00s)
=== RUN   TestExpandNKSNodePoolAutoScale
--- PASS: TestExpandNKSNodePoolAutoScale (0.00s)
=== CONT  TestAccResourceNcloudNKSCluster_InvalidSubnet
--- PASS: TestAccResourceNcloudNKSNodePool_invalidNodeCount (1503.30s)
--- PASS: TestAccDataSourceNcloudNKSCluster (1508.84s)
=== CONT  TestAccDataSourceNcloudNKSNodePool
--- PASS: TestAccResourceNcloudNKSCluster_InvalidSubnet (87.34s)
=== CONT  TestAccResourceNcloudNKSCluster_basic
--- PASS: TestAccResourceNcloudNKSNodePool_basic (2628.03s)
=== CONT  TestAccDataSourceNcloudNKSNodePools
--- PASS: TestAccResourceNcloudNKSNodePool_publicNetwork (2678.95s)
=== CONT  TestAccDataSourceNcloudNKSKubeConfig
--- PASS: TestAccResourceNcloudNKSCluster_basic (1545.03s)
=== CONT  TestAccDataSourceNcloudNKSClusters
--- PASS: TestAccDataSourceNcloudNKSClusters (6.00s)
=== CONT  TestAccResourceNcloudNKSCluster_public_network
--- PASS: TestAccResourceNcloudNKSNodePool_updateNodeCountAndAutoScale (3677.06s)
--- PASS: TestAccDataSourceNcloudNKSKubeConfig (1463.85s)
--- PASS: TestAccDataSourceNcloudNKSNodePool (2744.04s)
--- PASS: TestAccResourceNcloudNKSCluster_public_network (1484.56s)
--- PASS: TestAccDataSourceNcloudNKSNodePools (2651.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ncloud/ncloud	5280.135s

```