### PR TITLE
test: Update testAccResourceNcloudNatGatewayConfigOnlyRequiredParam t…

### DIFF
--- a/internal/service/vpc/nat_gateway_test.go
+++ b/internal/service/vpc/nat_gateway_test.go
@@ -227,8 +227,18 @@ resource "ncloud_vpc" "vpc" {
 	ipv4_cidr_block = "10.3.0.0/16"
 }
 
+resource "ncloud_subnet" "subnet_public" {
+  vpc_no         = ncloud_vpc.vpc.id
+  subnet         = cidrsubnet(ncloud_vpc.vpc.ipv4_cidr_block, 8, 1)
+  zone           = "KR-1"
+  network_acl_no = ncloud_vpc.vpc.default_network_acl_no
+  subnet_type    = "PUBLIC"
+  usage_type     = "NATGW"
+}
+	
 resource "ncloud_nat_gateway" "nat_gateway" {
   vpc_no      = ncloud_vpc.vpc.vpc_no
+  subnet_no   = ncloud_subnet.subnet_public.id
   zone        = "KR-1"
 }
 `, name)

--- a/internal/service/vpc/nat_gateway_test.go
+++ b/internal/service/vpc/nat_gateway_test.go
@@ -93,6 +93,7 @@ func TestAccResourceNcloudNatGateway_onlyRequiredParam(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceName, "vpc_no", regexp.MustCompile(`^\d+$`)),
 					resource.TestMatchResourceAttr(resourceName, "nat_gateway_no", regexp.MustCompile(`^\d+$`)),
 					resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile(`^[a-z0-9]+$`)),
+					resource.TestMatchResourceAttr(resourceName, "subnet_no", regexp.MustCompile(`^\d+$`)),
 				),
 			},
 			{


### PR DESCRIPTION
### Overview
- resolve #292 
- Recently, the specifications for NAT Gateway have changed, but this was not reflected in the test code, which led to some problems.
  - [Reference](https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/274/files) 

- The NAT Gateway should be used by explicitly setting the subnet.

### Changes
- The subnet setting was added to testAccResourceNcloudNatGatewayConfigOnlyRequiredParam according to the specifications.

### Test Result
```
$ go test -v -run TestAccResourceNcloudNatGateway_onlyRequiredParam nat_gateway_test.go
=== RUN   TestAccResourceNcloudNatGateway_onlyRequiredParam
--- PASS: TestAccResourceNcloudNatGateway_onlyRequiredParam (85.32s)
PASS
ok      command-line-arguments  85.808s
```