### PR TITLE
fix : launch configuration classic test

### DIFF
--- a/internal/service/launchconfiguration/launch_configuration.go
+++ b/internal/service/launchconfiguration/launch_configuration.go
@@ -7,9 +7,11 @@ import (
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/autoscaling"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vautoscaling"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/common"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
+	. "github.com/terraform-providers/terraform-provider-ncloud/internal/verify"
 )
 
 func ResourceNcloudLaunchConfiguration() *schema.Resource {
@@ -26,10 +28,11 @@ func ResourceNcloudLaunchConfiguration() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: ToDiagFunc(validation.StringLenBetween(1, 255)),
 			},
 			"server_image_product_code": {
 				Type:          schema.TypeString,
@@ -67,11 +70,12 @@ func ResourceNcloudLaunchConfiguration() *schema.Resource {
 				ForceNew: true,
 			},
 			"access_control_group_no_list": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				ForceNew: true,
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				ForceNew:    true,
+				Description: "This parameter cannot be duplicated in classic type.",
 			},
 			"is_encrypted_volume": {
 				Type:     schema.TypeBool,

--- a/internal/service/launchconfiguration/launch_configuration_test.go
+++ b/internal/service/launchconfiguration/launch_configuration_test.go
@@ -18,6 +18,7 @@ func TestAccResourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
 	var launchConfiguration launchconfiguration.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
 	serverImageProductCode := "SPSW0LINUX000046"
+	serverProductCode := "SPSVRSSD00000003"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { TestAccPreCheck(t) },
 		Providers: GetTestAccProviders(false),
@@ -26,7 +27,7 @@ func TestAccResourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchConfigurationConfig(serverImageProductCode),
+				Config: testAccLaunchConfigurationConfig(serverImageProductCode, serverProductCode),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchConfigurationExists(resourceName, &launchConfiguration, GetTestProvider(false)),
 				),
@@ -52,7 +53,7 @@ func TestAccResourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchConfigurationConfig(serverImageProductCode),
+				Config: testAccLaunchConfigurationConfig(serverImageProductCode, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchConfigurationExists(resourceName, &launchConfiguration, GetTestProvider(true)),
 				),
@@ -78,7 +79,7 @@ func TestAccResourceNcloudLaunchConfiguration_classic_disappears(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchConfigurationConfig(serverImageProductCode),
+				Config: testAccLaunchConfigurationConfig(serverImageProductCode, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchConfigurationExists(resourceName, &launchConfiguration, GetTestProvider(false)),
 					TestAccCheckResourceDisappears(GetTestProvider(false), launchconfiguration.ResourceNcloudLaunchConfiguration(), resourceName),
@@ -101,7 +102,7 @@ func TestAccResourceNcloudLaunchConfiguration_vpc_disappears(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchConfigurationConfig(serverImageProductCode),
+				Config: testAccLaunchConfigurationConfig(serverImageProductCode, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchConfigurationExists(resourceName, &launchConfiguration, GetTestProvider(true)),
 					TestAccCheckResourceDisappears(GetTestProvider(true), launchconfiguration.ResourceNcloudLaunchConfiguration(), resourceName),
@@ -155,10 +156,11 @@ func testAccCheckLaunchConfigurationDestroy(s *terraform.State, provider *schema
 	return nil
 }
 
-func testAccLaunchConfigurationConfig(serverImageProductCode string) string {
+func testAccLaunchConfigurationConfig(serverImageProductCode string, serverProductCode string) string {
 	return fmt.Sprintf(`
 resource "ncloud_launch_configuration" "lc" {
 	server_image_product_code = "%[1]s"
+	server_product_code = "%[2]s"
 }
-`, serverImageProductCode)
+`, serverImageProductCode, serverProductCode)
 }

--- a/internal/service/launchconfiguration/launch_configuration_test.go
+++ b/internal/service/launchconfiguration/launch_configuration_test.go
@@ -71,6 +71,7 @@ func TestAccResourceNcloudLaunchConfiguration_classic_disappears(t *testing.T) {
 	var launchConfiguration launchconfiguration.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
 	serverImageProductCode := "SPSW0LINUX000046"
+	serverProductCode := "SPSVRSSD00000003"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { TestAccPreCheck(t) },
 		Providers: GetTestAccProviders(false),
@@ -79,7 +80,7 @@ func TestAccResourceNcloudLaunchConfiguration_classic_disappears(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLaunchConfigurationConfig(serverImageProductCode, ""),
+				Config: testAccLaunchConfigurationConfig(serverImageProductCode, serverProductCode),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchConfigurationExists(resourceName, &launchConfiguration, GetTestProvider(false)),
 					TestAccCheckResourceDisappears(GetTestProvider(false), launchconfiguration.ResourceNcloudLaunchConfiguration(), resourceName),


### PR DESCRIPTION
### 개요

- 해결 : #298 

### 변경 사항

- launch configuration schema 검증 로직 추가
- launch configuration classic_basic, disappears test code에 Terraform Provider 에서 요구하는 값을 추가 [ncloud_launch_configuration information in terraform](https://registry.terraform.io/providers/NaverCloudPlatform/ncloud/latest/docs/resources/launch_configuration)
- launch configuration config method 코드 수정

### 추가 사항

- classic과 vpc type이 요구하는 제약사항이 달라 기준을 ncp console로 정함. 요구하는 필수 값인 launchConfigurationName만 검증 추가
- vpc test 시, testLaunchConfigurationConfig Param으로 전달해야 할 serverProductCode에 빈 문자열을 넣어 compile error 해결

### 테스트 결과

- TestAccResourceNcloudLaunchConfiguration_classic_basic의 경우
<br/>

```
go test ./internal/service/launchconfiguration/... -run TestAccResourceNcloudLaunchConfiguration_classic_basic -v
=== RUN   TestAccResourceNcloudLaunchConfiguration_classic_basic
=== PAUSE TestAccResourceNcloudLaunchConfiguration_classic_basic
=== CONT  TestAccResourceNcloudLaunchConfiguration_classic_basic
--- PASS: TestAccResourceNcloudLaunchConfiguration_classic_basic (5.36s)
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/launchconfiguration   5.888s

```
<br/>

- TestAccResourceNcloudLaunchConfiguration_classic_disappears의 경우, classic_basic과 동일한 Error Message 확인. 같은 방법으로 해결
<br/>

```
go test ./internal/service/launchconfiguration/... -run TestAccResourceNcloudLaunchConfiguration_classic_disappears -v
=== RUN   TestAccResourceNcloudLaunchConfiguration_classic_disappears
=== PAUSE TestAccResourceNcloudLaunchConfiguration_classic_disappears
=== CONT  TestAccResourceNcloudLaunchConfiguration_classic_disappears
--- PASS: TestAccResourceNcloudLaunchConfiguration_classic_disappears (9.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/launchconfiguration   9.604s
```

모든 테스트는 통과했습니다.