### PR TITLE
docs: Categorize docs files by services

### DIFF
--- a/docs/data-sources/access_control_group.md
+++ b/docs/data-sources/access_control_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_access_control_group
 
 When creating a server instance (VM), you can add an ACG(Access Control Group) that you specified to set firewalls. `ncloud_access_control_group` provides details about a specific ACG(Access Control Group) information.

--- a/docs/data-sources/access_control_groups.md
+++ b/docs/data-sources/access_control_groups.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_access_control_groups
 
 When creating a server instance (VM), you can add an ACG(Access Control Group) that you specified to set firewalls. This data source gets a list of access control groups necessary to set firewalls.

--- a/docs/data-sources/access_control_rule.md
+++ b/docs/data-sources/access_control_rule.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_access_control_rule
 
 Access configuration rule you want to get.

--- a/docs/data-sources/access_control_rules.md
+++ b/docs/data-sources/access_control_rules.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_access_control_rules
 
 List of access configuration rules you want to get

--- a/docs/data-sources/auto_scaling_group.md
+++ b/docs/data-sources/auto_scaling_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Auto Scaling"
+---
+
+
 # Data Source: ncloud_auto_scaling_group
 
 This module can be useful for getting detail of Auto Scaling Group created before.

--- a/docs/data-sources/auto_scaling_policy.md
+++ b/docs/data-sources/auto_scaling_policy.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Auto Scaling"
+---
+
+
 # Data Source: ncloud_auto_scaling_policy
 
 This module can be useful for getting detail of Auto Scaling Policy created before.

--- a/docs/data-sources/auto_scaling_schedule.md
+++ b/docs/data-sources/auto_scaling_schedule.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Auto Scaling"
+---
+
+
 # Data Source: ncloud_auto_scaling_policy
 
 This module can be useful for getting detail of Auto Scaling Schedule created before.

--- a/docs/data-sources/block_storage.md
+++ b/docs/data-sources/block_storage.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_block_storage
 
 This module can be useful for getting detail of Block Storage created before.

--- a/docs/data-sources/block_storage_snapshot.md
+++ b/docs/data-sources/block_storage_snapshot.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_block_storage_snapshot
 
 This module can be useful for getting detail of Snapshot (Block Storage) created before.

--- a/docs/data-sources/cdss_cluster.md
+++ b/docs/data-sources/cdss_cluster.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Cloud Data Streaming Service"
+---
+
+
 # Data Source: ncloud_cdss_cluster
 
 ## Example Usage

--- a/docs/data-sources/cdss_config_group.md
+++ b/docs/data-sources/cdss_config_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Cloud Data Streaming Service"
+---
+
+
 # Data Source: ncloud_cdss_config_group
 
 ## Example Usage

--- a/docs/data-sources/cdss_kafka_version.md
+++ b/docs/data-sources/cdss_kafka_version.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Cloud Data Streaming Service"
+---
+
+
 # Data Source: ncloud_cdss_kafka_version
 
 ## Example Usage

--- a/docs/data-sources/cdss_kafka_versions.md
+++ b/docs/data-sources/cdss_kafka_versions.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Cloud Data Streaming Service"
+---
+
+
 # Data Source: ncloud_cdss_kafka_versions
 
 ## Example Usage

--- a/docs/data-sources/cdss_node_product.md
+++ b/docs/data-sources/cdss_node_product.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Cloud Data Streaming Service"
+---
+
+
 # Data Source: ncloud_cdss_node_product
 
 ## Example Usage

--- a/docs/data-sources/cdss_node_products.md
+++ b/docs/data-sources/cdss_node_products.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Cloud Data Streaming Service"
+---
+
+
 # Data Source: ncloud_cdss_node_products
 
 ## Example Usage

--- a/docs/data-sources/cdss_os_image.md
+++ b/docs/data-sources/cdss_os_image.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Cloud Data Streaming Service"
+---
+
+
 # Data Source: ncloud_cdss_os_image
 
 ## Example Usage

--- a/docs/data-sources/cdss_os_images.md
+++ b/docs/data-sources/cdss_os_images.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Cloud Data Streaming Service"
+---
+
+
 # Data Source: ncloud_cdss_os_images
 
 ## Example Usage

--- a/docs/data-sources/init_script.md
+++ b/docs/data-sources/init_script.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_init_script
 
 This module can be useful for getting detail of Init script created before.

