### PR TITLE
fix#287: Update product code in ncloud server test

### DIFF
--- a/internal/service/server/server_test.go
+++ b/internal/service/server/server_test.go
@@ -44,7 +44,7 @@ func TestAccResourceNcloudServer_classic_basic(t *testing.T) {
 					testAccCheckServerExistsWithProvider(resourceName, &serverInstance, GetTestProvider(false)),
 					testCheck(),
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
-					resource.TestCheckResourceAttr(resourceName, "server_image_product_code", "SPSW0LINUX000045"),
+					resource.TestCheckResourceAttr(resourceName, "server_image_product_code", "SPSW0LINUX000046"),
 					resource.TestCheckResourceAttr(resourceName, "server_product_code", productCode),
 					resource.TestCheckResourceAttr(resourceName, "name", testServerName),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -56,7 +56,7 @@ func TestAccResourceNcloudServer_classic_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "instance_no", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "platform_type", "LNX64"),
 					resource.TestCheckResourceAttr(resourceName, "is_protect_server_termination", "false"),
-					resource.TestCheckResourceAttr(resourceName, "server_image_name", "centos-7.2-64"),
+					resource.TestCheckResourceAttr(resourceName, "server_image_name", "centos-7.3-64"),
 					resource.TestCheckResourceAttr(resourceName, "login_key_name", fmt.Sprintf("%s-key", testServerName)),
 					resource.TestMatchResourceAttr(resourceName, "instance_no", regexp.MustCompile(`^\d+$`)),
 					resource.TestMatchResourceAttr(resourceName, "port_forwarding_public_ip", regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`)),
@@ -463,7 +463,7 @@ resource "ncloud_login_key" "loginkey" {
 
 resource "ncloud_server" "server" {
 	name = "%[1]s"
-	server_image_product_code = "SPSW0LINUX000045"
+	server_image_product_code = "SPSW0LINUX000046"
 	server_product_code = "%[2]s"
 	login_key_name = "${ncloud_login_key.loginkey.key_name}"
 }


### PR DESCRIPTION
## Description
The product code was out of date and was not renewed, so i renewed the product code.
<br>
## Relations
#287 
<br>
## Output from Acceptance Testing
```
go test -v -timeout 20m -run TestAccResourceNcloudServer_classic ./... 
?       github.com/terraform-providers/terraform-provider-ncloud        [no test files]
?       github.com/terraform-providers/terraform-provider-ncloud/internal/acctest       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/common        0.378s [no tests to run]
?       github.com/terraform-providers/terraform-provider-ncloud/internal/conn  [no test files]
?       github.com/terraform-providers/terraform-provider-ncloud/internal/provider      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/region        1.420s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/autoscaling   1.186s [no tests to run]
?       github.com/terraform-providers/terraform-provider-ncloud/internal/service/cdss  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/classicloadbalancer   0.442s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/devtools      0.698s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/launchconfiguration   0.304s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/loadbalancer  0.935s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/loginkey      1.299s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/memberserverimage     1.527s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/nasvolume     1.442s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/nks   1.467s [no tests to run]
=== RUN   TestAccResourceNcloudServer_classic_basic
--- PASS: TestAccResourceNcloudServer_classic_basic (352.53s)
=== RUN   TestAccResourceNcloudServer_classic_changeSpec
--- PASS: TestAccResourceNcloudServer_classic_changeSpec (482.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/server        836.511s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/ses   1.271s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/vpc   1.545s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/verify        1.374s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/zone  1.428s [no tests to run]
```