### PR TITLE
fix(BlockStorage): Set `ForceNew` for the name attribute

### DIFF
--- a/ncloud/resource_ncloud_block_storage.go
+++ b/ncloud/resource_ncloud_block_storage.go
@@ -54,6 +54,7 @@ func resourceNcloudBlockStorage() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"description": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
The name of BlockStorage/BlockStorageSnapShot has not been updated using Terraform. The block storage instance will be replaced in order to apply name changes.