### PR TITLE
Fix: Prevent empty string setting of devtools resources

### DIFF
--- a/docs/resources/sourcebuild_project.md
+++ b/docs/resources/sourcebuild_project.md
@@ -183,9 +183,9 @@ The following arguments are supported:
         * `key` - (Required) Key of environment variable.
         * `value` - (Required) Value of environment variable.
 * `build_command` - (Optional) Commands to execute in build.
-    * `pre_build` - (Optional) Commands before build.
-    * `in_build` - (Optional) Commands during build.
-    * `post_build` - (Optional) Commands after build.
+    * `pre_build` - (Optional) Commands before build. Empty string elements are not allowed.
+    * `in_build` - (Optional) Commands during build. Empty string elements are not allowed.
+    * `post_build` - (Optional) Commands after build. Empty string elements are not allowed.
     * `docker_image_build` - (Optional) Docker image build config.
         * `use` - (Optional) Whether or not to use of dockerbuild. (Default `false`)
         * `dockerfile` - (Optional, Required if `build_command.docker_image_build.use` is set to `true`) Dockerfile path in build source folder.
@@ -195,7 +195,7 @@ The following arguments are supported:
         * `latest` - (Optional) Save status of the latest tag. (Default `false`)
 * `artifact` - (Optional) Artifact to save build results.
     * `use` - (Optional) Whether or not to save build results. (Default `false`)
-    * `path` - (Optional, Required if `artifact.use` is set to `true`) Location to save build results.
+    * `path` - (Optional, Required if `artifact.use` is set to `true`) Location to save build results. Empty string elements are not allowed.
     * `object_storage_to_upload` - (Optional, Required if `artifact.use` is set to `true`) Object Storage to save build results.
         * `bucket` - (Required) Bucket name of NCP Object Storage to save build results.
         * `path` - (Required) path in the NCP Object Storage bucket to save build results.

--- a/docs/resources/sourcedeploy_project_stage_scenario.md
+++ b/docs/resources/sourcedeploy_project_stage_scenario.md
@@ -142,7 +142,7 @@ The following arguments are supported:
         * `type` - (Required) Repository type. Accepted values: `SourceCommit`.
         * `repository_name` - (Required) The name of repository.
         * `branch` - (Required) The name of repository branch.
-        * `path` - (Required) File path.
+        * `path` - (Required) File path. Empty string elements are not allowed.
     * `canary_config` - (Optional, Required If stage type is set to `KubernetesService` &  strategy is set to `canary` ) config when deploying Kubernetesservice canary.
         * `analysis_type` - (Required) Canary analysis method. Accepted values: `manual`, `auto`.
         * `canary_count` - (Required) Number of baseline and canary pod.

--- a/docs/resources/sourcepipeline_project.md
+++ b/docs/resources/sourcepipeline_project.md
@@ -142,7 +142,7 @@ The following arguments are supported:
         *   `scenario_id` - (Optional, Required if `task.type` value is SourceDeploy) Scenario Id of a task. Get avaliable values using the datasource `ncloud_sourcedeploy_project_stage_scenarios`
         *   `target`- (Optional) Target of a task job.
             *   `repository_branch` - (Optional) Target repository branch of SourceBuild task. Default : main branch of target repository
-    *   `linked_tasks` - (Required) Linked tasks which has to be executed before.
+    *   `linked_tasks` - (Required) Linked tasks which has to be executed before. Empty string elements are not allowed.
 *   `triggers` - (Required) `triggers` block describes trigger configuration.
     *   `repository` - (Optional)
         *   `type` - (Optional, Required if `trigger.repository` exists) Type of repository. Accepted values: `sourcecommit`

