### PR TITLE
fix  : devtoolsSource(Deploy|Commit)* data sources test failure

### DIFF
--- a/internal/service/devtools/sourcedeploy_project_stage_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_data_source_test.go
@@ -9,14 +9,15 @@ import (
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/acctest"
 )
 
-func TestAccDataSourceNcloudSourceDeployStage(t *testing.T) {
+func TestAccDataSourceNcloudSourceDeploySingleStage(t *testing.T) {
 	stageNameSvr := getTestSourceDeployStageName() + "svr"
+	productCode := "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudSourceDeployStageConfig(stageNameSvr),
+				Config: testAccDataSourceNcloudSourceDeployStageConfig(stageNameSvr, productCode),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID("data.ncloud_sourcedeploy_project_stage.stage"),
 				),
@@ -25,15 +26,33 @@ func TestAccDataSourceNcloudSourceDeployStage(t *testing.T) {
 	})
 }
 
-func testAccDataSourceNcloudSourceDeployStageConfig(stageNameSvr string) string {
+func testAccDataSourceNcloudSourceDeployStageConfig(stageNameSvr string, productCode string) string {
 	return fmt.Sprintf(`
-data "ncloud_server" "server" {
-	filter {
-		name   = "name"
-		values = ["%[1]s"]
-	}
+resource "ncloud_login_key" "loginkey" {
+	key_name = "%[2]s-key"
 }
 
+resource "ncloud_vpc" "vpc" {
+	ipv4_cidr_block    = "10.5.0.0/16"
+}
+
+resource "ncloud_subnet" "subnet" {
+	vpc_no             = ncloud_vpc.vpc.vpc_no
+	name               = "%[1]s"
+	subnet             = "10.5.0.0/24"
+	zone               = "KR-2"
+	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
+	subnet_type        = "PUBLIC"
+	usage_type         = "GEN"
+}
+
+resource "ncloud_server" "server" {
+	subnet_no = ncloud_subnet.subnet.id
+	name = "%[1]s"
+	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_product_code = "%[3]s"
+	login_key_name = ncloud_login_key.loginkey.key_name
+}
 resource "ncloud_sourcedeploy_project" "sd_project" {
 	name = "tf-test-project2"
 }
@@ -44,7 +63,7 @@ resource "ncloud_sourcedeploy_project_stage" "svr_stage" {
 	target_type = "Server"
 	config {
 		server{
-			id = data.ncloud_server.server.id
+			id = ncloud_server.server.id
 		} 
 	}
 }
@@ -53,5 +72,5 @@ data "ncloud_sourcedeploy_project_stage" "stage"{
 	project_id = ncloud_sourcedeploy_project.sd_project.id
 	id         = ncloud_sourcedeploy_project_stage.svr_stage.id
 }
-`, TF_TEST_SD_SERVER_NAME, stageNameSvr)
+`, TF_TEST_SD_SERVER_NAME, stageNameSvr, productCode)
 }

--- a/internal/service/devtools/sourcedeploy_project_stage_scenario_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_scenario_data_source_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/acctest"
 )
 
-func TestAccDataSourceNcloudSourceDeployScenario(t *testing.T) {
+func TestAccDataSourceNcloudSourceDeploySingleScenario(t *testing.T) {
 	stageNameSvr := GetTestSourceDeployScenarioName() + "svr"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },

--- a/internal/service/devtools/sourcedeploy_project_stage_scenarios_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_scenarios_data_source_test.go
@@ -10,12 +10,14 @@ import (
 )
 
 func TestAccDataSourceNcloudSourceDeployScenarios(t *testing.T) {
+	stageNameSvr := GetTestSourceDeployScenarioName() + "svr"
+	productCode := "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudSourceDeployScenariosConfig(),
+				Config: testAccDataSourceNcloudSourceDeployScenariosConfig(stageNameSvr, productCode),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID("data.ncloud_sourcedeploy_project_stage_scenarios.scenarios"),
 				),
@@ -24,26 +26,45 @@ func TestAccDataSourceNcloudSourceDeployScenarios(t *testing.T) {
 	})
 }
 
-func testAccDataSourceNcloudSourceDeployScenariosConfig() string {
+func testAccDataSourceNcloudSourceDeployScenariosConfig(stageNameSvr string, productCode string) string {
 	return fmt.Sprintf(`
-data "ncloud_server" "server" {
-	filter {
-		name   = "name"
-		values = ["%[1]s"]
-	}
+resource "ncloud_login_key" "loginkey" {
+	key_name = "%[2]s-key"
+}
+
+resource "ncloud_vpc" "vpc" {
+	ipv4_cidr_block    = "10.0.0.0/16"
+}
+
+resource "ncloud_subnet" "subnet" {
+	vpc_no             = ncloud_vpc.vpc.vpc_no
+	subnet             = "10.0.0.0/24"
+	zone               = "KR-2"
+	network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
+	subnet_type        = "PUBLIC"
+	usage_type         = "GEN"
+}
+
+
+resource "ncloud_server" "server" {
+	subnet_no = ncloud_subnet.subnet.id
+	name = "%[2]s"
+	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_product_code = "%[3]s"
+	login_key_name = ncloud_login_key.loginkey.key_name
 }
 
 resource "ncloud_sourcedeploy_project" "sd_project" {
-	name = "tf-test-project"
+	name = "%[2]s"
 }
 
 resource "ncloud_sourcedeploy_project_stage" "svr_stage" {
 	project_id  = ncloud_sourcedeploy_project.sd_project.id
-	name		= "svr"
+	name		= "%[2]s"
 	target_type = "Server"
 	config {
 		server {
-			id = data.ncloud_server.server.id
+			id = ncloud_server.server.id
 		}
 	}
 }
@@ -52,5 +73,5 @@ data "ncloud_sourcedeploy_project_stage_scenarios" "scenarios"{
 	project_id = ncloud_sourcedeploy_project.sd_project.id
 	stage_id   = ncloud_sourcedeploy_project_stage.svr_stage.id
 }
-`, TF_TEST_SD_SERVER_NAME)
+`, TF_TEST_SD_SERVER_NAME, stageNameSvr, productCode)
 }


### PR DESCRIPTION
### 개요

- 해결 : #297 

### 변경 사항

- ncloud_sourcedeploy_stage Test 통과, Test Signature 변경, Test Config 수정
- ncloud_sourcedeploy_scenarios Test 통과, Test Config 수정

### 추가 사항

- Test Signature 변경은 Test 수행 시, 같은 이름으로 시작되는 Signature 모두를 실행시키기 때문에 변경
- 총 5개의 Test를 수정해야 하지만 해결한 Test를 제외한 나머지 Test에선 "ncloud_sourcecommit_repository" resource 생성 시 “common bloc 에러http://common-api.pub.both.navercorp.com:5001/common_bloc/sourceCommitBO/createSourceCommitInstance” 에러 발생.

    - ncloud_sourcedeploy_scenario
    - ncloud_sourcepipeline_project
    - ncloud_sourcecommit_repositoy
    위 세 개의 Test는 에러 해결 후 수행 필요

### Test 실행 결과

- TestAccDataSourceNcloudSourceDeploySingleStage의 경우
<img width="1461" alt="스크린샷 2023-08-13 16 58 15" src="https://github.com/NaverCloudPlatform/terraform-provider-ncloud/assets/40160510/7fccdf04-0983-4f64-9f9f-c77fbd511581">

<br></br>
- TestAccDataSourceNcloudSourceDeployScenarios의 경우
<img width="1471" alt="스크린샷 2023-08-13 16 51 25" src="https://github.com/NaverCloudPlatform/terraform-provider-ncloud/assets/40160510/c1078d79-af50-4d6b-beed-3de6335b1518">
