### PR TITLE
Temporarily fix goreleaser version to v1.8.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,7 +40,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v1.8.3
           args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
### Description
Temporarily fix the goreleaser version to v1.8.3
latest version is [v1.9.0](https://github.com/goreleaser/goreleaser/releases/tag/v1.9.0) but it doesn't work