### PR TITLE
fix readme terraform logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
+<img src="https://cdn.jsdelivr.net/gh/hashicorp/terraform-website@master/public/img/logo-hashicorp.svg" width="600px">
 
 ## Requirements
 


### PR DESCRIPTION
## Changes
- [rawgit](https://rawgit.com/) was deprecated, so replace it with jsdelivr (already being redirected to jsdelivr)
- fix logo image path