--- a/internal/service/devtools/sourcebuild_project.go
+++ b/internal/service/devtools/sourcebuild_project.go
@@ -688,17 +688,32 @@ func getCommonProjectParams(d *schema.ResourceData) (*sourcebuild.ChangeProject,
 
 	cmd := sourcebuild.ProjectCmd{
 		Dockerbuild: &cmdDockerbuild,
+		Pre: []*string{}, //for setting as an empty array
+		Build: []*string{},
+		Post: []*string{},
 	}
 
 	if param, ok := d.GetOk("build_command.0.pre_build"); ok {
+		err := ValidateEmptyStringElement(param.([]interface{}));
+		if err != nil {
+			return nil, fmt.Errorf("build_command.pre_build cannot contain an empty string element")
+		}
 		cmd.Pre = ExpandStringInterfaceList(param.([]interface{}))
 	}
 
 	if param, ok := d.GetOk("build_command.0.in_build"); ok {
+		err := ValidateEmptyStringElement(param.([]interface{}));
+		if err != nil {
+			return nil, fmt.Errorf("build_command.in_build cannot contain an empty string element")
+		}
 		cmd.Build = ExpandStringInterfaceList(param.([]interface{}))
 	}
 
 	if param, ok := d.GetOk("build_command.0.post_build"); ok {
+		err := ValidateEmptyStringElement(param.([]interface{}));
+		if err != nil {
+			return nil, fmt.Errorf("build_command.post_build cannot contain an empty string element")
+		}
 		cmd.Post = ExpandStringInterfaceList(param.([]interface{}))
 	}
 
@@ -715,6 +730,10 @@ func getCommonProjectParams(d *schema.ResourceData) (*sourcebuild.ChangeProject,
 	}
 
 	if param, ok := d.GetOk("artifact.0.path"); ok {
+		err := ValidateEmptyStringElement(param.([]interface{}));
+		if err != nil {
+			return nil, fmt.Errorf("artifact.path cannot contain an empty string element")
+		}
 		artifact.Path = ExpandStringInterfaceList(param.([]interface{}))
 	}
 

--- a/internal/service/devtools/sourcedeploy_project_stage_scenario.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_scenario.go
@@ -696,6 +696,10 @@ func getManifest(deployTargetType string, d *schema.ResourceData) (*vsourcedeplo
 		}
 
 		if param, ok := d.GetOk("config.0.manifest.0.path"); ok {
+			err := ValidateEmptyStringElement(param.([]interface{}));
+			if err != nil {
+				return nil, fmt.Errorf("config.manifest.path cannot contain an empty string element")
+			}
 			reqParams.Path = ExpandStringInterfaceList(param.([]interface{}))
 		}
 

--- a/internal/service/devtools/sourcepipeline_project.go
+++ b/internal/service/devtools/sourcepipeline_project.go
@@ -475,6 +475,10 @@ func makeClassicPipelineTaskParams(d *schema.ResourceData) ([]*sourcepipeline.Cr
 			return nil, diag.FromErr(NotSupportClassic("Invalid argument: \"SourceDeploy\" task "))
 		}
 
+		err := ValidateEmptyStringElement(d.Get(prefix + "linked_tasks").([]interface{}));
+		if err != nil {
+			return nil, diag.Errorf("task.linkd_tasks cannot contain an empty string element")
+		}
 		pipelineTaskParams = append(pipelineTaskParams, &sourcepipeline.CreateProjectTasks{
 			Name:        ncloud.String(d.Get(prefix + "name").(string)),
 			Type_:       ncloud.String(d.Get(prefix + "type").(string)),
@@ -517,6 +521,10 @@ func makeVpcPipelineTaskParams(d *schema.ResourceData) ([]*vsourcepipeline.Creat
 			}
 		}
 
+		err := ValidateEmptyStringElement(d.Get(prefix + "linked_tasks").([]interface{}));
+		if err != nil {
+			return nil, diag.Errorf("task.linkd_tasks cannot contain an empty string element")
+		}
 		pipelineTaskParams = append(pipelineTaskParams, &vsourcepipeline.CreateProjectTasks{
 			Name:        ncloud.String(d.Get(prefix + "name").(string)),
 			Type_:       ncloud.String(d.Get(prefix + "type").(string)),

--- a/internal/verify/stringvalidator.go
+++ b/internal/verify/stringvalidator.go
@@ -1,6 +1,7 @@
 package verify
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -21,4 +22,13 @@ func InstanceNameValidator() []validator.String {
 			"must end with an alphabetic character or number",
 		),
 	}
+}
+
+func ValidateEmptyStringElement(i []interface{}) error {
+	for _, v := range i {
+		if v == nil || v == "" {
+			return fmt.Errorf("empty string element found")
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
### 문제점
리소스 생성 시 값을 아래와 같이 입력하는 경우,
```
  build_command {
    pre_build  = [""]
    in_build   = [""]
    post_build = [""]
...
```
[type casting 부분](https://github.com/NaverCloudPlatform/terraform-provider-ncloud/blob/ab74db299f10df774912997aad168a0d1bd2ebe5/internal/common/structures.go#L20)에서 'panic: interface conversion: interface {} is nil, not string' 와 같은 에러 발생.

### 변경
empty string(`""`) 값은 상품 로직 상 무효한 값이므로, 입력하지 못하도록 수정.
(이를 공통화 하기 위해 `ValidateEmptyStringElement` 메소드 추가)