### PR TITLE
fix : Change server name validation message

### DIFF
--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -61,7 +61,7 @@ func ResourceNcloudServer() *schema.Resource {
 				ForceNew: true,
 				ValidateDiagFunc: ToDiagFunc(validation.All(
 					validation.StringLenBetween(3, 30),
-					validation.StringMatch(regexp.MustCompile(`^[a-z]+[a-z0-9-]+[a-z0-9]$`), "start with an alphabets and composed of alphabets, numbers, hyphen (-) and wild card (*). Hyphen (-) cannot be used for the last character"),
+					validation.StringMatch(regexp.MustCompile(`^[a-z]+[a-z0-9-]+[a-z0-9]$`), "Allows only lowercase letters(a-z), numbers, hyphen (-). Must start with an alphabetic character, must end with an English letter or number"),
 				)),
 			},
 			"description": {


### PR DESCRIPTION

 server name에 유효한 값을 입력하지 않았을 때 validation message가 조건과 맞지 않아 이를 수정했습니다.