--- a/docs/data-sources/launch_configuration.md
+++ b/docs/data-sources/launch_configuration.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Launch Configuration"
+subcategory: "Auto Scaling"
 ---
 
 

--- a/docs/data-sources/launch_configuration.md
+++ b/docs/data-sources/launch_configuration.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Launch Configuration"
+---
+
+
 # Data Source: ncloud_launch_configuration
 
 This module can be useful for getting detail of Launch Configuration created before.

--- a/docs/data-sources/lb.md
+++ b/docs/data-sources/lb.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Load Balancer"
+---
+
+
 # Data Source: ncloud_lb
 
 This module can be useful for getting detail of Load Balancer created before.

--- a/docs/data-sources/lb_listener.md
+++ b/docs/data-sources/lb_listener.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Load Balancer"
+---
+
+
 # Data Source: ncloud_lb_listener
 
 This module can be useful for getting detail of Load Balancer Listener created before.

--- a/docs/data-sources/lb_target_group.md
+++ b/docs/data-sources/lb_target_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Load Balancer"
+---
+
+
 # Data Source: ncloud_lb_target_group
 
 This module can be useful for getting detail of Load Balancer Target Group created before.

--- a/docs/data-sources/member_server_image.md
+++ b/docs/data-sources/member_server_image.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Member Server Image"
+---
+
+
 # Data Source: ncloud_member_server_image
 
 Gets a member server image.

--- a/docs/data-sources/member_server_images.md
+++ b/docs/data-sources/member_server_images.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Member Server Image"
+---
+
+
 # Data Source: ncloud_member_server_images
 
 Gets a list of member server images.

--- a/docs/data-sources/nas_volume.md
+++ b/docs/data-sources/nas_volume.md
@@ -1,3 +1,8 @@
+---
+subcategory: "NAS Volume"
+---
+
+
 # Data Source: ncloud_nas_volume
 
 Get NAS volume instance

--- a/docs/data-sources/nas_volumes.md
+++ b/docs/data-sources/nas_volumes.md
@@ -1,3 +1,8 @@
+---
+subcategory: "NAS Volume"
+---
+
+
 # Data Source: ncloud_nas_volumes
 
 Gets a list of NAS volume instances.

--- a/docs/data-sources/nat_gateway.md
+++ b/docs/data-sources/nat_gateway.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_nat_gateway
 
 This module can provide useful for get detail of NAT Gateway created before.

--- a/docs/data-sources/network_acl_deny_allow_groups.md
+++ b/docs/data-sources/network_acl_deny_allow_groups.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_network_acl_deny_allow_groups
 
 This resource is useful for look up the list of Network ACL Deny-Allow Group in the region.

--- a/docs/data-sources/network_acls.md
+++ b/docs/data-sources/network_acls.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_network_acls
 
 This resource is useful for look up the list of Network ACL in the region.

--- a/docs/data-sources/network_interface.md
+++ b/docs/data-sources/network_interface.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_network_interface
 
 This module can be useful for getting detail of Network Interface created before.

--- a/docs/data-sources/nks_cluster.md
+++ b/docs/data-sources/nks_cluster.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Kubernetes Service"
+---
+
+
 # Data Source: ncloud_nks_cluster
 
 Provides a Kubernetes Service cluster data.

--- a/docs/data-sources/nks_clusters.md
+++ b/docs/data-sources/nks_clusters.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Kubernetes Service"
+---
+
+
 # Data Source: ncloud_nks_clusters
 
 Provides list of Kubernetes Service cluster uuid.

--- a/docs/data-sources/nks_kube_config.md
+++ b/docs/data-sources/nks_kube_config.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Kubernetes Service"
+---
+
+
 # Data Source: ncloud_nks_versions
 
 Provides a kubeconfig from Kubernetes Service cluster.

--- a/docs/data-sources/nks_node_pool.md
+++ b/docs/data-sources/nks_node_pool.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Kubernetes Service"
+---
+
+
 # Data Source: ncloud_nks_node_pool
 
 Provides a Kubernetes Service nodepool data.

--- a/docs/data-sources/nks_node_pools.md
+++ b/docs/data-sources/nks_node_pools.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Kubernetes Service"
+---
+
+
 # Data Source: ncloud_nks_clusters
 
 Provides list of Kubernetes Service nodepool name.

