### PR TITLE
Support auto scaling adjustment types Data Source

### DIFF
--- a/docs/data-sources/auto_scaling_adjustment_types.md
+++ b/docs/data-sources/auto_scaling_adjustment_types.md
@@ -1,0 +1,65 @@
+# Data Source : ncloud_auto_scaling_adjustment_types
+To create an Auto Scaling policy, it's necessary to select an Auto Scaling Adjustment Type. This data source provides a list of available Auto Scaling Adjustment Types
+
+
+## Example Usage
+```hcl
+resource "ncloud_launch_configuration" "lc" {
+  name = "my-lc"
+  server_image_product_code = "SPSW0LINUX000046"
+  server_product_code = "SPSVRSSD00000003"
+}
+
+resource "ncloud_auto_scaling_group" "asg" {
+  launch_configuration_no = ncloud_launch_configuration.lc.launch_configuration_no
+  min_size = 1
+  max_size = 1
+  zone_no_list = ["2"]
+  wait_for_capacity_timeout = "0"
+}
+
+resource "ncloud_auto_scaling_policy" "policy" {
+  name = "my-policy"
+  adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[2].code # 2. 조회된 Adjustment Type 참조
+  scaling_adjustment = 2
+  auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
+}
+
+data "ncloud_auto_scaling_adjustment_types" "test" {
+}
+```
+
+```hcl
+data "ncloud_auto_scaling_adjustment_types" "test" {
+  filter {
+    name   = "code"
+    values = ["EXACT"]
+  }
+}
+
+output "filtered_types" {
+  value = data.ncloud_auto_scaling_adjustment_types.test.types
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `types` - (Optional) This is the list of Auto Scaling Adjustment Types. Each type consists of the following fields:
+    * `code` - (Optional) - This is the code for the type of adjustment. The codes are defined as follows:
+        * `CHANG` - This refers to a `Change in Capacity` adjustment.
+        * `PRCNT` - This stands for `Percent Change in Capacity` adjustment.
+        * `EXACT` - This code is for an `Exact Capacity` adjustment.
+
+
+* `code_name` - (Optional) - This is a more descriptive name for each code. They are defined as follows:
+    * `ChangeInCapacity` - This means the auto-scaling policy adjusts the number of instances by a specified absolute number.
+    * `PercentChangeInCapacit` - The auto-scaling policy adjusts the number of instances by a specified percentage.
+    * `ExactCapacity` - The auto-scaling policy adjusts the number of instances to a specified exact number.
+
+
+* `filter` - (Optional) Custom filter block as described below.
+    * `name` - (Required) The name of the field to filter by.
+    * `values` - (Required) Set of values that are accepted for the given field.
+    * `regex` - (Optional) is `values` treated as a regular expression.

--- a/docs/data-sources/auto_scaling_adjustment_types.md
+++ b/docs/data-sources/auto_scaling_adjustment_types.md
@@ -20,7 +20,7 @@ resource "ncloud_auto_scaling_group" "asg" {
 
 resource "ncloud_auto_scaling_policy" "policy" {
   name = "my-policy"
-  adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[2].code # 
+  adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[2].code
   scaling_adjustment = 2
   auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
 }
@@ -46,25 +46,24 @@ output "filtered_types" {
 
 The following arguments are supported:
 
-* `types` - (Optional) This is the list of Auto Scaling Adjustment Types.
-
-
 * `filter` - (Optional) Custom filter block as described below.
     * `name` - (Required) The name of the field to filter by.
     * `values` - (Required) Set of values that are accepted for the given field.
     * `regex` - (Optional) is `values` treated as a regular expression.
 
-
 ## Attributes Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `code` - (Optional) - This is the code for the type of adjustment. </br>
-   Valid Values : `CHANG`, `PRCNT`, `EXACT`
-
-* `code_name` - (Optional) - This is a more descriptive name for each code. </br>
-   Valid Values : `ChangeInCapacity`, `PercentChangeInCapacit`,`ExactCapacity`
-  * `ChangeInCapacity` - This means the auto-scaling policy adjusts the number of instances by a specified absolute number.
-  * `PercentChangeInCapacit` - The auto-scaling policy adjusts the number of instances by a specified percentage.
-  * `ExactCapacity` - The auto-scaling policy adjusts the number of instances to a specified exact number.
+* `types` - This is the list of Auto Scaling Adjustment Types.
+    * `code` - This is the code for the type of adjustment. </br>
+    Valid Values :</br>
+        `CHANG` - This refers to a `Change in Capacity` adjustment.</br>
+        `PRCNT` - This stands for `Percent Change in Capacity` adjustment.</br>
+        `EXACT` - This code is for an `Exact Capacity` adjustment.
+    * `code_name` - This is a more descriptive name for each code.</br>
+        Valid Values :</br>
+            `ChangeInCapacity` - This means the auto-scaling policy adjusts the number of instances by a specified absolute number.</br>
+            `PercentChangeInCapacit` - The auto-scaling policy adjusts the number of instances by a specified percentage.</br>
+            `ExactCapacity` - The auto-scaling policy adjusts the number of instances to a specified exact number.
 

--- a/docs/data-sources/auto_scaling_adjustment_types.md
+++ b/docs/data-sources/auto_scaling_adjustment_types.md
@@ -20,7 +20,7 @@ resource "ncloud_auto_scaling_group" "asg" {
 
 resource "ncloud_auto_scaling_policy" "policy" {
   name = "my-policy"
-  adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[2].code # 2. 조회된 Adjustment Type 참조
+  adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[2].code # 
   scaling_adjustment = 2
   auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
 }
@@ -46,20 +46,25 @@ output "filtered_types" {
 
 The following arguments are supported:
 
-* `types` - (Optional) This is the list of Auto Scaling Adjustment Types. Each type consists of the following fields:
-    * `code` - (Optional) - This is the code for the type of adjustment. The codes are defined as follows:
-        * `CHANG` - This refers to a `Change in Capacity` adjustment.
-        * `PRCNT` - This stands for `Percent Change in Capacity` adjustment.
-        * `EXACT` - This code is for an `Exact Capacity` adjustment.
-
-
-* `code_name` - (Optional) - This is a more descriptive name for each code. They are defined as follows:
-    * `ChangeInCapacity` - This means the auto-scaling policy adjusts the number of instances by a specified absolute number.
-    * `PercentChangeInCapacit` - The auto-scaling policy adjusts the number of instances by a specified percentage.
-    * `ExactCapacity` - The auto-scaling policy adjusts the number of instances to a specified exact number.
+* `types` - (Optional) This is the list of Auto Scaling Adjustment Types.
 
 
 * `filter` - (Optional) Custom filter block as described below.
     * `name` - (Required) The name of the field to filter by.
     * `values` - (Required) Set of values that are accepted for the given field.
     * `regex` - (Optional) is `values` treated as a regular expression.
+
+
+## Attributes Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `code` - (Optional) - This is the code for the type of adjustment. </br>
+   Valid Values : `CHANG`, `PRCNT`, `EXACT`
+
+* `code_name` - (Optional) - This is a more descriptive name for each code. </br>
+   Valid Values : `ChangeInCapacity`, `PercentChangeInCapacit`,`ExactCapacity`
+  * `ChangeInCapacity` - This means the auto-scaling policy adjusts the number of instances by a specified absolute number.
+  * `PercentChangeInCapacit` - The auto-scaling policy adjusts the number of instances by a specified percentage.
+  * `ExactCapacity` - The auto-scaling policy adjusts the number of instances to a specified exact number.
+

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -32,6 +32,7 @@ func Provider() *schema.Provider {
 		"ncloud_auto_scaling_group":                      autoscaling.DataSourceNcloudAutoScalingGroup(),
 		"ncloud_auto_scaling_policy":                     autoscaling.DataSourceNcloudAutoScalingPolicy(),
 		"ncloud_auto_scaling_schedule":                   autoscaling.DataSourceNcloudAutoScalingSchedule(),
+		"ncloud_auto_scaling_adjustment_types":           autoscaling.DataSourceNcloudAutoScalingAdjustmentTypes(),
 		"ncloud_block_storage":                           server.DataSourceNcloudBlockStorage(),
 		"ncloud_block_storage_snapshot":                  server.DataSourceNcloudBlockStorageSnapshot(),
 		"ncloud_cdss_cluster":                            cdss.DataSourceNcloudCDSSCluster(),

--- a/internal/service/autoscaling/auto_scaling_adjustment_types_data_source.go
+++ b/internal/service/autoscaling/auto_scaling_adjustment_types_data_source.go
@@ -61,9 +61,9 @@ func getAutoScalingAdjustmentListFiltered(d *schema.ResourceData, config *conn.P
 	var err error
 
 	if config.SupportVPC == true {
-		resources, err = getVpcAutoScalingAdjustmentTypeList(d, config)
+		resources, err = getVpcAutoScalingAdjustmentTypeList(config)
 	} else {
-		resources, err = getClassicAutoScalingAdjustmentTypeList(d, config)
+		resources, err = getClassicAutoScalingAdjustmentTypeList(config)
 	}
 
 	if err != nil {
@@ -76,7 +76,7 @@ func getAutoScalingAdjustmentListFiltered(d *schema.ResourceData, config *conn.P
 	return resources, nil
 }
 
-func getVpcAutoScalingAdjustmentTypeList(d *schema.ResourceData, config *conn.ProviderConfig) ([]map[string]interface{}, error) {
+func getVpcAutoScalingAdjustmentTypeList(config *conn.ProviderConfig) ([]map[string]interface{}, error) {
 	client := config.Client
 	regionCode := config.RegionCode
 
@@ -107,7 +107,7 @@ func getVpcAutoScalingAdjustmentTypeList(d *schema.ResourceData, config *conn.Pr
 	return resources, nil
 }
 
-func getClassicAutoScalingAdjustmentTypeList(d *schema.ResourceData, config *conn.ProviderConfig) ([]map[string]interface{}, error) {
+func getClassicAutoScalingAdjustmentTypeList(config *conn.ProviderConfig) ([]map[string]interface{}, error) {
 	client := config.Client
 	regionCode := config.RegionCode
 

--- a/internal/service/autoscaling/auto_scaling_adjustment_types_data_source.go
+++ b/internal/service/autoscaling/auto_scaling_adjustment_types_data_source.go
@@ -1,0 +1,139 @@
+package autoscaling
+
+import (
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vautoscaling"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	. "github.com/terraform-providers/terraform-provider-ncloud/internal/common"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
+)
+
+func DataSourceNcloudAutoScalingAdjustmentTypes() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNcloudAutoScalingAdjustmentTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"code_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"filter": DataSourceFiltersSchema(),
+		},
+	}
+}
+
+func dataSourceNcloudAutoScalingAdjustmentTypesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*conn.ProviderConfig)
+
+	resources, err := getAutoScalingAdjustmentListFiltered(d, config)
+
+	if err != nil {
+		return err
+	}
+
+	types := make([]map[string]interface{}, len(resources))
+	for i, r := range resources {
+		types[i] = map[string]interface{}{
+			"code":      r["code"],
+			"code_name": r["code_name"],
+		}
+	}
+
+	d.SetId("ncloud_auto_scaling_adjustment_types")
+	d.Set("types", types)
+
+	return nil
+}
+
+func getAutoScalingAdjustmentListFiltered(d *schema.ResourceData, config *conn.ProviderConfig) ([]map[string]interface{}, error) {
+	var resources []map[string]interface{}
+	var err error
+
+	if config.SupportVPC == true {
+		resources, err = getVpcAutoScalingAdjustmentTypeList(d, config)
+	} else {
+		resources, err = getClassicAutoScalingAdjustmentTypeList(d, config)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if f, ok := d.GetOk("filter"); ok {
+		resources = ApplyFilters(f.(*schema.Set), resources, DataSourceNcloudAutoScalingAdjustmentTypes().Schema)
+	}
+	return resources, nil
+}
+
+func getVpcAutoScalingAdjustmentTypeList(d *schema.ResourceData, config *conn.ProviderConfig) ([]map[string]interface{}, error) {
+	client := config.Client
+	regionCode := config.RegionCode
+
+	reqParams := &vautoscaling.GetAdjustmentTypeListRequest{
+		RegionCode: &regionCode,
+	}
+
+	LogCommonRequest("GetAdjustmentTypeListRequest", reqParams)
+
+	resp, err := client.Vautoscaling.V2Api.GetAdjustmentTypeList(reqParams)
+	if err != nil {
+		LogErrorResponse("GetAdjustmentTypeListRequest", err, reqParams)
+		return nil, err
+	}
+
+	LogResponse("GetAdjustmentTypeListRequest", resp)
+
+	var resources []map[string]interface{}
+
+	for _, r := range resp.AdjustmentTypeList {
+		instance := map[string]interface{}{
+			"code":      *r.Code,
+			"code_name": *r.CodeName,
+		}
+
+		resources = append(resources, instance)
+	}
+	return resources, nil
+}
+
+func getClassicAutoScalingAdjustmentTypeList(d *schema.ResourceData, config *conn.ProviderConfig) ([]map[string]interface{}, error) {
+	client := config.Client
+	regionCode := config.RegionCode
+
+	reqParams := &vautoscaling.GetAdjustmentTypeListRequest{
+		RegionCode: &regionCode,
+	}
+
+	LogCommonRequest("GetAdjustmentTypeListRequest", reqParams)
+
+	resp, err := client.Vautoscaling.V2Api.GetAdjustmentTypeList(reqParams)
+	if err != nil {
+		LogErrorResponse("GetAdjustmentTypeListRequest", err, reqParams)
+		return nil, err
+	}
+
+	LogResponse("GetAdjustmentTypeListRequest", resp)
+
+	var resources []map[string]interface{}
+
+	for _, r := range resp.AdjustmentTypeList {
+		instance := map[string]interface{}{
+			"code":      *r.Code,
+			"code_name": *r.CodeName,
+		}
+
+		resources = append(resources, instance)
+	}
+	return resources, nil
+}

--- a/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
@@ -1,0 +1,146 @@
+package autoscaling_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	. "github.com/terraform-providers/terraform-provider-ncloud/internal/acctest"
+	"testing"
+)
+
+func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic(t *testing.T) {
+	dataName := "data.ncloud_auto_scaling_adjustment_types.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { TestAccPreCheck(t) },
+		Providers: GetTestAccProviders(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					TestAccCheckDataSourceID(dataName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic(t *testing.T) {
+	dataName := "data.ncloud_auto_scaling_adjustment_types.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { TestAccPreCheck(t) },
+		Providers: GetTestAccProviders(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					TestAccCheckDataSourceID(dataName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_byFilterCode(t *testing.T) {
+	dataName := "data.ncloud_auto_scaling_adjustment_types.by_filter"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { TestAccPreCheck(t) },
+		Providers: GetTestAccProviders(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesByFilterCodeConfig("EXACT"),
+				Check: resource.ComposeTestCheckFunc(
+					TestAccCheckDataSourceID(dataName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_byFilterCode(t *testing.T) {
+	dataName := "data.ncloud_auto_scaling_adjustment_types.by_filter"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { TestAccPreCheck(t) },
+		Providers: GetTestAccProviders(false),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesByFilterCodeConfig("EXACT"),
+				Check: resource.ComposeTestCheckFunc(
+					TestAccCheckDataSourceID(dataName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig() string {
+	return fmt.Sprint(`
+	resource "ncloud_launch_configuration" "lc" {
+		name = "my-lc"
+  		server_image_product_code = "SPSW0LINUX000046"
+  		server_product_code = "SPSVRSSD00000003"
+	}
+
+	resource "ncloud_auto_scaling_group" "asg" {
+  		launch_configuration_no = ncloud_launch_configuration.lc.launch_configuration_no
+  		min_size = 1
+		max_size = 1
+  		zone_no_list = ["2"]
+  		wait_for_capacity_timeout = "0"
+	}
+
+	resource "ncloud_auto_scaling_policy" "policy" {
+  		name = "my-policy"
+  		adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[0].code
+  		scaling_adjustment = 2
+  		auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
+	}
+	
+	
+	data "ncloud_auto_scaling_adjustment_types" "test" {
+	
+	}
+	`)
+}
+
+func testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig() string {
+	return fmt.Sprint(`
+	resource "ncloud_launch_configuration" "lc" {
+		name = "my-lc"
+  		server_image_product_code = "SPSW0LINUX000046"
+  		server_product_code = "SPSVRSSD00000003"
+	}
+
+	resource "ncloud_auto_scaling_group" "asg" {
+  		launch_configuration_no = ncloud_launch_configuration.lc.launch_configuration_no
+  		min_size = 1
+		max_size = 1
+  		zone_no_list = ["2"]
+  		wait_for_capacity_timeout = "0"
+	}
+
+	resource "ncloud_auto_scaling_policy" "policy" {
+  		name = "my-policy"
+  		adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[2].code 
+  		scaling_adjustment = 2
+  		auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
+	}
+	
+	
+	data "ncloud_auto_scaling_adjustment_types" "test" {
+	}
+	`)
+}
+
+func testAccDataSourceNcloudAutoScalingAdjustmentTypesByFilterCodeConfig(code string) string {
+	return fmt.Sprintf(`
+	data "ncloud_auto_scaling_adjustment_types" "by_filter" {
+  		filter {
+    		name   = "code"
+   			 values = ["%s"]
+	    }
+	}
+`, code)
+}

--- a/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
@@ -2,10 +2,11 @@ package autoscaling_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/acctest"
-	"testing"
 )
 
 func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic(t *testing.T) {
@@ -84,23 +85,23 @@ func testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig(lcName strin
 	return fmt.Sprintf(`
 	resource "ncloud_launch_configuration" "lc" {
 		name = "%s"
-  		server_image_product_code = "SPSW0LINUX000046"
-  		server_product_code = "SPSVRSSD00000003"
+		server_image_product_code = "SPSW0LINUX000046"
+		server_product_code = "SPSVRSSD00000003"
 	}
 
 	resource "ncloud_auto_scaling_group" "asg" {
-  		launch_configuration_no = ncloud_launch_configuration.lc.launch_configuration_no
-  		min_size = 1
+		launch_configuration_no = ncloud_launch_configuration.lc.launch_configuration_no
+		min_size = 1
 		max_size = 1
-  		zone_no_list = ["2"]
-  		wait_for_capacity_timeout = "0"
+		zone_no_list = ["2"]
+		wait_for_capacity_timeout = "0"
 	}
 
 	resource "ncloud_auto_scaling_policy" "policy" {
-  		name = "%s"
-  		adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[0].code
-  		scaling_adjustment = 2
-  		auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
+		name = "%s"
+		adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[0].code
+		scaling_adjustment = 2
+		auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
 	}
 	
 	
