### PR TITLE
fix_some_datasource_vpc_nacl

### DIFF
--- a/docs/data-sources/vpc.md
+++ b/docs/data-sources/vpc.md
@@ -41,3 +41,5 @@ In addition to all arguments above, the following attributes are exported:
 * `ipv4_cidr_block` - The CIDR block for the association.
 * `default_network_acl_no` - The ID of the network ACL created by default on VPC creation.
 * `default_access_control_group_no` - The ID of the ACG created by default on VPC creation.
+* `default_public_route_table_no` - The ID of the Public Route Table created by default on VPC creation.
+* `default_private_route_table_no` - The ID of the Private Route Table created by default on VPC creation.

--- a/ncloud/data_source_ncloud_network_acls.go
+++ b/ncloud/data_source_ncloud_network_acls.go
@@ -18,7 +18,7 @@ func dataSourceNcloudNetworkAcls() *schema.Resource {
 		Read: dataSourceNcloudNetworkAclsRead,
 
 		Schema: map[string]*schema.Schema{
-			"network_acl_no": {
+			"network_acl_no_list": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -56,8 +56,13 @@ func dataSourceNcloudNetworkAclsRead(d *schema.ResourceData, meta interface{}) e
 		RegionCode: &config.RegionCode,
 	}
 
-	if v, ok := d.GetOk("network_acl_no"); ok {
-		reqParams.NetworkAclNoList = []*string{ncloud.String(v.(string))}
+	if v, ok := d.GetOk("network_acl_no_list"); ok {
+		// reqParams.NetworkAclNoList = []*string{ncloud.String(v.(string))}
+		list := make([]*string, 0, len(v.([]interface{})))
+		for _, v := range v.([]interface{}) {
+			list = append(list, ncloud.String(v.(string)))
+		}
+		reqParams.NetworkAclNoList = list
 	}
 
 	if v, ok := d.GetOk("name"); ok {

--- a/ncloud/data_source_ncloud_vpc.go
+++ b/ncloud/data_source_ncloud_vpc.go
@@ -1,6 +1,8 @@
 package ncloud
 
 import (
+	"fmt"
+
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -75,11 +77,29 @@ func getVpcListFiltered(d *schema.ResourceData, config *ProviderConfig) ([]map[s
 	resources := []map[string]interface{}{}
 
 	for _, r := range resp.VpcList {
+		id := *r.VpcNo
+		defaultNetworkACLNo, err := getDefaultNetworkACL(config, id)
+		if err != nil {
+			return nil, fmt.Errorf("error get default network acl for VPC (%s): %s", id, err)
+		}
+		defaultAcgNo, err := getDefaultAccessControlGroup(config, id)
+		if err != nil {
+			return nil, fmt.Errorf("error get default Access Control Group for VPC (%s): %s", id, err)
+		}
+		publicRouteTableNo, privateRouteTableNo, err := getDefaultRouteTable(config, id)
+		if err != nil {
+			return nil, fmt.Errorf("error get default Route Table for VPC (%s): %s", id, err)
+		}
+
 		instance := map[string]interface{}{
-			"id":              *r.VpcNo,
-			"vpc_no":          *r.VpcNo,
-			"name":            *r.VpcName,
-			"ipv4_cidr_block": *r.Ipv4CidrBlock,
+			"id":                              *r.VpcNo,
+			"vpc_no":                          *r.VpcNo,
+			"name":                            *r.VpcName,
+			"ipv4_cidr_block":                 *r.Ipv4CidrBlock,
+			"default_network_acl_no":          defaultNetworkACLNo,
+			"default_access_control_group_no": defaultAcgNo,
+			"default_public_route_table_no":   publicRouteTableNo,
+			"default_private_route_table_no":  privateRouteTableNo,
 		}
 
 		resources = append(resources, instance)


### PR DESCRIPTION
Fixes

1. Fixed the issue that the `network_acl_no_list` attribute was not properly processed in `Datasource: ncloud_network_acls`

2. Fixed an issue where `default_network_acl_no`, `default_access_control_group_no`, `default_public_route_table_no`, `default_private_route_table_no` could not be output normally in `Datasource: ncloud_vpc`