### PR TITLE
Public ip fix

### DIFF
--- a/ncloud/resource_ncloud_public_ip.go
+++ b/ncloud/resource_ncloud_public_ip.go
@@ -174,7 +174,7 @@ func resourceNcloudPublicIpUpdate(d *schema.ResourceData, meta interface{}) erro
 				if err := associatedPublicIp(d, config); err != nil {
 					errBody, _ := GetCommonErrorBody(err)
 					if errBody.ReturnCode == "1003016" {
-						time.Sleep(1)
+						time.Sleep(time.Second * 1)
 						return resource.RetryableError(err)
 					}
 					return resource.NonRetryableError(err)

--- a/ncloud/resource_ncloud_public_ip.go
+++ b/ncloud/resource_ncloud_public_ip.go
@@ -192,17 +192,6 @@ func resourceNcloudPublicIpUpdate(d *schema.ResourceData, meta interface{}) erro
 				}); err != nil {
 					return err
 				}
-				// for i := 0; i < 3; i++ {
-				// 	if err = associatedPublicIp(d, config); err != nil {
-				// 		errBody, _ := GetCommonErrorBody(err)
-				// 		if errBody.ReturnCode != "1003016" {
-				// 			return err
-				// 		}
-				// 	} else {
-				// 		break
-				// 	}
-				// 	time.Sleep(1)
-				// }
 			} else if isAssociated {
 				if instance, err := getPublicIp(config, d.Id()); *instance.ServerInstanceNo != n.(string) {
 					d.Set("server_instance_no", "")

--- a/ncloud/resource_ncloud_public_ip.go
+++ b/ncloud/resource_ncloud_public_ip.go
@@ -170,7 +170,7 @@ func resourceNcloudPublicIpUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		if len(n.(string)) > 0 {
-			if err := resource.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute*time.Duration(19), func() *resource.RetryError {
+			if err := resource.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute * 19, func() *resource.RetryError {
 				if err := associatedPublicIp(d, config); err != nil {
 					errBody, _ := GetCommonErrorBody(err)
 					if errBody.ReturnCode == "1003016" {

--- a/ncloud/resource_ncloud_public_ip.go
+++ b/ncloud/resource_ncloud_public_ip.go
@@ -170,7 +170,7 @@ func resourceNcloudPublicIpUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		if len(n.(string)) > 0 {
-			if err := resource.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute*19, func() *resource.RetryError {
+			if err := resource.Retry(time.Minute, func() *resource.RetryError {
 				if err := associatedPublicIp(d, config); err != nil {
 					errBody, _ := GetCommonErrorBody(err)
 					if errBody.ReturnCode == "1003016" {

--- a/ncloud/resource_ncloud_public_ip.go
+++ b/ncloud/resource_ncloud_public_ip.go
@@ -32,7 +32,7 @@ func resourceNcloudPublicIpInstance() *schema.Resource {
 			"server_instance_no": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				// Computed: true,
 			},
 			"description": {
 				Type:             schema.TypeString,
@@ -161,13 +161,56 @@ func resourceNcloudPublicIpUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("server_instance_no") {
 		o, n := d.GetChange("server_instance_no")
 		if len(o.(string)) > 0 {
-			if err := disassociatedPublicIp(config, d.Id()); err != nil {
+			if isAssociated, err := checkAssociatedPublicIP(config, d.Id()); isAssociated {
+				if instance, err := getPublicIp(config, d.Id()); *instance.ServerInstanceNo != o.(string) {
+					d.Set("server_instance_no", o.(string))
+					return fmt.Errorf("Error since Public IP (%s) is associted with a different Server instance (%s) than the one (%s) you are trying to disassociated with.", d.Id(), *instance.ServerInstanceNo, o.(string))
+				} else if err != nil {
+					return err
+				}
+
+				if err := disassociatedPublicIp(config, d.Id()); err != nil {
+					return err
+				}
+			} else if err != nil {
 				return err
 			}
 		}
 
 		if len(n.(string)) > 0 {
-			if err := associatedPublicIp(d, config); err != nil {
+			if isAssociated, err := checkAssociatedPublicIP(config, d.Id()); !isAssociated {
+				if err := resource.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute*time.Duration(19), func() *resource.RetryError {
+					if err := associatedPublicIp(d, config); err != nil {
+						errBody, _ := GetCommonErrorBody(err)
+						if errBody.ReturnCode == "1003016" {
+							time.Sleep(1)
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				}); err != nil {
+					return err
+				}
+				// for i := 0; i < 3; i++ {
+				// 	if err = associatedPublicIp(d, config); err != nil {
+				// 		errBody, _ := GetCommonErrorBody(err)
+				// 		if errBody.ReturnCode != "1003016" {
+				// 			return err
+				// 		}
+				// 	} else {
+				// 		break
+				// 	}
+				// 	time.Sleep(1)
+				// }
+			} else if isAssociated {
+				if instance, err := getPublicIp(config, d.Id()); *instance.ServerInstanceNo != n.(string) {
+					d.Set("server_instance_no", "")
+					return fmt.Errorf("Error since Public IP (%s) is already associted with Server instance (%s).", d.Id(), *instance.ServerInstanceNo)
+				} else if err != nil {
+					return err
+				}
+			} else if err != nil {
 				return err
 			}
 		}

--- a/ncloud/resource_ncloud_public_ip.go
+++ b/ncloud/resource_ncloud_public_ip.go
@@ -170,7 +170,7 @@ func resourceNcloudPublicIpUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		if len(n.(string)) > 0 {
-			if err := resource.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute * 19, func() *resource.RetryError {
+			if err := resource.Retry(d.Timeout(schema.TimeoutDelete)-time.Minute*19, func() *resource.RetryError {
 				if err := associatedPublicIp(d, config); err != nil {
 					errBody, _ := GetCommonErrorBody(err)
 					if errBody.ReturnCode == "1003016" {


### PR DESCRIPTION
1. public ip 에 server instance no 공백 값에 대해 diff가 발생하도록 server_instance_no 스키마 값에서 Computed 옵션을 제거
2. real 환경에 맞추어 terraform code+state 셋을 적용할때 unathorized public ip error 가 발생하지 않도록 수정
3. terraform에서 public ip 를 붙이거나 뗄때 의도한 server instance no과 다른 server에 public ip 가 붙어있을 경우 에러메시지를 보여주고 state에 반영하지 않도록 수정
4. 서버에 서로다른 public ip 리소스로 교체 시 리소스 경합을 방지하기 위해 retry 로직 적용