### PR TITLE
feat:Support NAT GW(new)

### DIFF
--- a/docs/data-sources/nat_gateway.md
+++ b/docs/data-sources/nat_gateway.md
@@ -45,6 +45,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `nat_gateway_no` - The ID of NAT gateway. (It is the same result as `id`)
 * `vpc_no` - The ID of the associated VPC.
+* `subnet_no` - The ID of the associated Subnet.
+* `subnet_name` - The name of the associated Subnet.
 * `zone` - Available zone where the NAT gateway placed.
 * `public_ip` - Public IP on NAT Gateway created.
+* `public_ip_no` - The ID of the associated Public IP.
+* `private_ip` - Private IP on NAT Gateway created.
 * `description` - Description of NAT Gateway.

--- a/docs/data-sources/subnet.md
+++ b/docs/data-sources/subnet.md
@@ -14,7 +14,7 @@ data "ncloud_subnet" "selected" {
 }
 
 resource "ncloud_access_control_group" "acg" {
- vpc_no = ncloud_subnet.selected.vpc_no
+ vpc_no = data.ncloud_subnet.selected.vpc_no
 }
 
 resource "ncloud_access_control_group_rule" "subnet-inbound-tcp-80" {
@@ -36,7 +36,7 @@ The following arguments are supported:
 * `zone` - (Optional) Available zone where the subnet will be placed physically.
 * `network_acl_no` - (Optional) The ID of Network ACL.
 * `subnet_type` - (Optional) Internet connectivity. If you use `PUBLIC`, all VMs created within Subnet will be assigned a certified IP by default and will be able to communicate directly over the Internet. Considering the characteristics of Subnet, you can choose Subnet for the purpose of use. Accepted values: `PUBLIC` (Public) | `PRIVATE` (Private).
-* `usage_type` - (Optional) Usage type, Accepted values: `GEN` (General) | `LOADB` (For load balancer) | `NATGW` (for NAT Gateway. Only pub env)..
+* `usage_type` - (Optional) Usage type, Accepted values: `GEN` (General) | `LOADB` (For LoadBalancer) | `BM` (For BareMetal) |`NATGW` (for NATGateway).
 * `filter` - (Optional) Custom filter block as described below.
   * `name` - (Required) The name of the field to filter by.
   * `values` - (Required) Set of values that are accepted for the given field.

--- a/docs/data-sources/subnets.md
+++ b/docs/data-sources/subnets.md
@@ -1,4 +1,4 @@
-# Data Source: ncloud_subnet
+# Data Source: ncloud_subnets
 
 This resource is useful for look up the list of Subnet in the region.
 
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `zone` - (Optional) Available zone where the subnet will be placed physically.
 * `network_acl_no` - (Optional) The ID of Network ACL.
 * `subnet_type` - (Optional) Internet connectivity. If you use `PUBLIC`, all VMs created within Subnet will be assigned a certified IP by default and will be able to communicate directly over the Internet. Considering the characteristics of Subnet, you can choose Subnet for the purpose of use. Accepted values: `PUBLIC` (Public) | `PRIVATE` (Private).
-* `usage_type` - (Optional) Usage type, Accepted values: `GEN` (General) | `LOADB` (For load balancer) | `NATGW` (for NAT Gateway. Only pub env).
+* `usage_type` - (Optional) Usage type, Accepted values: `GEN` (General) | `LOADB` (For LoadBalancer) | `BM` (For BareMetal) |`NATGW` (for NATGateway).
 * `filter` - (Optional) Custom filter block as described below.
   * `name` - (Required) The name of the field to filter by
   * `values` - (Required) Set of values that are accepted for the given field.

--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -4,7 +4,7 @@ Provides a NAT gateway resource.
 
 ## Example Usage
 
-### Basic Usage
+### Old Version(Subnet not associated) Usage
 
 ```hcl
 resource "ncloud_vpc" "vpc" {
@@ -22,13 +22,44 @@ resource "ncloud_nat_gateway" "nat_gateway" {
 
 ```
 
+### New Version(Subnet associated) Usage
+
+```hcl
+resource "ncloud_vpc" "vpc" {
+  name            = "vpc"
+  ipv4_cidr_block = "10.0.0.0/16"
+}
+
+resource "ncloud_subnet" "subnet" {
+  vpc_no         = ncloud_vpc.vpc.id
+  subnet         = "10.0.1.0/24"
+  zone           = "KR-2"
+  network_acl_no = ncloud_vpc.vpc.default_network_acl_no
+  subnet_type    = "PUBLIC" // PUBLIC(Public) | PRIVATE(Private)
+  usage_type     = "NATGW"
+}
+
+resource "ncloud_nat_gateway" "nat_gateway" {
+  vpc_no      = ncloud_vpc.vpc.id
+  subnet_no   = ncloud_subnet.subnet.id
+  zone        = "KR-2"
+  // below fields is optional
+  name        = "nat-gw"
+  description = "description"
+}
+
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `vpc_no` - (Required) The ID of the associated VPC.
 * `zone` - (Required) Available zone where the subnet will be placed physically.
+* `subnet_no` - (Conditional) The ID of the associated SUBNET. This is required when creating a new one. The subnet type determines whether the NATGateway type is public or private. 
 * `name` - (Optional) The name to create. If omitted, Terraform will assign a random, unique name.
+* `public_ip_no` - (Optional) The ID of the associated Public IP. If omitted, will auto create. should only be set if public type.
+* `private ip` - (Optional) Private IP on created NAT Gateway. If omitted, will auto create.
 * `description` - (Optional) description to create.
 
 ## Attributes Reference
@@ -39,5 +70,9 @@ In addition to all arguments above, the following attributes are exported:
 * `nat_gateway_no` - The ID of the NAT Gateway. (It is the same result as `id`) 
 * `public_ip` - Public IP on created NAT Gateway.
 * `subnet_name` - Subnet name on created NAT Gateway.
-* `subnet_no` - Subnet ID on created NAT Gateway.
-* `private_ip` - Private IP on created NAT Gateway.
+
+## Import
+
+NAT Gateway can be imported using the id, e.g.,
+
+$ terraform import ncloud_nat_gateway.my_nat_gateway id

--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -2,6 +2,10 @@
 
 Provides a NAT gateway resource.
 
+~> **NOTE:** This resource only supports VPC environment.
+
+~> **NOTE:** Old Version(Subnet not associated) no longer support new creation.
+
 ## Example Usage
 
 ### Old Version(Subnet not associated) Usage
@@ -15,7 +19,7 @@ resource "ncloud_vpc" "vpc" {
 resource "ncloud_nat_gateway" "nat_gateway" {
   vpc_no      = ncloud_vpc.vpc.id
   zone        = "KR-2"
-  // below fields is optional
+  // below fields are optional
   name        = "nat-gw"
   description = "description"
 }
@@ -43,7 +47,7 @@ resource "ncloud_nat_gateway" "nat_gateway" {
   vpc_no      = ncloud_vpc.vpc.id
   subnet_no   = ncloud_subnet.subnet.id
   zone        = "KR-2"
-  // below fields is optional
+  // below fields are optional
   name        = "nat-gw"
   description = "description"
 }

--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -58,7 +58,6 @@ The following arguments are supported:
 * `zone` - (Required) Available zone where the subnet will be placed physically.
 * `subnet_no` - (Conditional) The ID of the associated SUBNET. This is required when creating a new one. The subnet type determines whether the NATGateway type is public or private. 
 * `name` - (Optional) The name to create. If omitted, Terraform will assign a random, unique name.
-* `public_ip_no` - (Optional) The ID of the associated Public IP. If omitted, will auto create. should only be set if public type.
 * `private ip` - (Optional) Private IP on created NAT Gateway. If omitted, will auto create.
 * `description` - (Optional) description to create.
 
@@ -69,6 +68,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The ID of the NAT Gateway.
 * `nat_gateway_no` - The ID of the NAT Gateway. (It is the same result as `id`) 
 * `public_ip` - Public IP on created NAT Gateway.
+* `public_ip_no` - The ID of the associated Public IP.
 * `subnet_name` - Subnet name on created NAT Gateway.
 
 ## Import

--- a/docs/resources/subnet.md
+++ b/docs/resources/subnet.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `network_acl_no` - (Required) The ID of Network ACL.
 * `subnet_type` - (Required) Internet connectivity. If you use `PUBLIC` all VMs created within Subnet will be assigned a certified IP by default and will be able to communicate directly over the Internet. Considering the characteristics of Subnet, you can choose Subnet for the purpose of use. Accepted values: `PUBLIC` (Public) | `PRIVATE` (Private).
 * `name` - (Optional) The name to create. If omitted, Terraform will assign a random, unique name.
-* `usage_type` - (Optional) Usage type, Default `GEN`. Accepted values: `GEN` (General) | `LOADB` (For load balancer) | `NATGW` (for NAT Gateway. Only pub env).
+* `usage_type` - (Optional) Usage type, Default `GEN`. Accepted values: `GEN` (General) | `LOADB` (For LoadBalancer) | `BM` (For BareMetal) |`NATGW` (for NATGateway).
 
 ## Attributes Reference
 

--- a/ncloud/data_source_ncloud_nat_gateway.go
+++ b/ncloud/data_source_ncloud_nat_gateway.go
@@ -26,6 +26,10 @@ func dataSourceNcloudNatGateway() *schema.Resource {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"filter": dataSourceFiltersSchema(),
 	}
 
@@ -91,7 +95,12 @@ func getNatGatewayListFiltered(d *schema.ResourceData, config *ProviderConfig) (
 			"description":    *r.NatGatewayDescription,
 			"public_ip":      *r.PublicIp,
 			"vpc_no":         *r.VpcNo,
+			"vpc_name":       *r.VpcName,
 			"zone":           *r.ZoneCode,
+			"subnet_no":      *r.SubnetNo,
+			"subnet_name":    *r.SubnetName,
+			"private_ip":     *r.PrivateIp,
+			"public_ip_no":   *r.PublicIpInstanceNo,
 		}
 
 		resources = append(resources, instance)

--- a/ncloud/resource_ncloud_nat_gateway.go
+++ b/ncloud/resource_ncloud_nat_gateway.go
@@ -61,10 +61,10 @@ func resourceNcloudNatGateway() *schema.Resource {
 				ForceNew: true,
 			},
 			"public_ip_no": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type: schema.TypeString,
+				//Optional: true,
 				Computed: true,
-				ForceNew: true,
+				//ForceNew: true,
 			},
 			"nat_gateway_no": {
 				Type:     schema.TypeString,
@@ -108,9 +108,11 @@ func resourceNcloudNatGatewayCreate(d *schema.ResourceData, meta interface{}) er
 		reqParams.NatGatewayDescription = ncloud.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("public_ip_no"); ok {
-		reqParams.PublicIpInstanceNo = ncloud.String(v.(string))
-	}
+	/*
+		if v, ok := d.GetOk("public_ip_no"); ok {
+			reqParams.PublicIpInstanceNo = ncloud.String(v.(string))
+		}
+	*/
 
 	if v, ok := d.GetOk("private_ip"); ok {
 		reqParams.PrivateIp = ncloud.String(v.(string))

--- a/ncloud/resource_ncloud_nat_gateway.go
+++ b/ncloud/resource_ncloud_nat_gateway.go
@@ -61,10 +61,8 @@ func resourceNcloudNatGateway() *schema.Resource {
 				ForceNew: true,
 			},
 			"public_ip_no": {
-				Type: schema.TypeString,
-				//Optional: true,
+				Type:     schema.TypeString,
 				Computed: true,
-				//ForceNew: true,
 			},
 			"nat_gateway_no": {
 				Type:     schema.TypeString,
@@ -107,12 +105,6 @@ func resourceNcloudNatGatewayCreate(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("description"); ok {
 		reqParams.NatGatewayDescription = ncloud.String(v.(string))
 	}
-
-	/*
-		if v, ok := d.GetOk("public_ip_no"); ok {
-			reqParams.PublicIpInstanceNo = ncloud.String(v.(string))
-		}
-	*/
 
 	if v, ok := d.GetOk("private_ip"); ok {
 		reqParams.PrivateIp = ncloud.String(v.(string))

--- a/ncloud/resource_ncloud_public_ip.go
+++ b/ncloud/resource_ncloud_public_ip.go
@@ -393,6 +393,10 @@ func checkAssociatedPublicIP(config *ProviderConfig, id string) (bool, error) {
 		return false, err
 	}
 
+	if instance == nil {
+		return false, nil
+	}
+
 	return instance.ServerInstanceNo != nil && *instance.ServerInstanceNo != "", nil
 }
 


### PR DESCRIPTION
## Description
Support for new NAT Gateway with private NAT capabilities and public IP reuse

## Features
- A dedicated subnet is required
- You can choose a private or public NAT gateway to suit your needs
  (The gateway type is determined by the subnet type)
- You can set up a private IP

### Resource
- ncloud_nat_gateway
  - Add Argument : subnet_no, private_ip

### Datasource
- ncloud_nat_gateway
  - Add Attribute : subnet_no, subnet_name, public_ip_no, private_ip