### PR TITLE
Feat: auto scaling schedule validation

### DIFF
--- a/internal/service/autoscaling/auto_scaling_schedule.go
+++ b/internal/service/autoscaling/auto_scaling_schedule.go
@@ -1,13 +1,17 @@
 package autoscaling
 
 import (
+	"regexp"
+
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/autoscaling"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vautoscaling"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/common"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
+	. "github.com/terraform-providers/terraform-provider-ncloud/internal/verify"
 )
 
 const SCHEDULE_TIME_FORMAT = "2006-01-02T15:04:05Z0700"
@@ -26,26 +30,40 @@ func ResourceNcloudAutoScalingSchedule() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateDiagFunc: ToDiagFunc(validation.All(
+					validation.StringLenBetween(1, 255),
+					validation.StringMatch(regexp.MustCompile(`^[a-z]+[a-z0-9-]+[a-z0-9]$`), "Allows only lowercase letters(a-z), numbers, hyphen (-). Must start with an alphabetic character, must end with an English letter or number"))),
 			},
 			"desired_capacity": {
 				Type:     schema.TypeInt,
 				Required: true,
+				ValidateDiagFunc: ToDiagFunc(validation.IntBetween(0, 30)),
 			},
 			"min_size": {
 				Type:     schema.TypeInt,
 				Required: true,
+				ValidateDiagFunc: ToDiagFunc(validation.IntBetween(0, 30)),
 			},
 			"max_size": {
 				Type:     schema.TypeInt,
 				Required: true,
+				ValidateDiagFunc: ToDiagFunc(validation.IntBetween(0,30)),
 			},
 			"start_time": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateDiagFunc: ToDiagFunc(validation.Any(
+					validation.IsRFC3339Time,
+					ValidateDateISO8601,
+				)),
 			},
 			"end_time": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateDiagFunc: ToDiagFunc(validation.Any(
+					validation.IsRFC3339Time,
+					ValidateDateISO8601,
+				)),
 			},
 			"recurrence": {
 				Type:     schema.TypeString,

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -113,6 +113,16 @@ func ValidateParseDuration(v interface{}, k string) (ws []string, errors []error
 	return
 }
 
+func ValidateDateISO8601(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	
+	if _, err := time.Parse("2006-01-02T15:04:05Z0700", value); err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be parsed as a ISO8601 date: %s", k, err))
+	}
+	return
+}
+
 func ToDiagFunc(validator schema.SchemaValidateFunc) schema.SchemaValidateDiagFunc {
 	return func(v interface{}, path cty.Path) diag.Diagnostics {
 		var diags diag.Diagnostics

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -133,3 +133,66 @@ func Test_ValidatePortRange(t *testing.T) {
 		}
 	}
 }
+
+func Test_ValidateDateISO8601(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:   "2023-01-02T15:04:05Z0700",
+			ErrCount: 1,
+		},
+		{
+			Value:   "2023-01-02T15:04:05Z07:00",
+			ErrCount: 1,
+		}, 
+		{
+			Value:   "2023-01-02T15:04:05+0700",
+			ErrCount: 0,
+		},
+		{
+			Value:   "2023-01-02T15:04:05-0700",
+			ErrCount: 0,
+		},
+		{
+			Value:   "2023-01-02T15:04:05+0100",
+			ErrCount: 0,
+		},
+		{
+			Value:   "2023-01-02T15:04:05+07:00",
+			ErrCount: 1,
+		},
+		{
+			Value:   "2023-01-02T15:04:05Z+07:00",
+			ErrCount: 1,
+		},
+		{
+			Value:   "2023-01-02T15:04:05-07:00",
+			ErrCount: 1,
+		},
+		{
+			Value:   "2023-01-02T15:04:05Z",
+			ErrCount: 0,
+		},
+		{
+			Value:   "2023-01-02T15:04:05",
+			ErrCount: 1,
+		},
+		{
+			Value:   "2023-01-02",
+			ErrCount: 1,
+		},
+		{
+			Value:   "2023-01-02T",
+			ErrCount: 1,
+		},
+	}
+	for _, tc := range cases {
+		_, errors := ValidateDateISO8601(tc.Value, "date")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Date Format to trigger a validation error for %q", tc.Value)
+		}
+	}
+}


### PR DESCRIPTION
Changes
- auto_scaling_schedule_schema 검증 로직 추가
- start_time과 end_time 검증을 위한 date format(ISO8601) 추가 (두 가지 date format (콜론 유무)를 모두 검증하기 위함)

![image](https://github.com/NaverCloudPlatform/terraform-provider-ncloud/assets/73868703/e52079b2-1fb0-4962-802e-cfa51c281830)


Related Issue
- #309 