### PR TITLE
ci: Fix to properly import gpg key by action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,7 @@ jobs:
         name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
-        env:
+        with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       -


### PR DESCRIPTION
https://github.com/crazy-max/ghaction-import-gpg을 사용하도록 변경하면서 env->with 로 변경이 누락된 부분을 업데이트합니다.