### PR TITLE
Add 'description' validation in lb_target_group

### DIFF
--- a/internal/service/loadbalancer/lb_target_group.go
+++ b/internal/service/loadbalancer/lb_target_group.go
@@ -51,8 +51,9 @@ func ResourceNcloudLbTargetGroup() *schema.Resource {
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"TCP", "PROXY_TCP", "HTTP", "HTTPS"}, false)),
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: ToDiagFunc(validation.StringLenBetween(0, 1000)),
 			},
 			"health_check": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
### Description
Add validation for the `description` field in `lb_target_group`

### Features
- The schema definition of the `description` field in the `lb_target_group` resource has been updated to include a `ValidateDiagFunc`. This function enforces the validation rule that the length of the string must be between 0 and 1000 characters.
    - [Reference(Ncloud API Docs)](https://api.ncloud-docs.com/docs/networking-vloadbalancer-targetgroup-createtargetgroup)
 
 
 After verifying that the validation for the `description` field is well-implemented in other resources, I've initiated this Pull Request 
    - ex) [nat_gateway](https://github.com/NaverCloudPlatform/terraform-provider-ncloud/blob/main/internal/service/vpc/nat_gateway.go#L39)
