### PR TITLE
fix: change NKS test method

### DIFF
--- a/internal/service/nks/nks_cluster_data_source_test.go
+++ b/internal/service/nks/nks_cluster_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceNcloudNKSCluster(t *testing.T) {
 	testClusterName := GetTestClusterName()
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/nks/nks_cluster_test.go
+++ b/internal/service/nks/nks_cluster_test.go
@@ -29,7 +29,7 @@ func TestAccResourceNcloudNKSCluster_basic(t *testing.T) {
 
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
@@ -70,7 +70,7 @@ func TestAccResourceNcloudNKSCluster_public_network(t *testing.T) {
 
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
@@ -97,7 +97,7 @@ func TestAccResourceNcloudNKSCluster_InvalidSubnet(t *testing.T) {
 
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
@@ -117,7 +117,7 @@ func TestAccResourceNcloudNKSCluster_Update(t *testing.T) {
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 	resourceName := "ncloud_nks_cluster.cluster"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
@@ -172,7 +172,7 @@ func TestAccResourceNcloudNKSCluster_UpdateOnce(t *testing.T) {
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 	resourceName := "ncloud_nks_cluster.cluster"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
@@ -205,7 +205,7 @@ func TestAccResourceNcloudNKSCluster_VersionUpgrade(t *testing.T) {
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 	resourceName := "ncloud_nks_cluster.cluster"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
@@ -235,7 +235,7 @@ func TestAccResourceNcloudNKSCluster_OIDCSpec(t *testing.T) {
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 	resourceName := "ncloud_nks_cluster.cluster"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
@@ -286,7 +286,7 @@ func TestAccResourceNcloudNKSCluster_AuditLog(t *testing.T) {
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 	resourceName := "ncloud_nks_cluster.cluster"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
@@ -317,7 +317,7 @@ func TestAccResourceNcloudNKSCluster_AddSubnet(t *testing.T) {
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 	resourceName := "ncloud_nks_cluster.cluster"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,

--- a/internal/service/nks/nks_kube_config_data_source_test.go
+++ b/internal/service/nks/nks_kube_config_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNcloudNKSKubeConfig(t *testing.T) {
 	testClusterName := GetTestClusterName()
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { TestAccPreCheck(t) },
 		Providers: GetTestAccProviders(true),
 		Steps: []resource.TestStep{

--- a/internal/service/nks/nks_node_pool_data_source_test.go
+++ b/internal/service/nks/nks_node_pool_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceNcloudNKSNodePool(t *testing.T) {
 
 	region, clusterType, productType, k8sVersion := getRegionAndNKSType()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/service/nks/nks_node_pool_test.go
+++ b/internal/service/nks/nks_node_pool_test.go
@@ -25,7 +25,7 @@ func TestAccResourceNcloudNKSNodePool_basic(t *testing.T) {
 	resourceName := "ncloud_nks_node_pool.node_pool"
 	region, clusterType, productCode, k8sVersion := getRegionAndNKSType()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
@@ -54,7 +54,7 @@ func TestAccResourceNcloudNKSNodePool_publicNetwork(t *testing.T) {
 	resourceName := "ncloud_nks_node_pool.node_pool"
 	region, clusterType, productCode, k8sVersion := getRegionAndNKSType()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
@@ -78,7 +78,7 @@ func TestAccResourceNcloudNKSNodePool_updateNodeCountAndAutoScale(t *testing.T) 
 	region, clusterType, productCode, k8sVersion := getRegionAndNKSType()
 	resourceName := "ncloud_nks_node_pool.node_pool"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSNodePoolDestroy,
@@ -111,7 +111,7 @@ func TestAccResourceNcloudNKSNodePool_upgrade(t *testing.T) {
 	region, clusterType, productCode, k8sVersion := getRegionAndNKSType()
 	resourceName := "ncloud_nks_node_pool.node_pool"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckNKSNodePoolDestroy,
@@ -139,7 +139,7 @@ func TestAccResourceNcloudNKSNodePool_invalidNodeCount(t *testing.T) {
 	clusterName := GetTestClusterName()
 	region, clusterType, productCode, k8sVersion := getRegionAndNKSType()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckSubnetDestroy,

--- a/internal/service/nks/nks_node_pools_data_source_test.go
+++ b/internal/service/nks/nks_node_pools_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNcloudNKSNodePools(t *testing.T) {
 
 	region, clusterType, productType, k8sVersion := getRegionAndNKSType()
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
## Description
- In the case of the existing test, it was Parallel Test, so an error occurred due to the limitation of the number of vpc (up to three)
- Therefore, parallel test was removed only when vpc was generated during test

## Related Issue
- #300 

## Additional
- For NKS that take a long time to create resources, you need to increase the timeout setting because you don't run tests in parallel