### PR TITLE
fix_compute_option_launch_configuration_server_image_product_code

### DIFF
--- a/ncloud/resource_ncloud_launch_configuration.go
+++ b/ncloud/resource_ncloud_launch_configuration.go
@@ -35,6 +35,7 @@ func resourceNcloudLaunchConfiguration() *schema.Resource {
 			"server_image_product_code": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"member_server_image_no"},
 				ForceNew:      true,
 			},


### PR DESCRIPTION
`ncloud_launch_configuration`

			"server_image_product_code": {
				Type:          schema.TypeString,
				Optional:      true,
				Computed:      true,    <- added
				ConflictsWith: []string{"member_server_image_no"},
				ForceNew:      true,
			},