### PR TITLE
fix_delete_nas_other_region

### DIFF
--- a/ncloud/resource_ncloud_block_storage.go
+++ b/ncloud/resource_ncloud_block_storage.go
@@ -426,6 +426,7 @@ func deleteClassicBlockStorage(d *schema.ResourceData, config *ProviderConfig, i
 
 func deleteVpcBlockStorage(d *schema.ResourceData, config *ProviderConfig, id string) error {
 	reqParams := vserver.DeleteBlockStorageInstancesRequest{
+		RegionCode:                 &config.RegionCode,
 		BlockStorageInstanceNoList: []*string{ncloud.String(id)},
 	}
 

--- a/ncloud/resource_ncloud_nas_volume.go
+++ b/ncloud/resource_ncloud_nas_volume.go
@@ -436,7 +436,10 @@ func deleteClassicNasVolume(config *ProviderConfig, id string) error {
 }
 
 func deleteVpcNasVolume(config *ProviderConfig, id string) error {
-	reqParams := &vnas.DeleteNasVolumeInstancesRequest{NasVolumeInstanceNoList: []*string{ncloud.String(id)}}
+	reqParams := &vnas.DeleteNasVolumeInstancesRequest{
+		RegionCode:              &config.RegionCode,
+		NasVolumeInstanceNoList: []*string{ncloud.String(id)},
+	}
 	logCommonRequest("deleteVpcNasVolume", reqParams)
 
 	resp, err := config.Client.vnas.V2Api.DeleteNasVolumeInstances(reqParams)


### PR DESCRIPTION
한국리전을 제외한 타 리전에서 blockstorage와 nas볼륨이 삭제가 안되어 오류를 수정

delete blockstorage, delete nas instance 의 파라메터로 리전코드 추가

테스트결과 정상 삭제됨