### PR TITLE
fix_region_code_when_get_root_password

### DIFF
--- a/ncloud/data_source_ncloud_root_password.go
+++ b/ncloud/data_source_ncloud_root_password.go
@@ -75,6 +75,7 @@ func getClassicRootPassword(d *schema.ResourceData, config *ProviderConfig) (*st
 
 func getVpcRootPassword(d *schema.ResourceData, config *ProviderConfig) (*string, error) {
 	reqParams := &vserver.GetRootPasswordRequest{
+		RegionCode:       &config.RegionCode,
 		ServerInstanceNo: ncloud.String(d.Get("server_instance_no").(string)),
 		PrivateKey:       ncloud.String(d.Get("private_key").(string)),
 	}


### PR DESCRIPTION
added region code to datasource : ncloud_root_password -> getVpcRootPassword