### PR TITLE
Fix: Prevent panic while updating network interface

### DIFF
--- a/internal/service/server/network_interface.go
+++ b/internal/service/server/network_interface.go
@@ -376,6 +376,8 @@ func attachNetworkInterface(d *schema.ResourceData, config *conn.ProviderConfig)
 		return err
 	}
 
+	waitForPublicIpDisassociate(d, config)
+
 	return nil
 }
 
@@ -398,6 +400,30 @@ func attachVpcNetworkInterface(d *schema.ResourceData, config *conn.ProviderConf
 
 	if err := waitForNetworkInterfaceAttachment(config, d.Id()); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func waitForPublicIpDisassociate(d *schema.ResourceData, config *conn.ProviderConfig) error {
+	reqParams := &vserver.GetServerInstanceDetailRequest{
+		RegionCode:         &config.RegionCode,
+		ServerInstanceNo:   ncloud.String(d.Get("server_instance_no").(string)),
+	}
+
+	resp, err := config.Client.Vserver.V2Api.GetServerInstanceDetail(reqParams)
+	if err != nil {
+		return err
+	}
+
+	if err := ValidateOneResult(len(resp.ServerInstanceList)); err != nil {
+		return err
+	}
+
+	if publicIpNo := *resp.ServerInstanceList[0].PublicIpInstanceNo; publicIpNo != "" {
+		if err := waitForPublicIpDisassociation(config, publicIpNo); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/service/server/network_interface.go
+++ b/internal/service/server/network_interface.go
@@ -376,10 +376,6 @@ func attachNetworkInterface(d *schema.ResourceData, config *conn.ProviderConfig)
 		return err
 	}
 
-	if err := waitForPublicIpDisassociation(config, d.Id()); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -61,7 +61,7 @@ func ResourceNcloudServer() *schema.Resource {
 				ForceNew: true,
 				ValidateDiagFunc: ToDiagFunc(validation.All(
 					validation.StringLenBetween(3, 30),
-					validation.StringMatch(regexp.MustCompile(`^[A-Za-z0-9-*]+$`), "Composed of alphabets, numbers, hyphen (-) and wild card (*)."),
+					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]+[A-Za-z0-9-*]+$`), "start with an alphabets and composed of alphabets, numbers, hyphen (-) and wild card (*)."),
 					validation.StringMatch(regexp.MustCompile(`.*[^\\-]$`), "Hyphen (-) cannot be used for the last character and if wild card (*) is used, other characters cannot be input."),
 				)),
 			},

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -61,8 +61,7 @@ func ResourceNcloudServer() *schema.Resource {
 				ForceNew: true,
 				ValidateDiagFunc: ToDiagFunc(validation.All(
 					validation.StringLenBetween(3, 30),
-					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]+[A-Za-z0-9-*]+$`), "start with an alphabets and composed of alphabets, numbers, hyphen (-) and wild card (*)."),
-					validation.StringMatch(regexp.MustCompile(`.*[^\\-]$`), "Hyphen (-) cannot be used for the last character and if wild card (*) is used, other characters cannot be input."),
+					validation.StringMatch(regexp.MustCompile(`^[a-z]+[a-z0-9\-]+[a-z0-9]$`), "start with an alphabets and composed of alphabets, numbers, hyphen (-) and wild card (*). Hyphen (-) cannot be used for the last character"),
 				)),
 			},
 			"description": {

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -61,8 +61,7 @@ func ResourceNcloudServer() *schema.Resource {
 				ForceNew: true,
 				ValidateDiagFunc: ToDiagFunc(validation.All(
 					validation.StringLenBetween(3, 30),
-					validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]+[A-Za-z0-9-*]+$`), "start with an alphabets and composed of alphabets, numbers, hyphen (-) and wild card (*)."),
-					validation.StringMatch(regexp.MustCompile(`.*[^\\-]$`), "Hyphen (-) cannot be used for the last character and if wild card (*) is used, other characters cannot be input."),
+					validation.StringMatch(regexp.MustCompile(`^[a-z]+[a-z0-9-]+[a-z0-9]$`), "start with an alphabets and composed of alphabets, numbers, hyphen (-) and wild card (*). Hyphen (-) cannot be used for the last character"),
 				)),
 			},
 			"description": {

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -986,7 +986,7 @@ func stopVpcServerInstance(config *conn.ProviderConfig, id string) error {
 	LogCommonRequest("stopVpcServerInstance", reqParams)
 	resp, err := config.Client.Vserver.V2Api.StopServerInstances(reqParams)
 	if err != nil {
-		LogErrorResponse("stopClassicServerInstance", err, reqParams)
+		LogErrorResponse("stopVpcServerInstance", err, reqParams)
 		return err
 	}
 	LogResponse("stopVpcServerInstance", resp)


### PR DESCRIPTION
### related issues
#289 

### Description
Deleted by calling an unrelated function.

### Cause
 - public_ip is not created.
 - 'waitForPublicIpDisassociation()' in public_ip is called with network_interface's id

![image](https://github.com/NaverCloudPlatform/terraform-provider-ncloud/assets/77601495/8571e05f-338e-4242-b13d-73a486b56c68)
