### PR TITLE
fix: Add to support network interface update in server

### DIFF
--- a/ncloud/data_source_ncloud_subnets.go
+++ b/ncloud/data_source_ncloud_subnets.go
@@ -46,7 +46,7 @@ func dataSourceNcloudSubnets() *schema.Resource {
 			"subnet_type": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"PUBLIC", "PRIVATE"}, false)),
+				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{SubnetTypePublic, SubnetTypePrivate}, false)),
 				Description:      "Internet Gateway Only. PUBLC(Yes/Public), PRIVATE(No/Private).",
 			},
 			"usage_type": {

--- a/ncloud/list.go
+++ b/ncloud/list.go
@@ -1,0 +1,32 @@
+package ncloud
+
+func DiffByArg(old []interface{}, new []interface{}, arg string) ([]interface{}, []interface{}) {
+	var added []interface{}
+	var deleted []interface{}
+	oldMark := make([]bool, len(old))
+	newMark := make([]bool, len(new))
+
+	for o, oldItem := range old {
+		oldItemMap := oldItem.(map[string]interface{})
+		for n, newItem := range new {
+			newItemMap := newItem.(map[string]interface{})
+			if oldItemMap[arg].(string) == newItemMap[arg].(string) {
+				oldMark[o] = true
+				newMark[n] = true
+			}
+		}
+	}
+
+	for i, noChange := range oldMark {
+		if !noChange {
+			deleted = append(deleted, old[i])
+		}
+	}
+	for i, noChange := range newMark {
+		if !noChange {
+			added = append(added, new[i])
+		}
+	}
+
+	return added, deleted
+}

--- a/ncloud/resource_ncloud_subnet.go
+++ b/ncloud/resource_ncloud_subnet.go
@@ -17,6 +17,8 @@ func init() {
 }
 
 const (
+	SubnetTypePublic              = "PUBLIC"
+	SubnetTypePrivate             = "PRIVATE"
 	SubnetPleaseTryAgainErrorCode = "3000"
 )
 
@@ -63,7 +65,7 @@ func resourceNcloudSubnet() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"PUBLIC", "PRIVATE"}, false)),
+				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{SubnetTypePublic, SubnetTypePrivate}, false)),
 			},
 			"usage_type": {
 				Type:             schema.TypeString,


### PR DESCRIPTION
When the network interface was changed, the server is regenerated. The network interface cannot be changed in a public subnet environment but this change extends the ability to add or delete network interfaces in a private subnet environment.
(Default (order=0) interface cannot be modified even on the private subnet)