### PR TITLE
chore : add validation in auto scaling policy

### DIFF
--- a/internal/service/autoscaling/auto_scaling_policy.go
+++ b/internal/service/autoscaling/auto_scaling_policy.go
@@ -23,9 +23,10 @@ func ResourceNcloudAutoScalingPolicy() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: ToDiagFunc(validation.IntBetween(1, 255)),
 			},
 			"adjustment_type_code": {
 				Type:             schema.TypeString,
@@ -33,17 +34,20 @@ func ResourceNcloudAutoScalingPolicy() *schema.Resource {
 				ValidateDiagFunc: ToDiagFunc(validation.StringInSlice([]string{"CHANG", "EXACT", "PRCNT"}, false)),
 			},
 			"scaling_adjustment": {
-				Type:     schema.TypeInt,
-				Required: true,
+				Type:             schema.TypeInt,
+				Required:         true,
+				ValidateDiagFunc: ToDiagFunc(validation.IntBetween(-2147483648, 2147483647)),
 			},
 			"cooldown": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Computed:         true,
+				ValidateDiagFunc: ToDiagFunc(validation.IntBetween(0, 2147483647)),
 			},
 			"min_adjustment_step": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:             schema.TypeInt,
+				Optional:         true,
+				ValidateDiagFunc: ToDiagFunc(validation.IntBetween(1, 2147483647)),
 			},
 			"auto_scaling_group_no": {
 				Type:     schema.TypeString,

--- a/internal/service/autoscaling/auto_scaling_policy.go
+++ b/internal/service/autoscaling/auto_scaling_policy.go
@@ -29,7 +29,7 @@ func ResourceNcloudAutoScalingPolicy() *schema.Resource {
 				ForceNew: true,
 				ValidateDiagFunc: ToDiagFunc(validation.All(
 					validation.StringLenBetween(1, 255),
-					validation.StringMatch(regexp.MustCompile(`^[a-z]+[a-z0-9-]+[a-z0-9]$`), "start with an alphabets and composed of alphabets, numbers, hyphen (-) and wild card (*). Hyphen (-) cannot be used for the last character"))),
+					validation.StringMatch(regexp.MustCompile(`^[a-z]+[a-z0-9-]+[a-z0-9]$`), "Allows only lowercase letters(a-z), numbers, hyphen (-). Must start with an alphabetic character, must end with an English letter or number"))),
 			},
 			"adjustment_type_code": {
 				Type:             schema.TypeString,

--- a/internal/service/autoscaling/auto_scaling_policy.go
+++ b/internal/service/autoscaling/auto_scaling_policy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vautoscaling"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"regexp"
 
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/common"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
@@ -23,10 +24,12 @@ func ResourceNcloudAutoScalingPolicy() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: ToDiagFunc(validation.IntBetween(1, 255)),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateDiagFunc: ToDiagFunc(validation.All(
+					validation.StringLenBetween(1, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-z]+[a-z0-9-]+[a-z0-9]$`), "start with an alphabets and composed of alphabets, numbers, hyphen (-) and wild card (*). Hyphen (-) cannot be used for the last character"))),
 			},
 			"adjustment_type_code": {
 				Type:             schema.TypeString,


### PR DESCRIPTION
### 개요

- 해결 : #308 

### 변경 사항

- auto_scaling_policy schema 검증 로직 추가

### 추가 사항

- autoScalingPolicy의 두 타입인 classic, vpc가 요구하는 요청 파라미터가 다름.

<br/>
<img width="754" alt="image" src="https://github.com/NaverCloudPlatform/terraform-provider-ncloud/assets/40160510/bacc3f23-53c2-476e-b832-13acd89cdc14">

Auto Scaling policy **Classic** 에서 요구하는 파라미터 Image
<br/>

<img width="1079" alt="image" src="https://github.com/NaverCloudPlatform/terraform-provider-ncloud/assets/40160510/d85ea8e7-caac-48aa-9373-34e8ee326c02">

Auto Scaling policy **VPC** 에서 요구하는 파라미터 Image
<br/>

<img width="1072" alt="image" src="https://github.com/NaverCloudPlatform/terraform-provider-ncloud/assets/40160510/c61659bd-3129-40c6-9c33-0ebb7f414477">
<Auto Scaling policy Classic 생성 메서드 >

 하지만, 위 이미지에서 볼 수 있듯  "auto_scaling_group_no"를 사용해 AutoScalingGroupName을 구하기 때문에 결과적으로 Classic의 "auto_scaling_group_name" 검증은 필요하지 않음.

<br/>
- Auto Scaling Policy VPC의 scalingAdjustment 파라미터에서 아래 이미지와 같은 추가적인 검증이 요구됨 하지만 현재 스키마 작성 시 사용하는 Validation으로 검증할 방법이 없음. 검증을 수행한다면 CUD 과정에서 추가적인 로직 필요.

<img width="1111" alt="image" src="https://github.com/NaverCloudPlatform/terraform-provider-ncloud/assets/40160510/1ea0023a-08f7-4c7d-bdd1-9a3229861bef">
<br/>


