### PR TITLE
Refactor : Subnet resource to Framework

### DIFF
--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -67,6 +67,8 @@ func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSo
 
 	dataSources = append(dataSources, vpc.NewVpcDataSource)
 	dataSources = append(dataSources, vpc.NewVpcsDataSource)
+	dataSources = append(dataSources, vpc.NewSubnetDataSource)
+	dataSources = append(dataSources, vpc.NewSubnetsDataSource)
 
 	if err := errs.ErrorOrNil(); err != nil {
 		tflog.Warn(ctx, "registering resources", map[string]interface{}{
@@ -82,6 +84,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 	var resources []func() resource.Resource
 
 	resources = append(resources, vpc.NewVpcResource)
+	resources = append(resources, vpc.NewSubnetResource)
 
 	if err := errs.ErrorOrNil(); err != nil {
 		tflog.Warn(ctx, "registering resources", map[string]interface{}{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -103,8 +103,6 @@ func New(ctx context.Context) *schema.Provider {
 		"ncloud_sourcepipeline_project":                  devtools.DataSourceNcloudSourcePipelineProject(),
 		"ncloud_sourcepipeline_projects":                 devtools.DataSourceNcloudSourcePipelineProjects(),
 		"ncloud_sourcepipeline_trigger_timezone":         devtools.DataSourceNcloudSourcePipelineTimeZone(),
-		"ncloud_subnet":                                  vpc.DataSourceNcloudSubnet(),
-		"ncloud_subnets":                                 vpc.DataSourceNcloudSubnets(),
 		"ncloud_vpc_peering":                             vpc.DataSourceNcloudVpcPeering(),
 		"ncloud_zones":                                   zone.DataSourceNcloudZones(),
 	}
@@ -150,7 +148,6 @@ func New(ctx context.Context) *schema.Provider {
 		"ncloud_sourcedeploy_project_stage":          devtools.ResourceNcloudSourceDeployStage(),
 		"ncloud_sourcedeploy_project":                devtools.ResourceNcloudSourceDeployProject(),
 		"ncloud_sourcepipeline_project":              devtools.ResourceNcloudSourcePipeline(),
-		"ncloud_subnet":                              vpc.ResourceNcloudSubnet(),
 		"ncloud_vpc_peering":                         vpc.ResourceNcloudVpcPeering(),
 	}
 

--- a/internal/service/vpc/subnet.go
+++ b/internal/service/vpc/subnet.go
@@ -64,7 +64,6 @@ func (s *subnetResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Description: "Subnet name to create. default: Assigned by NAVER CLOUD PLATFORM",
 			},
 			"id": framework.IDAttribute(),
-
 			"vpc_no": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{

--- a/internal/service/vpc/subnet.go
+++ b/internal/service/vpc/subnet.go
@@ -189,6 +189,7 @@ func (s *subnetResource) Create(ctx context.Context, req resource.CreateRequest,
 	})
 
 	if err != nil {
+		resp.Diagnostics.AddError("fail to create subnet", err.Error())
 		return
 	}
 

--- a/internal/service/vpc/subnet_data_source.go
+++ b/internal/service/vpc/subnet_data_source.go
@@ -54,7 +54,9 @@ func (s *subnetDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Optional: true,
 				Computed: true,
 			},
-
+			"subnet_no": schema.StringAttribute{
+				Computed: true,
+			},
 			"zone": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
@@ -215,7 +217,7 @@ type subnetDataSourceModel struct {
 	Filters      types.Set    `tfsdk:"filter"`
 	ID           types.String `tfsdk:"id"`
 	Subnet       types.String `tfsdk:"subnet"`
-	Zone         types.String `tfsdk:"zone""`
+	Zone         types.String `tfsdk:"zone"`
 	SubnetType   types.String `tfsdk:"subnet_type"`
 	UsageType    types.String `tfsdk:"usage_type"`
 	Name         types.String `tfsdk:"name"`

--- a/internal/service/vpc/subnet_data_source.go
+++ b/internal/service/vpc/subnet_data_source.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	_ datasource.DataSource = &subnetDataSource{}
-	_ datasource.DataSource = &subnetDataSource{}
+	_ datasource.DataSource              = &subnetDataSource{}
+	_ datasource.DataSourceWithConfigure = &subnetDataSource{}
 )
 
 func NewSubnetDataSource() datasource.DataSource {

--- a/internal/service/vpc/subnet_data_source.go
+++ b/internal/service/vpc/subnet_data_source.go
@@ -1,146 +1,243 @@
 package vpc
 
 import (
-	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
+	"context"
+	"fmt"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
-	. "github.com/terraform-providers/terraform-provider-ncloud/internal/common"
-	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/verify"
+
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/common"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
 )
 
-func DataSourceNcloudSubnet() *schema.Resource {
-	fieldMap := map[string]*schema.Schema{
-		"id": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"vpc_no": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"subnet": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"zone": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"network_acl_no": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
-		"subnet_type": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			Computed:         true,
-			ValidateDiagFunc: verify.ToDiagFunc(validation.StringInSlice([]string{"PUBLIC", "PRIVATE"}, false)),
-		},
-		"usage_type": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			Computed:         true,
-			ValidateDiagFunc: verify.ToDiagFunc(validation.StringInSlice([]string{"GEN", "LOADB", "BM", "NATGW"}, false)),
-		},
-		"filter": DataSourceFiltersSchema(),
-	}
+var (
+	_ datasource.DataSource = &subnetDataSource{}
+	_ datasource.DataSource = &subnetDataSource{}
+)
 
-	return GetSingularDataSourceItemSchema(ResourceNcloudSubnet(), fieldMap, dataSourceNcloudSubnetRead)
+func NewSubnetDataSource() datasource.DataSource {
+	return &subnetDataSource{}
 }
 
-func dataSourceNcloudSubnetRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*conn.ProviderConfig)
-
-	if !config.SupportVPC {
-		return NotSupportClassic("data source `ncloud_subnet`")
-	}
-
-	resources, err := getSubnetListFiltered(d, config)
-
-	if err != nil {
-		return err
-	}
-
-	if err := verify.ValidateOneResult(len(resources)); err != nil {
-		return err
-	}
-
-	SetSingularResourceDataFromMap(d, resources[0])
-
-	return nil
+type subnetDataSource struct {
+	config *conn.ProviderConfig
 }
 
-func getSubnetListFiltered(d *schema.ResourceData, config *conn.ProviderConfig) ([]map[string]interface{}, error) {
+func (s *subnetDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_subnet"
+}
+
+// Schema defines the schema for the data source.
+func (s *subnetDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"vpc_no": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"subnet": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+
+			"zone": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"network_acl_no": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"subnet_type": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf([]string{"PUBLIC", "PRIVATE"}...),
+				},
+			},
+			"usage_type": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf([]string{"GEN", "LOADB", "BM", "NATGW"}...),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"filter": common.DataSourceFiltersBlock(),
+		},
+	}
+}
+
+func (s *subnetDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*conn.ProviderConfig)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	s.config = config
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (s *subnetDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if !s.config.SupportVPC {
+		resp.Diagnostics.AddError(
+			"Not Supported Classic",
+			"subnet data source does not supported in classic",
+		)
+		return
+	}
+
+	var data subnetDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	reqParams := &vpc.GetSubnetListRequest{
-		RegionCode: &config.RegionCode,
+		RegionCode: &s.config.RegionCode,
 	}
 
-	if v, ok := d.GetOk("id"); ok {
-		reqParams.SubnetNoList = []*string{ncloud.String(v.(string))}
+	if !data.ID.IsNull() && !data.ID.IsUnknown() {
+		reqParams.SubnetNoList = []*string{data.ID.ValueStringPointer()}
 	}
 
-	if v, ok := d.GetOk("vpc_no"); ok {
-		reqParams.VpcNo = ncloud.String(v.(string))
+	if !data.VpcNo.IsNull() && !data.VpcNo.IsUnknown() {
+		reqParams.VpcNo = data.VpcNo.ValueStringPointer()
 	}
 
-	if v, ok := d.GetOk("subnet"); ok {
-		reqParams.Subnet = ncloud.String(v.(string))
+	if !data.Subnet.IsNull() && !data.Subnet.IsUnknown() {
+		reqParams.Subnet = data.Subnet.ValueStringPointer()
 	}
 
-	if v, ok := d.GetOk("zone"); ok {
-		reqParams.ZoneCode = ncloud.String(v.(string))
+	if !data.Zone.IsNull() && !data.Zone.IsUnknown() {
+		reqParams.ZoneCode = data.VpcNo.ValueStringPointer()
 	}
 
-	if v, ok := d.GetOk("network_acl_no"); ok {
-		reqParams.NetworkAclNo = ncloud.String(v.(string))
+	if !data.NetworkAclNo.IsNull() && !data.NetworkAclNo.IsUnknown() {
+		reqParams.NetworkAclNo = data.VpcNo.ValueStringPointer()
 	}
 
-	if v, ok := d.GetOk("subnet_type_code"); ok {
-		reqParams.SubnetTypeCode = ncloud.String(v.(string))
+	if !data.SubnetType.IsNull() && !data.SubnetType.IsUnknown() {
+		reqParams.SubnetTypeCode = data.VpcNo.ValueStringPointer()
 	}
 
-	if v, ok := d.GetOk("usage_type_code"); ok {
-		reqParams.UsageTypeCode = ncloud.String(v.(string))
+	if !data.UsageType.IsNull() && !data.UsageType.IsUnknown() {
+		reqParams.UsageTypeCode = data.VpcNo.ValueStringPointer()
 	}
 
-	LogCommonRequest("GetSubnetList", reqParams)
-	resp, err := config.Client.Vpc.V2Api.GetSubnetList(reqParams)
+	tflog.Info(ctx, "GetSubnetList", map[string]any{
+		"reqParams": common.MarshalUncheckedString(reqParams),
+	})
+	subnetResp, err := s.config.Client.Vpc.V2Api.GetSubnetList(reqParams)
 
 	if err != nil {
-		LogErrorResponse("GetSubnetList", err, reqParams)
-		return nil, err
+		var diags diag.Diagnostics
+		diags.AddError(
+			"GetSubnetList",
+			fmt.Sprintf("error: %s, reqParams: %s", err.Error(), common.MarshalUncheckedString(reqParams)),
+		)
+		resp.Diagnostics.Append(diags...)
+		return
 	}
-	LogResponse("GetSubnetList", resp)
+	tflog.Info(ctx, "GetSubnetList response", map[string]any{
+		"subnetResponse": common.MarshalUncheckedString(subnetResp),
+	})
 
-	resources := []map[string]interface{}{}
+	subnetList, diags := flattenSubnets(ctx, subnetResp.SubnetList, s.config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	for _, r := range resp.SubnetList {
-		instance := map[string]interface{}{
-			"id":             *r.SubnetNo,
-			"subnet_no":      *r.SubnetNo,
-			"vpc_no":         *r.VpcNo,
-			"zone":           *r.ZoneCode,
-			"name":           *r.SubnetName,
-			"subnet":         *r.Subnet,
-			"subnet_type":    *r.SubnetType.Code,
-			"usage_type":     *r.UsageType.Code,
-			"network_acl_no": *r.NetworkAclNo,
+	filteredList := common.FilterModels(ctx, data.Filters, subnetList)
+
+	if err := verify.ValidateOneResult(len(filteredList)); err != nil {
+		var diags diag.Diagnostics
+		diags.AddError(
+			"GetSubnetList result validation",
+			err.Error(),
+		)
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	state := filteredList[0]
+	state.Filters = data.Filters
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func flattenSubnets(ctx context.Context, subnets []*vpc.Subnet, config *conn.ProviderConfig) ([]*subnetDataSourceModel, diag.Diagnostics) {
+	var outputs []*subnetDataSourceModel
+
+	for _, v := range subnets {
+		var output subnetDataSourceModel
+
+		diags := output.refreshFromOutput(v, config)
+		if diags.HasError() {
+			return nil, diags
 		}
 
-		resources = append(resources, instance)
+		outputs = append(outputs, &output)
 	}
 
-	if f, ok := d.GetOk("filter"); ok {
-		resources = ApplyFilters(f.(*schema.Set), resources, ResourceNcloudSubnet().Schema)
+	return outputs, nil
+}
+
+type subnetDataSourceModel struct {
+	NetworkAclNo types.String `tfsdk:"network_acl_no"`
+	VpcNo        types.String `tfsdk:"vpc_no"`
+	Filters      types.Set    `tfsdk:"filter"`
+	ID           types.String `tfsdk:"id"`
+	Subnet       types.String `tfsdk:"subnet"`
+	Zone         types.String `tfsdk:"zone""`
+	SubnetType   types.String `tfsdk:"subnet_type"`
+	UsageType    types.String `tfsdk:"usage_type"`
+	Name         types.String `tfsdk:"name"`
+	SubnetNo     types.String `tfsdk:"subnet_no"`
+}
+
+func (d *subnetDataSourceModel) refreshFromOutput(output *vpc.Subnet, config *conn.ProviderConfig) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if diags.HasError() {
+		return diags
 	}
 
-	return resources, nil
+	d.ID = types.StringPointerValue(output.SubnetNo)
+	d.SubnetNo = types.StringPointerValue(output.SubnetNo)
+	d.VpcNo = types.StringPointerValue(output.VpcNo)
+	d.Zone = types.StringPointerValue(output.ZoneCode)
+	d.Name = types.StringPointerValue(output.SubnetName)
+	d.Subnet = types.StringPointerValue(output.Subnet)
+	d.SubnetType = types.StringPointerValue(output.SubnetType.Code)
+	d.UsageType = types.StringPointerValue(output.UsageType.Code)
+	d.NetworkAclNo = types.StringPointerValue(output.NetworkAclNo)
+
+	return diags
 }

--- a/internal/service/vpc/subnet_data_source.go
+++ b/internal/service/vpc/subnet_data_source.go
@@ -43,7 +43,6 @@ func (s *subnetDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Computed: true,
 			},
 			"name": schema.StringAttribute{
-				Optional: true,
 				Computed: true,
 			},
 			"vpc_no": schema.StringAttribute{
@@ -137,19 +136,19 @@ func (s *subnetDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	if !data.Zone.IsNull() && !data.Zone.IsUnknown() {
-		reqParams.ZoneCode = data.VpcNo.ValueStringPointer()
+		reqParams.ZoneCode = data.Zone.ValueStringPointer()
 	}
 
 	if !data.NetworkAclNo.IsNull() && !data.NetworkAclNo.IsUnknown() {
-		reqParams.NetworkAclNo = data.VpcNo.ValueStringPointer()
+		reqParams.NetworkAclNo = data.NetworkAclNo.ValueStringPointer()
 	}
 
 	if !data.SubnetType.IsNull() && !data.SubnetType.IsUnknown() {
-		reqParams.SubnetTypeCode = data.VpcNo.ValueStringPointer()
+		reqParams.SubnetTypeCode = data.SubnetType.ValueStringPointer()
 	}
 
 	if !data.UsageType.IsNull() && !data.UsageType.IsUnknown() {
-		reqParams.UsageTypeCode = data.VpcNo.ValueStringPointer()
+		reqParams.UsageTypeCode = data.UsageType.ValueStringPointer()
 	}
 
 	tflog.Info(ctx, "GetSubnetList", map[string]any{
@@ -226,10 +225,6 @@ type subnetDataSourceModel struct {
 
 func (d *subnetDataSourceModel) refreshFromOutput(output *vpc.Subnet, config *conn.ProviderConfig) diag.Diagnostics {
 	var diags diag.Diagnostics
-
-	if diags.HasError() {
-		return diags
-	}
 
 	d.ID = types.StringPointerValue(output.SubnetNo)
 	d.SubnetNo = types.StringPointerValue(output.SubnetNo)

--- a/internal/service/vpc/subnet_test.go
+++ b/internal/service/vpc/subnet_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -18,7 +18,7 @@ import (
 
 func TestAccResourceNcloudSubnet_basic(t *testing.T) {
 	var subnet vpc.Subnet
-	name := fmt.Sprintf("test-subnet-basic-%s", acctest.RandString(5))
+	name := fmt.Sprintf("test-subnet-basic-%s", sdkacctest.RandString(5))
 	cidr := "10.2.2.0/24"
 	resourceName := "ncloud_subnet.bar"
 
@@ -49,7 +49,7 @@ func TestAccResourceNcloudSubnet_basic(t *testing.T) {
 
 func TestAccResourceNcloudSubnet_disappears(t *testing.T) {
 	var subnet vpc.Subnet
-	name := fmt.Sprintf("test-subnet-disappears-%s", acctest.RandString(5))
+	name := fmt.Sprintf("test-subnet-disappears-%s", sdkacctest.RandString(5))
 	cidr := "10.2.2.0/24"
 	resourceName := "ncloud_subnet.bar"
 
@@ -72,7 +72,7 @@ func TestAccResourceNcloudSubnet_disappears(t *testing.T) {
 
 func TestAccResourceNcloudSubnet_updateName(t *testing.T) {
 	var subnet vpc.Subnet
-	name := fmt.Sprintf("test-subnet-name-%s", acctest.RandString(5))
+	name := fmt.Sprintf("test-subnet-name-%s", sdkacctest.RandString(5))
 	cidr := "10.2.2.0/24"
 	resourceName := "ncloud_subnet.bar"
 
@@ -99,7 +99,7 @@ func TestAccResourceNcloudSubnet_updateName(t *testing.T) {
 
 func TestAccResourceNcloudSubnet_updateNetworkACL(t *testing.T) {
 	var subnet vpc.Subnet
-	name := fmt.Sprintf("test-subnet-update-nacl-%s", acctest.RandString(5))
+	name := fmt.Sprintf("test-subnet-update-nacl-%s", sdkacctest.RandString(5))
 	cidr := "10.2.2.0/24"
 	resourceName := "ncloud_subnet.bar"
 
@@ -125,7 +125,7 @@ func TestAccResourceNcloudSubnet_updateNetworkACL(t *testing.T) {
 }
 
 func TestAccResourceNcloudSubnet_InvalidCIDR(t *testing.T) {
-	name := fmt.Sprintf("test-subnet-update-nacl-%s", acctest.RandString(5))
+	name := fmt.Sprintf("test-subnet-update-nacl-%s", sdkacctest.RandString(5))
 	cidr := "10.3.2.0/24"
 
 	resource.Test(t, resource.TestCase{

--- a/internal/service/vpc/subnets_data_source.go
+++ b/internal/service/vpc/subnets_data_source.go
@@ -43,7 +43,7 @@ func (s *subnetsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 		Attributes: map[string]schema.Attribute{
 			"id": framework.IDAttribute(),
 
-			"subnet_no": schema.StringAttribute{
+			"subnet_no": schema.ListAttribute{
 				Optional:    true,
 				Description: "List of subnet ID to retrieve",
 			},
@@ -169,19 +169,19 @@ func (s *subnetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	if !data.Zone.IsNull() && !data.Zone.IsUnknown() {
-		reqParams.ZoneCode = data.VpcNo.ValueStringPointer()
+		reqParams.ZoneCode = data.Zone.ValueStringPointer()
 	}
 
 	if !data.NetworkAclNo.IsNull() && !data.NetworkAclNo.IsUnknown() {
-		reqParams.NetworkAclNo = data.VpcNo.ValueStringPointer()
+		reqParams.NetworkAclNo = data.NetworkAclNo.ValueStringPointer()
 	}
 
 	if !data.SubnetType.IsNull() && !data.SubnetType.IsUnknown() {
-		reqParams.SubnetTypeCode = data.VpcNo.ValueStringPointer()
+		reqParams.SubnetTypeCode = data.SubnetType.ValueStringPointer()
 	}
 
 	if !data.UsageType.IsNull() && !data.UsageType.IsUnknown() {
-		reqParams.UsageTypeCode = data.VpcNo.ValueStringPointer()
+		reqParams.UsageTypeCode = data.UsageType.ValueStringPointer()
 	}
 
 	tflog.Info(ctx, "GetSubnetList", map[string]any{

--- a/internal/service/vpc/subnets_data_source.go
+++ b/internal/service/vpc/subnets_data_source.go
@@ -47,7 +47,6 @@ func (s *subnetsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				Optional:    true,
 				Description: "List of subnet ID to retrieve",
 			},
-
 			"vpc_no": schema.StringAttribute{
 				Optional:    true,
 				Description: "The VPC ID that you want to filter from",

--- a/internal/service/vpc/subnets_data_source.go
+++ b/internal/service/vpc/subnets_data_source.go
@@ -42,7 +42,9 @@ func (s *subnetsDataSource) Metadata(_ context.Context, req datasource.MetadataR
 func (s *subnetsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id": framework.IDAttribute(),
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
 			"subnet_no": schema.ListAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
@@ -109,7 +111,7 @@ func (s *subnetsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 						"usage_type": schema.StringAttribute{
 							Computed: true,
 						},
-						"subnet_no": schema.ListAttribute{
+						"subnet_no": schema.StringAttribute{
 							Computed: true,
 						},
 					},
@@ -157,8 +159,11 @@ func (s *subnetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		RegionCode: &s.config.RegionCode,
 	}
 
-	if !data.ID.IsNull() && !data.ID.IsUnknown() {
-		reqParams.SubnetNoList = []*string{data.ID.ValueStringPointer()}
+	if !data.SubnetNo.IsNull() {
+		for _, subnetNo := range data.SubnetNo.Elements() {
+			subnetStr := subnetNo.String()
+			reqParams.SubnetNoList = append(reqParams.SubnetNoList, &subnetStr)
+		}
 	}
 
 	if !data.VpcNo.IsNull() && !data.VpcNo.IsUnknown() {
@@ -220,7 +225,7 @@ func (s *subnetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 type subnetsDataSourceModel struct {
 	Filters      types.Set    `tfsdk:"filter"`
 	ID           types.String `tfsdk:"id"`
-	SubnetNo     types.String `tfsdk:"subnet_no"`
+	SubnetNo     types.List   `tfsdk:"subnet_no"`
 	VpcNo        types.String `tfsdk:"vpc_no"`
 	Subnet       types.String `tfsdk:"subnet"`
 	Zone         types.String `tfsdk:"zone"`

--- a/internal/service/vpc/subnets_data_source.go
+++ b/internal/service/vpc/subnets_data_source.go
@@ -1,87 +1,278 @@
 package vpc
 
 import (
+	"context"
 	"fmt"
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/framework"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
-	. "github.com/terraform-providers/terraform-provider-ncloud/internal/common"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/common"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
-	"github.com/terraform-providers/terraform-provider-ncloud/internal/verify"
 )
 
-func DataSourceNcloudSubnets() *schema.Resource {
-	return &schema.Resource{
-		Read: dataSourceNcloudSubnetsRead,
+var (
+	_ datasource.DataSource = &subnetsDataSource{}
+	_ datasource.DataSource = &subnetsDataSource{}
+)
 
-		Schema: map[string]*schema.Schema{
-			"subnet_no": {
-				Type:        schema.TypeList,
+func NewSubnetsDataSource() datasource.DataSource {
+	return &subnetsDataSource{}
+}
+
+type subnetsDataSource struct {
+	config *conn.ProviderConfig
+}
+
+func (s *subnetsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_subnets"
+}
+
+// Schema defines the schema for the data source.
+func (s *subnetsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttribute(),
+
+			"subnet_no": schema.StringAttribute{
 				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "List of subnet ID to retrieve",
 			},
-			"vpc_no": {
-				Type:        schema.TypeString,
+
+			"vpc_no": schema.StringAttribute{
 				Optional:    true,
 				Description: "The VPC ID that you want to filter from",
 			},
-			"subnet": {
-				Type:        schema.TypeString,
+			"subnet": schema.StringAttribute{
 				Optional:    true,
 				Description: "The CIDR block for the subnet.",
 			},
-			"zone": {
-				Type:        schema.TypeString,
+			"zone": schema.StringAttribute{
 				Optional:    true,
 				Description: "Available Zone. Get available values using the `data ncloud_zones`.",
 			},
-			"network_acl_no": {
-				Type:        schema.TypeString,
+			"network_acl_no": schema.StringAttribute{
 				Optional:    true,
 				Description: "Network ACL No. Get available values using the `default_network_acl_no` from Resource `ncloud_vpc` or Data source `data.ncloud_network_acls`.",
 			},
-			"subnet_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: verify.ToDiagFunc(validation.StringInSlice([]string{"PUBLIC", "PRIVATE"}, false)),
-				Description:      "Internet Gateway Only. PUBLC(Yes/Public), PRIVATE(No/Private).",
+			"subnet_type": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf([]string{"PUBLIC", "PRIVATE"}...),
+				},
+				Description: "Internet Gateway Only. PUBLC(Yes/Public), PRIVATE(No/Private).",
 			},
-			"usage_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: verify.ToDiagFunc(validation.StringInSlice([]string{"GEN", "LOADB", "BM", "NATGW"}, false)),
-				Description:      "Usage type. GEN(Normal), LOADB(Load Balance), BM(BareMetal), NATGW(NAT Gateway). default : GEN(Normal).",
-			},
-			"filter": DataSourceFiltersSchema(),
-			"subnets": {
-				Type:     schema.TypeList,
+			"usage_type": schema.StringAttribute{
 				Computed: true,
-				Elem:     GetDataSourceItemSchema(ResourceNcloudSubnet()),
+				Validators: []validator.String{
+					stringvalidator.OneOf([]string{"GEN", "LOADB", "BM", "NATGW"}...),
+				},
+				Description: "Usage type. GEN(Normal), LOADB(Load Balance), BM(BareMetal), NATGW(NAT Gateway). default : GEN(Normal).",
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"filter": common.DataSourceFiltersBlock(),
+			"subnets": schema.SetNestedBlock{
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+						"id": framework.IDAttribute(),
+						"vpc_no": schema.StringAttribute{
+							Computed: true,
+						},
+						"subnet": schema.StringAttribute{
+							Computed: true,
+						},
+						"zone": schema.StringAttribute{
+							Computed: true,
+						},
+						"network_acl_no": schema.StringAttribute{
+							Computed: true,
+						},
+						"subnet_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"usage_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"subnet_no": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
 			},
 		},
 	}
 }
 
-func dataSourceNcloudSubnetsRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*conn.ProviderConfig)
-
-	if !config.SupportVPC {
-		return NotSupportClassic("data source `ncloud_subnets`")
+func (s *subnetsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
 	}
 
-	resources, err := getSubnetListFiltered(d, config)
+	config, ok := req.ProviderData.(*conn.ProviderConfig)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	s.config = config
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (s *subnetsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if !s.config.SupportVPC {
+		resp.Diagnostics.AddError(
+			"Not Supported Classic",
+			"subnet data source does not supported in classic",
+		)
+		return
+	}
+
+	var data subnetsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	reqParams := &vpc.GetSubnetListRequest{
+		RegionCode: &s.config.RegionCode,
+	}
+
+	if !data.ID.IsNull() && !data.ID.IsUnknown() {
+		reqParams.SubnetNoList = []*string{data.ID.ValueStringPointer()}
+	}
+
+	if !data.VpcNo.IsNull() && !data.VpcNo.IsUnknown() {
+		reqParams.VpcNo = data.VpcNo.ValueStringPointer()
+	}
+
+	if !data.Subnet.IsNull() && !data.Subnet.IsUnknown() {
+		reqParams.Subnet = data.Subnet.ValueStringPointer()
+	}
+
+	if !data.Zone.IsNull() && !data.Zone.IsUnknown() {
+		reqParams.ZoneCode = data.VpcNo.ValueStringPointer()
+	}
+
+	if !data.NetworkAclNo.IsNull() && !data.NetworkAclNo.IsUnknown() {
+		reqParams.NetworkAclNo = data.VpcNo.ValueStringPointer()
+	}
+
+	if !data.SubnetType.IsNull() && !data.SubnetType.IsUnknown() {
+		reqParams.SubnetTypeCode = data.VpcNo.ValueStringPointer()
+	}
+
+	if !data.UsageType.IsNull() && !data.UsageType.IsUnknown() {
+		reqParams.UsageTypeCode = data.VpcNo.ValueStringPointer()
+	}
+
+	tflog.Info(ctx, "GetSubnetList", map[string]any{
+		"reqParams": common.MarshalUncheckedString(reqParams),
+	})
+	subnetResp, err := s.config.Client.Vpc.V2Api.GetSubnetList(reqParams)
 
 	if err != nil {
-		return err
+		var diags diag.Diagnostics
+		diags.AddError(
+			"GetSubnetList",
+			fmt.Sprintf("error: %s, reqParams: %s", err.Error(), common.MarshalUncheckedString(reqParams)),
+		)
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	tflog.Info(ctx, "GetSubnetList response", map[string]any{
+		"subnetResponse": common.MarshalUncheckedString(subnetResp),
+	})
+
+	subnetList, diags := flattenSubnets(ctx, subnetResp.SubnetList, s.config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	d.SetId(time.Now().UTC().String())
-	if err := d.Set("subnets", resources); err != nil {
-		return fmt.Errorf("Error setting Subnets: %s", err)
-	}
+	filteredList := common.FilterModels(ctx, data.Filters, subnetList)
 
-	return nil
+	state := data
+	state.ID = types.StringValue(time.Now().UTC().String())
+	resp.Diagnostics.Append(state.refreshFromSubnetOutputModel(ctx, filteredList, s.config)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
+
+type subnetsDataSourceModel struct {
+	Filters      types.Set    `tfsdk:"filter"`
+	ID           types.String `tfsdk:"id"`
+	SubnetNo     types.String `tfsdk:"subnet_no"`
+	VpcNo        types.String `tfsdk:"vpc_no"`
+	Subnet       types.String `tfsdk:"subnet"`
+	Zone         types.String `tfsdk:"zone"`
+	NetworkAclNo types.String `tfsdk:"network_acl_no"`
+	SubnetType   types.String `tfsdk:"subnet_type"`
+	UsageType    types.String `tfsdk:"usage_type"`
+	Subnets      types.Set    `tfsdk:"subnets"`
+}
+
+func (d *subnetsDataSourceModel) refreshFromSubnetOutputModel(ctx context.Context, subnetModels []*subnetDataSourceModel, config *conn.ProviderConfig) diag.Diagnostics {
+	var diags diag.Diagnostics
+	elemType := types.ObjectType{AttrTypes: subnetAttrTypes}
+	elems := []attr.Value{}
+
+	for _, model := range subnetModels {
+		obj := map[string]attr.Value{
+			"network_acl_no": model.NetworkAclNo,
+			"vpc_no":         model.VpcNo,
+			"id":             model.ID,
+			"subnet":         model.Subnet,
+			"zone":           model.Zone,
+			"subnet_type":    model.SubnetType,
+			"usage_type":     model.UsageType,
+			"name":           model.Name,
+			"subnet_no":      model.SubnetNo,
+		}
+		objVal, di := types.ObjectValue(subnetAttrTypes, obj)
+		diags.Append(di...)
+
+		elems = append(elems, objVal)
+	}
+	setVal, di := types.SetValue(elemType, elems)
+	diags.Append(di...)
+
+	if diags.HasError() {
+		return diags
+	}
+
+	d.Subnets = setVal
+	return diags
+}
+
+var (
+	subnetAttrTypes = map[string]attr.Type{
+		"network_acl_no": types.StringType,
+		"vpc_no":         types.StringType,
+		"id":             types.StringType,
+		"subnet":         types.StringType,
+		"zone":           types.StringType,
+		"subnet_type":    types.StringType,
+		"usage_type":     types.StringType,
+		"name":           types.StringType,
+		"subnet_no":      types.StringType,
+	}
+)


### PR DESCRIPTION
### Description
resolve #332 

refactor the `subnet` resource and data sources to use the framework

### Feautures

#### Resource
- subnet

#### Datasource
- subnet


### Test
```
$ go test -run TestAccResourceNcloudSubnet_basic subnet_test.go
ok      command-line-arguments  43.359s
$ go test -run TestAccResourceNcloudSubnet_disappears subnet_test.go
ok      command-line-arguments  41.615s
$ go test -run TestAccResourceNcloudSubnet_updateName subnet_test.go
ok      command-line-arguments  41.853s
$ go test -run TestAccResourceNcloudSubnet_updateNetworkACL subnet_test.go
ok      command-line-arguments  49.337s
$ go test -run TestAccResourceNcloudSubnet_InvalidCIDR subnet_test.go
ok      command-line-arguments  18.453s

$ go test -run TestAccDataSourceNcloudSubnet subnet_data_source_test.go
ok      command-line-arguments  42.117s

$ go test -run TestAccDataSourceNcloudSubnetsBasic subnets_data_source_test.go
ok      command-line-arguments  1.687s
$ go test -run TestAccDataSourceNcloudSubnetsName subnets_data_source_test.go
ok      command-line-arguments  1.387s
$ go test -run TestAccDataSourceNcloudSubnetsVpcNo subnets_data_source_test.go
ok      command-line-arguments  1.310s
```

close #332 