--- a/docs/data-sources/nks_server_images.md
+++ b/docs/data-sources/nks_server_images.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Kubernetes Service"
+---
+
+
 # Data Source: ncloud_nks_server_images
 
 Provides list of available Kubernetes Nodepool ServerImages.

--- a/docs/data-sources/nks_server_products.md
+++ b/docs/data-sources/nks_server_products.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Kubernetes Service"
+---
+
+
 # Data Source: ncloud_nks_server_products
 
 Provides list of available Kubernetes Nodepool ServerProducts.

--- a/docs/data-sources/nks_versions.md
+++ b/docs/data-sources/nks_versions.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Kubernetes Service"
+---
+
+
 # Data Source: ncloud_nks_versions
 
 Provides list of available Kubernetes Service versions.

--- a/docs/data-sources/placement_group.md
+++ b/docs/data-sources/placement_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_placement_group
 
 This module can be useful for getting detail of Placement group created before.

--- a/docs/data-sources/port_forwarding_rule.md
+++ b/docs/data-sources/port_forwarding_rule.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_port_forwarding_rule
 
 Get a port forwarding rule.

--- a/docs/data-sources/port_forwarding_rules.md
+++ b/docs/data-sources/port_forwarding_rules.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_port_forwarding_rules
 
 Gets a list of port forwarding rules.

--- a/docs/data-sources/public_ip.md
+++ b/docs/data-sources/public_ip.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_public_ip
 
 Get public IP instance.

--- a/docs/data-sources/regions.md
+++ b/docs/data-sources/regions.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Meta Data Sources"
+---
+
+
 # Data Source: ncloud_regions
 
 Gets a list of available regions.

--- a/docs/data-sources/root_password.md
+++ b/docs/data-sources/root_password.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_root_password
 
 Gets the password of a root account with the server's login key.

--- a/docs/data-sources/route_table.md
+++ b/docs/data-sources/route_table.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_route_table
 
 This module can be useful for getting detail of Route Table created before.

--- a/docs/data-sources/route_tables.md
+++ b/docs/data-sources/route_tables.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_route_tables
 
 This resource is useful for look up the list of Route table in the region.

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_server
 
 This module can be useful for getting detail of Server instance created before.

--- a/docs/data-sources/server_image.md
+++ b/docs/data-sources/server_image.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_server_image
 
 To create a server instance (VM), you should select a server image. This data source gets a server image.

--- a/docs/data-sources/server_images.md
+++ b/docs/data-sources/server_images.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_server_images
 
 To create a server instance (VM), you should select a server image. This data source gets a list of server images.

--- a/docs/data-sources/server_product.md
+++ b/docs/data-sources/server_product.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_server_product
 
 You should select a server product (server specification) to create a server instance (VM).

--- a/docs/data-sources/server_products.md
+++ b/docs/data-sources/server_products.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_server_products
 
 You should select a server product (server specification) to create a server instance (VM).

--- a/docs/data-sources/servers.md
+++ b/docs/data-sources/servers.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Data Source: ncloud_servers
 
 Use this data source to get multiple `ncloud_server` ids 

--- a/docs/data-sources/ses_cluster.md
+++ b/docs/data-sources/ses_cluster.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Search Engine Service"
+---
+
+
 # Data Source: ncloud_ses_cluster
 
 Provides a Search Engine Service cluster data.

--- a/docs/data-sources/ses_clusters.md
+++ b/docs/data-sources/ses_clusters.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Search Engine Service"
+---
+
+
 # Data Source: ncloud_ses_clusters
 
 Provides list of Search Engine Service cluster uuid.

--- a/docs/data-sources/ses_node_os_images.md
+++ b/docs/data-sources/ses_node_os_images.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Search Engine Service"
+---
+
+
 # Data Source: ncloud_ses_node_os_images
 
 Provides list of available Server OS images.

--- a/docs/data-sources/ses_node_products.md
+++ b/docs/data-sources/ses_node_products.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Search Engine Service"
+---
+
+
 # Data Source: ncloud_ses_node_products
 
 Provides list of available Server product.

--- a/docs/data-sources/ses_versions.md
+++ b/docs/data-sources/ses_versions.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Search Engine Service"
+---
+
+
 # Data Source: ncloud_ses_versions
 
 Provides list of available Search Engine Service versions.

