### PR TITLE
fix(vpc): Use `vpc_no` attribute in vpcs data source

### DIFF
--- a/internal/service/vpc/vpcs_data_source.go
+++ b/internal/service/vpc/vpcs_data_source.go
@@ -41,7 +41,9 @@ func (v *vpcsDataSource) Metadata(_ context.Context, req datasource.MetadataRequ
 func (v *vpcsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"id": framework.IDAttribute(),
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
 			"name": schema.StringAttribute{
 				Optional: true,
 			},
@@ -124,8 +126,8 @@ func (v *vpcsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		RegionCode: &v.config.RegionCode,
 	}
 
-	if !data.ID.IsNull() && !data.ID.IsUnknown() {
-		reqParams.VpcNoList = []*string{data.ID.ValueStringPointer()}
+	if !data.VpcNo.IsNull() && !data.VpcNo.IsUnknown() {
+		reqParams.VpcNoList = []*string{data.VpcNo.ValueStringPointer()}
 	}
 	if !data.Name.IsNull() && !data.Name.IsUnknown() {
 		reqParams.VpcName = data.Name.ValueStringPointer()


### PR DESCRIPTION
- Change the way to declare `id` attribute  from `framework.IDAttribute()` to manual
  - There is no problem with using `framework.IDAttribute()`, but since it is using the type definition of the resource and not the data source, it modifies it to use the type of the data source.
- Improve where the `vpc_no` attribute was not being used and was using a dead `id` attribute. This is not a regression caused by the framework migration, but rather a fix for an error in the existing logic.