### PR TITLE
refactor(launchconfiguration): Move to autoscaling service

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,7 +12,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/cdss"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/classicloadbalancer"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/devtools"
-	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/launchconfiguration"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/loadbalancer"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/loginkey"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/memberserverimage"
@@ -44,7 +43,7 @@ func Provider() *schema.Provider {
 		"ncloud_cdss_os_image":                           cdss.DataSourceNcloudCDSSOsImage(),
 		"ncloud_cdss_os_images":                          cdss.DataSourceNcloudCDSSOsImages(),
 		"ncloud_init_script":                             server.DataSourceNcloudInitScript(),
-		"ncloud_launch_configuration":                    launchconfiguration.DataSourceNcloudLaunchConfiguration(),
+		"ncloud_launch_configuration":                    autoscaling.DataSourceNcloudLaunchConfiguration(),
 		"ncloud_lb":                                      loadbalancer.DataSourceNcloudLb(),
 		"ncloud_lb_listener":                             loadbalancer.DataSourceNcloudLbListener(),
 		"ncloud_lb_target_group":                         loadbalancer.DataSourceNcloudLbTargetGroup(),
@@ -120,7 +119,7 @@ func Provider() *schema.Provider {
 		"ncloud_cdss_cluster":                        cdss.ResourceNcloudCDSSCluster(),
 		"ncloud_cdss_config_group":                   cdss.ResourceNcloudCDSSConfigGroup(),
 		"ncloud_init_script":                         server.ResourceNcloudInitScript(),
-		"ncloud_launch_configuration":                launchconfiguration.ResourceNcloudLaunchConfiguration(),
+		"ncloud_launch_configuration":                autoscaling.ResourceNcloudLaunchConfiguration(),
 		"ncloud_lb_listener":                         loadbalancer.ResourceNcloudLbListener(),
 		"ncloud_lb_target_group_attachment":          loadbalancer.ResourceNcloudLbTargetGroupAttachment(),
 		"ncloud_lb_target_group":                     loadbalancer.ResourceNcloudLbTargetGroup(),

--- a/internal/service/autoscaling/accesscontrolgrouplist.go
+++ b/internal/service/autoscaling/accesscontrolgrouplist.go
@@ -1,4 +1,4 @@
-package launchconfiguration
+package autoscaling
 
 import "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/autoscaling"
 

--- a/internal/service/autoscaling/auto_scaling_group.go
+++ b/internal/service/autoscaling/auto_scaling_group.go
@@ -15,7 +15,6 @@ import (
 
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/common"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
-	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/launchconfiguration"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/vpc"
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/verify"
 )
@@ -204,7 +203,7 @@ func createClassicAutoScalingGroup(d *schema.ResourceData, config *conn.Provider
 		return nil, ErrorRequiredArgOnClassic("zone_no_list")
 	}
 	// TODO : Zero value 핸들링
-	l, err := launchconfiguration.GetClassicLaunchConfigurationByNo(StringPtrOrNil(d.GetOk("launch_configuration_no")), config)
+	l, err := GetClassicLaunchConfigurationByNo(StringPtrOrNil(d.GetOk("launch_configuration_no")), config)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +440,7 @@ func changeClassicAutoScalingGroup(d *schema.ResourceData, config *conn.Provider
 	}
 
 	if d.HasChange("launch_configuration_no") {
-		launchConfiguration, err := launchconfiguration.GetClassicLaunchConfigurationByNo(ncloud.String(d.Get("launch_configuration_no").(string)), config)
+		launchConfiguration, err := GetClassicLaunchConfigurationByNo(ncloud.String(d.Get("launch_configuration_no").(string)), config)
 		if err != nil {
 			return err
 		}

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -1,4 +1,4 @@
-package launchconfiguration
+package autoscaling
 
 import (
 	"fmt"

--- a/internal/service/autoscaling/launch_configuration_data_source.go
+++ b/internal/service/autoscaling/launch_configuration_data_source.go
@@ -1,4 +1,4 @@
-package launchconfiguration
+package autoscaling
 
 import (
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"

--- a/internal/service/autoscaling/launch_configuration_data_source_test.go
+++ b/internal/service/autoscaling/launch_configuration_data_source_test.go
@@ -1,4 +1,4 @@
-package launchconfiguration_test
+package autoscaling_test
 
 import (
 	"fmt"

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -1,4 +1,4 @@
-package launchconfiguration_test
+package autoscaling_test
 
 import (
 	"fmt"
@@ -11,11 +11,11 @@ import (
 
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/acctest"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
-	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/launchconfiguration"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/autoscaling"
 )
 
 func TestAccResourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
-	var launchConfiguration launchconfiguration.LaunchConfiguration
+	var launchConfiguration autoscaling.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
 	serverImageProductCode := "SPSW0LINUX000046"
 	serverProductCode := "SPSVRSSD00000003"
@@ -42,7 +42,7 @@ func TestAccResourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
-	var launchConfiguration launchconfiguration.LaunchConfiguration
+	var launchConfiguration autoscaling.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
 	serverImageProductCode := "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
 	resource.ParallelTest(t, resource.TestCase{
@@ -68,7 +68,7 @@ func TestAccResourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudLaunchConfiguration_classic_disappears(t *testing.T) {
-	var launchConfiguration launchconfiguration.LaunchConfiguration
+	var launchConfiguration autoscaling.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
 	serverImageProductCode := "SPSW0LINUX000046"
 	serverProductCode := "SPSVRSSD00000003"
@@ -83,7 +83,7 @@ func TestAccResourceNcloudLaunchConfiguration_classic_disappears(t *testing.T) {
 				Config: testAccLaunchConfigurationConfig(serverImageProductCode, serverProductCode),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchConfigurationExists(resourceName, &launchConfiguration, GetTestProvider(false)),
-					TestAccCheckResourceDisappears(GetTestProvider(false), launchconfiguration.ResourceNcloudLaunchConfiguration(), resourceName),
+					TestAccCheckResourceDisappears(GetTestProvider(false), autoscaling.ResourceNcloudLaunchConfiguration(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -92,7 +92,7 @@ func TestAccResourceNcloudLaunchConfiguration_classic_disappears(t *testing.T) {
 }
 
 func TestAccResourceNcloudLaunchConfiguration_vpc_disappears(t *testing.T) {
-	var launchConfiguration launchconfiguration.LaunchConfiguration
+	var launchConfiguration autoscaling.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
 	serverImageProductCode := "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
 	resource.ParallelTest(t, resource.TestCase{
@@ -106,7 +106,7 @@ func TestAccResourceNcloudLaunchConfiguration_vpc_disappears(t *testing.T) {
 				Config: testAccLaunchConfigurationConfig(serverImageProductCode, ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchConfigurationExists(resourceName, &launchConfiguration, GetTestProvider(true)),
-					TestAccCheckResourceDisappears(GetTestProvider(true), launchconfiguration.ResourceNcloudLaunchConfiguration(), resourceName),
+					TestAccCheckResourceDisappears(GetTestProvider(true), autoscaling.ResourceNcloudLaunchConfiguration(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -114,7 +114,7 @@ func TestAccResourceNcloudLaunchConfiguration_vpc_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckLaunchConfigurationExists(n string, l *launchconfiguration.LaunchConfiguration, provider *schema.Provider) resource.TestCheckFunc {
+func testAccCheckLaunchConfigurationExists(n string, l *autoscaling.LaunchConfiguration, provider *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -126,7 +126,7 @@ func testAccCheckLaunchConfigurationExists(n string, l *launchconfiguration.Laun
 		}
 
 		config := provider.Meta().(*conn.ProviderConfig)
-		launchConfiguration, err := launchconfiguration.GetLaunchConfiguration(config, rs.Primary.ID)
+		launchConfiguration, err := autoscaling.GetLaunchConfiguration(config, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -145,7 +145,7 @@ func testAccCheckLaunchConfigurationDestroy(s *terraform.State, provider *schema
 		if rs.Type != "ncloud_launch_configuration" {
 			continue
 		}
-		launchConfiguration, err := launchconfiguration.GetClassicLaunchConfiguration(config, rs.Primary.ID)
+		launchConfiguration, err := autoscaling.GetClassicLaunchConfiguration(config, rs.Primary.ID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The launch configuration is one of the features of the autoscaling service, let's move it to be located under the autoscaling service.