--- a/docs/data-sources/sourcebuild_project.md
+++ b/docs/data-sources/sourcebuild_project.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcebuild_project
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcebuild_project_computes.md
+++ b/docs/data-sources/sourcebuild_project_computes.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcebuild_project_computes
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcebuild_project_docker_engines.md
+++ b/docs/data-sources/sourcebuild_project_docker_engines.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcebuild_project_docker_engines
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcebuild_project_os.md
+++ b/docs/data-sources/sourcebuild_project_os.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcebuild_project_os
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcebuild_project_os_runtime_versions.md
+++ b/docs/data-sources/sourcebuild_project_os_runtime_versions.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcebuild_project_os_runtime_versions
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcebuild_project_os_runtimes.md
+++ b/docs/data-sources/sourcebuild_project_os_runtimes.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcebuild_project_os_runtimes
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcebuild_projects.md
+++ b/docs/data-sources/sourcebuild_projects.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcebuild_projects
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcecommit_repositories.md
+++ b/docs/data-sources/sourcecommit_repositories.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcecommit_repositories
 
 ~> **Note:** This data source only supports 'public' site.

--- a/docs/data-sources/sourcecommit_repository.md
+++ b/docs/data-sources/sourcecommit_repository.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcecommit_repository
 
 ~> **Note:** This data source only supports 'public' site.

--- a/docs/data-sources/sourcedeploy_project_stage.md
+++ b/docs/data-sources/sourcedeploy_project_stage.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcedeploy_project_stage
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcedeploy_project_stage_scenario.md
+++ b/docs/data-sources/sourcedeploy_project_stage_scenario.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcedeploy_project_stage_scenario
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcedeploy_project_stage_scenarios.md
+++ b/docs/data-sources/sourcedeploy_project_stage_scenarios.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcedeploy_project_stage_scenarios
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcedeploy_project_stages.md
+++ b/docs/data-sources/sourcedeploy_project_stages.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcedeploy_project_stages
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcedeploy_projects.md
+++ b/docs/data-sources/sourcedeploy_projects.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcedeploy_projects
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcepipeline_project.md
+++ b/docs/data-sources/sourcepipeline_project.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcepipieline_project
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcepipeline_projects.md
+++ b/docs/data-sources/sourcepipeline_projects.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcepipieline_projects
 
 ~> **Note** This data source only supports 'public' site.

--- a/docs/data-sources/sourcepipeline_trigger_timezone.md
+++ b/docs/data-sources/sourcepipeline_trigger_timezone.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Data Source: ncloud_sourcepipieline_trigger_timezone
 
 This data source is useful for look up the list of Sourcepipeline trigger time zone.

--- a/docs/data-sources/subnet.md
+++ b/docs/data-sources/subnet.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_subnet
 
 This module can be useful for getting detail of Subnet created before. for example, determine the CIDR block of that Subnet

--- a/docs/data-sources/subnets.md
+++ b/docs/data-sources/subnets.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_subnets
 
 This resource is useful for look up the list of Subnet in the region.

--- a/docs/data-sources/vpc.md
+++ b/docs/data-sources/vpc.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_vpc
 
 This module can be useful for getting detail of VPC created before, such as determining the CIDR block of that VPC.

--- a/docs/data-sources/vpc_peering.md
+++ b/docs/data-sources/vpc_peering.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_vpc_peering
 
 This module can be useful for getting detail of VPC peering created before.

--- a/docs/data-sources/vpcs.md
+++ b/docs/data-sources/vpcs.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Data Source: ncloud_vpcs
 
 This resource is useful for look up the list of VPC in the region.

--- a/docs/data-sources/zones.md
+++ b/docs/data-sources/zones.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Meta Data Sources"
+---
+
+
 # Data Source: ncloud_zones
 
 Gets a list of available zones.

--- a/docs/resources/access_control_group.md
+++ b/docs/resources/access_control_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Resource: ncloud_access_control_group
 
 Provides an ACG(Access Control Group) resource.

--- a/docs/resources/access_control_group_rule.md
+++ b/docs/resources/access_control_group_rule.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Resource: ncloud_access_control_group_rule
 
 Provides an rule of ACG(Access Control Group) resource.

--- a/docs/resources/auto_scaling_group.md
+++ b/docs/resources/auto_scaling_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Auto Scaling"
+---
+
+
 # Resource: ncloud_auto_scaling_group
 
 Provides a ncloud auto scaling group resource.

--- a/docs/resources/auto_scaling_policy.md
+++ b/docs/resources/auto_scaling_policy.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Auto Scaling"
+---
+
+
 # Resource: ncloud_auto_scaling_policy
 
 Provides a ncloud auto scaling policy resource.

