### PR TITLE
fix: Use list type for nestedBlock on vpcs/subnets data sources

### DIFF
--- a/internal/service/vpc/subnets_data_source.go
+++ b/internal/service/vpc/subnets_data_source.go
@@ -3,11 +3,12 @@ package vpc
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -83,9 +84,9 @@ func (s *subnetsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 		},
 		Blocks: map[string]schema.Block{
 			"filter": common.DataSourceFiltersBlock(),
-			"subnets": schema.SetNestedBlock{
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
+			"subnets": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -232,7 +233,7 @@ type subnetsDataSourceModel struct {
 	NetworkAclNo types.String `tfsdk:"network_acl_no"`
 	SubnetType   types.String `tfsdk:"subnet_type"`
 	UsageType    types.String `tfsdk:"usage_type"`
-	Subnets      types.Set    `tfsdk:"subnets"`
+	Subnets      types.List   `tfsdk:"subnets"`
 }
 
 func (d *subnetsDataSourceModel) refreshFromSubnetOutputModel(ctx context.Context, subnetModels []*subnetDataSourceModel, config *conn.ProviderConfig) diag.Diagnostics {
@@ -257,7 +258,7 @@ func (d *subnetsDataSourceModel) refreshFromSubnetOutputModel(ctx context.Contex
 
 		elems = append(elems, objVal)
 	}
-	setVal, di := types.SetValue(elemType, elems)
+	setVal, di := types.ListValue(elemType, elems)
 	diags.Append(di...)
 
 	if diags.HasError() {

--- a/internal/service/vpc/vpcs_data_source.go
+++ b/internal/service/vpc/vpcs_data_source.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -51,9 +51,9 @@ func (v *vpcsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 		},
 		Blocks: map[string]schema.Block{
 			"filter": common.DataSourceFiltersBlock(),
-			"vpcs": schema.SetNestedBlock{
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
+			"vpcs": schema.ListNestedBlock{
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
 				},
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -168,7 +168,7 @@ type vpcsDataSourceModel struct {
 	ID      types.String `tfsdk:"id"`
 	Name    types.String `tfsdk:"name"`
 	VpcNo   types.String `tfsdk:"vpc_no"`
-	Vpcs    types.Set    `tfsdk:"vpcs"`
+	Vpcs    types.List   `tfsdk:"vpcs"`
 }
 
 func (d *vpcsDataSourceModel) refreshFromVpcOutputModel(ctx context.Context, vpcModels []*vpcDataSourceModel, config *conn.ProviderConfig) diag.Diagnostics {
@@ -192,7 +192,7 @@ func (d *vpcsDataSourceModel) refreshFromVpcOutputModel(ctx context.Context, vpc
 
 		elems = append(elems, objVal)
 	}
-	setVal, di := types.SetValue(elemType, elems)
+	setVal, di := types.ListValue(elemType, elems)
 	diags.Append(di...)
 
 	if diags.HasError() {


### PR DESCRIPTION
To keep the compatibility, fix to use the block attribute of the type list instead of set.
- Vpcs, Subnets data sources

Test example
```hcl
data "ncloud_vpcs" "testvpcdata2" {
}

data "ncloud_vpc" "check" {
  id = data.ncloud_vpcs.testvpcdata2.vpcs[0].id
}
```
