### PR TITLE
docs: Fix Autoscaling & Load Balancer related documents

### DIFF
--- a/docs/resources/auto_scaling_policy.md
+++ b/docs/resources/auto_scaling_policy.md
@@ -68,7 +68,7 @@ resource "ncloud_auto_scaling_policy" "test-policy-CHANG" {
 
 The following arguments are supported:
 
-* `name` - (Required) Auto Scaling Policy name to create.
+* `name` - (Required) Auto Scaling Policy name to create. Only lowercase alphanumeric characters and non-consecutive hyphens (-) allowed. First character must be a letter, but the last character may be a letter or a number.
 * `adjustment_type_code` - (Required) Determines how the number of servers is scaled when the scaling policy is performed. Valid values are `CHANG`, `EXACT`, and `PRCNT`.
 * `scaling_adjustment` - (Required) Specify the adjustment value for the adjustment type. Enter a negative value to decrease when adjustTypeCode is `CHANG` or `PRCNT`.
 * `cooldown` - (Optional) The cooldown time is the period set to ignore even if the monitoring event alarm occurs after the actual scaling is being performed or is completed.

--- a/docs/resources/auto_scaling_schedule.md
+++ b/docs/resources/auto_scaling_schedule.md
@@ -75,9 +75,9 @@ resource "ncloud_auto_scaling_schedule" "schedule" {
 The following arguments are supported:
 
 * `name` - (Required) Auto Scaling Schedule name to create.
-* `desired_capacity` - (Required) The number of servers is adjusted according to the desired capacity value.
-* `min_size` - (Required) The minimum size of the Auto Scaling Group.
-* `max_size` - (Required) The maximum size of the Auto Scaling Group.
+* `desired_capacity` - (Required) The number of servers is adjusted according to the desired capacity value. Valid from `0` to `30`.
+* `min_size` - (Required) The minimum size of the Auto Scaling Group. Valid from `0` to `30`.
+* `max_size` - (Required) The maximum size of the Auto Scaling Group. Valid from `0` to `30`.
 * `start_time` - (Optional) You can determine the date and time when the schedule first starts. If you don't enter `recurrence`, be sure to enter startTime. It cannot be duplicated with the startTime of another schedule and must be later than the current time, before endTime. Format : `yyyy-MM-ddTHH:mm:ssZ` format in UTC/KST only (for example, 2021-02-02T15:00:00+0900).
 * `end_time` - (Optional) You can determine the date and time when the schedule end. If you don't enter `recurrence`, be sure to enter startTime. 
 It must be a time later than the current time and a time later than the startTime. Format : `yyyy-MM-ddTHH:mm:ssZ` format in UTC/KST only (for example, 2021-02-02T18:00:00+0900).

--- a/docs/resources/lb_listener.md
+++ b/docs/resources/lb_listener.md
@@ -26,7 +26,7 @@ The following arguments are supported:
 
 * `load_balancer_no` - (Required) The ID of the load balancer.
 * `target_group_no` - (Required) The ID of the target group.
-* `port` - (Required) The port on which the load balancer is listening.
+* `port` - (Required) The port on which the load balancer is listening. Valid from `1` to `65534`.
 * `protocol` - (Required) The protocol type for the listener. The types of protocols available are limited by the type of load balancer. `APPLICATION` Load Balancer Accepted values: `HTTP` | `HTTPS`, `NETWORK` Load Balancer Accepted values : `TCP`, `NETWORK_PROXY` Load Balancer Accepted values : `TCP` | `TLS`. 
 * `tls_min_version_type` - (Optional) The TLS minimum supported version type code. Valid only if the listener protocol type is `HTTPS` or `TLS`. Accepted values : `TLSV10`(TLSv1.0) | `TLSV11`(TLSv1.1) | `TLSV12`(TLSv1.2). Default: `TLSV10`.
 * `use_http2` - (Optional) Whether to use HTTP/2 protocol. Valid only if the listener protocol type is `HTTPS`. Accepted values : `true`, `false`. Default: `false`.

--- a/docs/resources/lb_target_group.md
+++ b/docs/resources/lb_target_group.md
@@ -28,15 +28,15 @@ resource "ncloud_lb_target_group" "test" {
 The following arguments are supported:
 
 * `name` - (Optional) The name of the target group.
-* `port` - (Optional) The port on which targets receive traffic. Default: 80.
+* `port` - (Optional) The port on which targets receive traffic. Default: `80`. Valid from `1` to `65534`.
 * `protocol` - (Required) The protocol to use for routing traffic to the targets. Accepted values: `TCP` | `PROXY_TCP` | `HTTP` | `HTTPS`. The protocol you use determines which type of load balancer is applicable. `APPLICATION` Load Balancer Accepted values: `HTTP` | `HTTPS`, `NETWORK` Load Balancer Accepted values : `TCP`, `NETWORK_PROXY` Load Balancer Accepted values : `PROXY_TCP`.
 * `description` - (Optional) The description of the target group.
 * `health_check` - (Optional) The health check to check the health of the target.
-    * `cycle` - (Optional) The number of health check cycle.
-    * `down_threshold` - (Optional) The number of health check failure threshold. You can determine the number of consecutive health check failures that are required before a health check is considered a failed state.
-    * `up_threshold` - (Optional) The number of health check normal threshold. You can determine the number of consecutive health checks that are required before health checks are considered success state.
+    * `cycle` - (Optional) The number of health check cycle. Default: `30`. Valid from `5` to `300`.
+    * `down_threshold` - (Optional) The number of health check failure threshold. You can determine the number of consecutive health check failures that are required before a health check is considered a failed state. Default: `2`. Valid from `2` to `10`.
+    * `up_threshold` - (Optional) The number of health check normal threshold. You can determine the number of consecutive health checks that are required before health checks are considered success state. Default: `30`.  Valid from `2` to `10`.
     * `http_method` - (Optional) The HTTP method for the health check. You can determine which HTTP method to use for health checks. If the health check protocol type is `HTTP` or `HTTPS`, be sure to enter it. Accepted values: `HEAD` | `GET`.
-    * `port` - (Optional) The port to use for health checks. Default: 80.
+    * `port` - (Optional) The port to use for health checks. Default: 80. Valid from `1` to `65534`.
     * `protocol` - (Required) The type of protocol to use for health checks. If the target group protocol type is `TCP` or `PROXY_TCP`, Heal Check Protocol is only valid for `TCP`. If the target group protocol type is `HTTP` or `HTTPS`, Heal Check Protocol is valid only for `HTTP` and `HTTPS`.
     * `url_path` - (Optional) The URL path of the health check. Valid only if Health Check protocol type is `HTTP` or `HTTPS`. URL path must begin with `/`.
 * `target_type` - (Optional) The type of target to be added to the target group.

--- a/docs/resources/lb_target_group.md
+++ b/docs/resources/lb_target_group.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 * `health_check` - (Optional) The health check to check the health of the target.
     * `cycle` - (Optional) The number of health check cycle. Default: `30`. Valid from `5` to `300`.
     * `down_threshold` - (Optional) The number of health check failure threshold. You can determine the number of consecutive health check failures that are required before a health check is considered a failed state. Default: `2`. Valid from `2` to `10`.
-    * `up_threshold` - (Optional) The number of health check normal threshold. You can determine the number of consecutive health checks that are required before health checks are considered success state. Default: `30`.  Valid from `2` to `10`.
+    * `up_threshold` - (Optional) The number of health check normal threshold. You can determine the number of consecutive health checks that are required before health checks are considered success state. Default: `2`.  Valid from `2` to `10`.
     * `http_method` - (Optional) The HTTP method for the health check. You can determine which HTTP method to use for health checks. If the health check protocol type is `HTTP` or `HTTPS`, be sure to enter it. Accepted values: `HEAD` | `GET`.
     * `port` - (Optional) The port to use for health checks. Default: 80. Valid from `1` to `65534`.
     * `protocol` - (Required) The type of protocol to use for health checks. If the target group protocol type is `TCP` or `PROXY_TCP`, Heal Check Protocol is only valid for `TCP`. If the target group protocol type is `HTTP` or `HTTPS`, Heal Check Protocol is valid only for `HTTP` and `HTTPS`.


### PR DESCRIPTION
## Summary
- Add valid value explanations in documents for `auto_scaling_schedule`, `auto_scaling_policy`, `lb_target_group` and `lb_listener`
- Fix `lb_target_group` up_threshold default value typo according to [createTargetGroup](https://api.ncloud-docs.com/docs/ko/networking-vloadbalancer-targetgroup-createtargetgroup).