--- a/docs/resources/auto_scaling_schedule.md
+++ b/docs/resources/auto_scaling_schedule.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Auto Scaling"
+---
+
+
 # Resource: ncloud_auto_scaling_schedule
 
 Provides a ncloud auto scaling schedule resource.

--- a/docs/resources/block_storage.md
+++ b/docs/resources/block_storage.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Resource: ncloud_block_storage
 
 Provides a Block Storage resource.

--- a/docs/resources/block_storage_snapshot.md
+++ b/docs/resources/block_storage_snapshot.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Resource: ncloud_block_storage
 
 Provides a ncloud block storage snapshot resource.

--- a/docs/resources/cdss_cluster.md
+++ b/docs/resources/cdss_cluster.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Cloud Data Streaming Service"
+---
+
+
 # Resource: ncloud_cdss_cluster
 
 ## Example Usage

--- a/docs/resources/cdss_config_group.md
+++ b/docs/resources/cdss_config_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Cloud Data Streaming Service"
+---
+
+
 # Resource: ncloud_cdss_config_group
 
 ## Example Usage

--- a/docs/resources/init_script.md
+++ b/docs/resources/init_script.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Resource: ncloud_init_script
 
 Provides an Init script resource.

--- a/docs/resources/launch_configuration.md
+++ b/docs/resources/launch_configuration.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Launch Configuration"
+---
+
+
 # Resource: ncloud_launch_configuration
 
 Provides a ncloud launch configuration resource.

--- a/docs/resources/launch_configuration.md
+++ b/docs/resources/launch_configuration.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Launch Configuration"
+subcategory: "Auto Scaling"
 ---
 
 

--- a/docs/resources/lb.md
+++ b/docs/resources/lb.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Load Balancer"
+---
+
+
 # Resource: ncloud_lb
 
 Provides a Load Balancer resource.

--- a/docs/resources/lb_listener.md
+++ b/docs/resources/lb_listener.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Load Balancer"
+---
+
+
 # Resource: ncloud_lb_listener
 
 Provides a Load Balancer Listener resource.

--- a/docs/resources/lb_target_group.md
+++ b/docs/resources/lb_target_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Load Balancer"
+---
+
+
 # Resource: ncloud_lb_target_group
 
 Provides a Target Group resource.

--- a/docs/resources/lb_target_group_attachment.md
+++ b/docs/resources/lb_target_group_attachment.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Load Balancer"
+---
+
+
 # Resource: ncloud_lb_target_group_attachment
 
 Provides a Target Group Attachment resource.

--- a/docs/resources/load_balancer.md
+++ b/docs/resources/load_balancer.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Load Balancer"
+---
+
+
 # Resource: ncloud_load_balancer
 Provides a ncloud load balancer instance resource.
 

--- a/docs/resources/load_balancer_ssl_certificate.md
+++ b/docs/resources/load_balancer_ssl_certificate.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Load Balancer"
+---
+
+
 # Resource: load_balancer_ssl_certificate
 
 Provides a ncloud load balancer ssl certificate resource.

--- a/docs/resources/login_key.md
+++ b/docs/resources/login_key.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Login Key"
+---
+
+
 # Resource: ncloud_login_key
 
 Provides a Login key resource.

--- a/docs/resources/nas_volume.md
+++ b/docs/resources/nas_volume.md
@@ -1,3 +1,8 @@
+---
+subcategory: "NAS Volume"
+---
+
+
 # Resource: ncloud_nas_volume
 
 Provides a NAS volume.

--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_nat_gateway
 
 Provides a NAT gateway resource.

--- a/docs/resources/network_acl.md
+++ b/docs/resources/network_acl.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_network_acl
 
 Provides a Network ACL resource.

--- a/docs/resources/network_acl_deny_allow_group.md
+++ b/docs/resources/network_acl_deny_allow_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_network_acl_deny_allow_group
 
 Provides a rule of Network ACL Deny-Allow Group resource. You can manage list of IP using this resource, \

--- a/docs/resources/network_acl_rule.md
+++ b/docs/resources/network_acl_rule.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_network_acl_rule
 
 Provides a rule of Network ACL  resource.

--- a/docs/resources/network_interface.md
+++ b/docs/resources/network_interface.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_network_interface
 
 Provides a Network Interface resource.