@@ -114,23 +115,23 @@ func testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(lcName string, p
 	return fmt.Sprintf(`
 	resource "ncloud_launch_configuration" "lc" {
 		name = "%s"
-  		server_image_product_code = "SPSW0LINUX000046"
-  		server_product_code = "SPSVRSSD00000003"
+		server_image_product_code = "SPSW0LINUX000046"
+		server_product_code = "SPSVRSSD00000003"
 	}
 
 	resource "ncloud_auto_scaling_group" "asg" {
-  		launch_configuration_no = ncloud_launch_configuration.lc.launch_configuration_no
-  		min_size = 1
+		launch_configuration_no = ncloud_launch_configuration.lc.launch_configuration_no
+		min_size = 1
 		max_size = 1
-  		zone_no_list = ["2"]
-  		wait_for_capacity_timeout = "0"
+		zone_no_list = ["2"]
+		wait_for_capacity_timeout = "0"
 	}
 
 	resource "ncloud_auto_scaling_policy" "policy" {
-  		name = "%s"
-  		adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[2].code 
-  		scaling_adjustment = 2
-  		auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
+		name = "%s"
+		adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[2].code 
+		scaling_adjustment = 2
+		auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
 	}
 	
 	
@@ -142,10 +143,10 @@ func testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(lcName string, p
 func testAccDataSourceNcloudAutoScalingAdjustmentTypesByFilterCodeConfig(code string) string {
 	return fmt.Sprintf(`
 	data "ncloud_auto_scaling_adjustment_types" "by_filter" {
-  		filter {
-    		 name   = "code"
-   			 values = ["%s"]
-	    }
+		filter {
+			name   = "code"
+			values = ["%s"]
+		}
 	}
 `, code)
 }

--- a/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
@@ -2,12 +2,15 @@ package autoscaling_test
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/acctest"
 	"testing"
 )
 
 func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic(t *testing.T) {
+	lcName := fmt.Sprintf("lc-%s", acctest.RandString(5))
+	policyName := fmt.Sprintf("policy-%s", acctest.RandString(5))
 	dataName := "data.ncloud_auto_scaling_adjustment_types.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -15,7 +18,7 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic(t *testing.
 		Providers: GetTestAccProviders(false),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig(),
+				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig(lcName, policyName),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID(dataName),
 				),
@@ -25,6 +28,8 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic(t *testing.
 }
 
 func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic(t *testing.T) {
+	lcName := fmt.Sprintf("lc-%s", acctest.RandString(5))
+	policyName := fmt.Sprintf("policy-%s", acctest.RandString(5))
 	dataName := "data.ncloud_auto_scaling_adjustment_types.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -32,7 +37,7 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic(t *testing.T) {
 		Providers: GetTestAccProviders(false),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(),
+				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(lcName, policyName),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID(dataName),
 				),
@@ -75,10 +80,10 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_byFilterCode(t *testi
 	})
 }
 
-func testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig() string {
-	return fmt.Sprint(`
+func testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig(lcName string, policyName string) string {
+	return fmt.Sprintf(`
 	resource "ncloud_launch_configuration" "lc" {
-		name = "my-lc"
+		name = "%s"
   		server_image_product_code = "SPSW0LINUX000046"
   		server_product_code = "SPSVRSSD00000003"
 	}
@@ -92,7 +97,7 @@ func testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig() string {
 	}
 
 	resource "ncloud_auto_scaling_policy" "policy" {
-  		name = "my-policy"
+  		name = "%s"
   		adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[0].code
   		scaling_adjustment = 2
   		auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
@@ -102,13 +107,13 @@ func testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig() string {
 	data "ncloud_auto_scaling_adjustment_types" "test" {
 	
 	}
-	`)
+	`, lcName, policyName)
 }
 
-func testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig() string {
-	return fmt.Sprint(`
+func testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(lcName string, policyName string) string {
+	return fmt.Sprintf(`
 	resource "ncloud_launch_configuration" "lc" {
-		name = "my-lc"
+		name = "%s"
   		server_image_product_code = "SPSW0LINUX000046"
   		server_product_code = "SPSVRSSD00000003"
 	}
@@ -122,7 +127,7 @@ func testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig() string {
 	}
 
 	resource "ncloud_auto_scaling_policy" "policy" {
-  		name = "my-policy"
+  		name = "%s"
   		adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[2].code 
   		scaling_adjustment = 2
   		auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
@@ -131,14 +136,14 @@ func testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig() string {
 	
 	data "ncloud_auto_scaling_adjustment_types" "test" {
 	}
-	`)
+	`, lcName, policyName)
 }
 
 func testAccDataSourceNcloudAutoScalingAdjustmentTypesByFilterCodeConfig(code string) string {
 	return fmt.Sprintf(`
 	data "ncloud_auto_scaling_adjustment_types" "by_filter" {
   		filter {
-    		name   = "code"
+    		 name   = "code"
    			 values = ["%s"]
 	    }
 	}


### PR DESCRIPTION
refer #310 

## Features

### Data Source
- datasource_ncloud_auto_scaling_adjustment_type

### Docs
- auto_scaling_adjustment_types.md

### Test
```
$ go test -run=TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic -v
=== RUN   TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic
=== PAUSE TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic
=== CONT  TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic
--- PASS: TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic (10.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/autoscaling   11.023s

$ go test -run=TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic -v
=== RUN   TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic
=== PAUSE TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic
=== CONT  TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic
--- PASS: TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic (16.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/autoscaling   16.539s

$ go test -run=TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_byFilterCode -v
=== RUN   TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_byFilterCode
=== PAUSE TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_byFilterCode
=== CONT  TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_byFilterCode
--- PASS: TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_byFilterCode (1.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/autoscaling   1.499s

$ go test -run=TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_byFilterCode -v
=== RUN   TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_byFilterCode
=== PAUSE TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_byFilterCode
=== CONT  TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_byFilterCode
--- PASS: TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_byFilterCode (1.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-ncloud/internal/service/autoscaling   1.477s

```

Closes #310 