--- a/docs/resources/nks_cluster.md
+++ b/docs/resources/nks_cluster.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Kubernetes Service"
+---
+
+
 # Resource: ncloud_nks_cluster
 
 Provides a Kubernetes Service cluster resource.

--- a/docs/resources/nks_node_pool.md
+++ b/docs/resources/nks_node_pool.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Kubernetes Service"
+---
+
+
 # Resource: ncloud_nks_node_pool
 
 Provides a Kubernetes Service nodepool resource.

--- a/docs/resources/placement_group.md
+++ b/docs/resources/placement_group.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Resource: ncloud_placement_group
 
 Provides a Placement group resource.

--- a/docs/resources/port_forwarding_rule.md
+++ b/docs/resources/port_forwarding_rule.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # ncloud_port_forwarding_rule
 
 Provides a ncloud port forwarding rule resource.

--- a/docs/resources/public_ip.md
+++ b/docs/resources/public_ip.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Resource: ncloud_public_ip
 
 Provides a Public IP instance resource.

--- a/docs/resources/route.md
+++ b/docs/resources/route.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_route
 
 Provides a Route resource.

--- a/docs/resources/route_table.md
+++ b/docs/resources/route_table.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_route_table
 
 Provides a Route Table resource.

--- a/docs/resources/route_table_association.md
+++ b/docs/resources/route_table_association.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_route_table_association
 
 Provide a resource to create association between route table and a subnet.

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Server"
+---
+
+
 # Resource: ncloud_server
 
 Provides a Server instance resource.

--- a/docs/resources/ses_cluster.md
+++ b/docs/resources/ses_cluster.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Search Engine Service"
+---
+
+
 # Resource: ncloud_ses_cluster
 
 Provides a Search Engine Service cluster resource.

--- a/docs/resources/sourcebuild_project.md
+++ b/docs/resources/sourcebuild_project.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Resource: ncloud_sourcebuild_project
 
 ~> **Note** This resource only supports 'public' site.

--- a/docs/resources/sourcecommit_repository.md
+++ b/docs/resources/sourcecommit_repository.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Resource: ncloud_sourcecommit_repository
 
 ~> **Note:** This resource only supports 'public' site.

--- a/docs/resources/sourcedeploy_project.md
+++ b/docs/resources/sourcedeploy_project.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Resource: ncloud_sourcedeploy_project
 
 ~> **Note** This resource only supports 'public' site.

--- a/docs/resources/sourcedeploy_project_stage.md
+++ b/docs/resources/sourcedeploy_project_stage.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Resource : ncloud_sourcedeploy_project_stage
 
 ~> **Note** This resource only supports 'public' site.

--- a/docs/resources/sourcedeploy_project_stage_scenario.md
+++ b/docs/resources/sourcedeploy_project_stage_scenario.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Resource : ncloud_sourcedeploy_project_stage_scenario
 
 ~> **Note** This resource only supports 'public' site.

--- a/docs/resources/sourcepipeline_project.md
+++ b/docs/resources/sourcepipeline_project.md
@@ -1,3 +1,8 @@
+---
+subcategory: "Developer Tools"
+---
+
+
 # Resource: ncloud_sourcepipeline_project
 
 ~> **Note** This resource only supports 'public' site.

--- a/docs/resources/subnet.md
+++ b/docs/resources/subnet.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_subnet
 
 Provides a Subnet resource.

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_vpc
 
 Provides a VPC resource.

--- a/docs/resources/vpc_peering.md
+++ b/docs/resources/vpc_peering.md
@@ -1,3 +1,8 @@
+---
+subcategory: "VPC"
+---
+
+
 # Resource: ncloud_vpc_peering
 
 Provides a VPC Peering resource.


### PR DESCRIPTION
## Summary
- Categorized docs files by service

## Changes
- Categorized resources by service with reference to [official documents](https://developer.hashicorp.com/terraform/registry/providers/docs#subcategories)
- Added `subcategory` field to top of markdown document

```
---
subcategory: "Service Name"
---
```
- Named service name with reference to [ncloud api docs](https://guide.ncloud-docs.com/docs/ko/home) and [ncloud console](https://www.ncloud.com/)
ex. `Cloud Data Streaming Service`, `NAS Volume`, `Kubernetes Service`, `Search Engine Service`, `Login Key`
- Grouped `regions.md` and `zones.md` in `Meta Data Sources`

