### PR TITLE
Fix: Change LoginKey package classification

### DIFF
--- a/docs/resources/login_key.md
+++ b/docs/resources/login_key.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Login Key"
+subcategory: "Server"
 ---
 
 
@@ -27,9 +27,9 @@ The following arguments are supported:
 
 ## Attributes Reference
 
+* `id` - The ID of login key.
 * `private_key` - Generated private key
 * `fingerprint` - Fingerprint of the login key
-* `create_date` - Creation date of the login key
 
 ## Import
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -15,7 +15,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/classicloadbalancer"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/devtools"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/loadbalancer"
-	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/loginkey"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/memberserverimage"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/nasvolume"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/nks"
@@ -124,7 +123,7 @@ func New(ctx context.Context) *schema.Provider {
 		"ncloud_lb":                                  loadbalancer.ResourceNcloudLb(),
 		"ncloud_load_balancer_ssl_certificate":       classicloadbalancer.ResourceNcloudLoadBalancerSSLCertificate(),
 		"ncloud_load_balancer":                       classicloadbalancer.ResourceNcloudLoadBalancer(),
-		"ncloud_login_key":                           loginkey.ResourceNcloudLoginKey(),
+		"ncloud_login_key":                           server.ResourceNcloudLoginKey(),
 		"ncloud_nas_volume":                          nasvolume.ResourceNcloudNasVolume(),
 		"ncloud_network_acl":                         vpc.ResourceNcloudNetworkACL(),
 		"ncloud_network_acl_deny_allow_group":        vpc.ResourceNcloudNetworkACLDenyAllowGroup(),

--- a/internal/service/loginkey/types.go
+++ b/internal/service/loginkey/types.go
@@ -1,6 +1,0 @@
-package loginkey
-
-type LoginKey struct {
-	KeyName     *string `json:"key_name,omitempty"`
-	Fingerprint *string `json:"fingerprint,omitempty"`
-}

--- a/internal/service/server/login_key_test.go
+++ b/internal/service/server/login_key_test.go
@@ -1,4 +1,4 @@
-package loginkey_test
+package server_test
 
 import (
 	"fmt"
@@ -10,7 +10,7 @@ import (
 
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/acctest"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
-	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/loginkey"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/server"
 )
 
 func TestAccResourceNcloudLoginKey_classic_basic(t *testing.T) {
@@ -22,7 +22,7 @@ func TestAccResourceNcloudLoginKey_vpc_basic(t *testing.T) {
 }
 
 func testAccResourceNcloudLoginKeyBasic(t *testing.T, isVpc bool) {
-	var loginKey *loginkey.LoginKey
+	var loginKey *server.LoginKey
 	prefix := GetTestPrefix()
 	testKeyName := prefix + "-key"
 
@@ -64,7 +64,7 @@ func testAccResourceNcloudLoginKeyBasic(t *testing.T, isVpc bool) {
 	})
 }
 
-func testAccCheckLoginKeyExistsWithProvider(n string, l *loginkey.LoginKey, provider *schema.Provider) resource.TestCheckFunc {
+func testAccCheckLoginKeyExistsWithProvider(n string, l *server.LoginKey, provider *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -76,7 +76,7 @@ func testAccCheckLoginKeyExistsWithProvider(n string, l *loginkey.LoginKey, prov
 		}
 
 		config := provider.Meta().(*conn.ProviderConfig)
-		loginKey, err := loginkey.GetLoginKey(config, rs.Primary.ID)
+		loginKey, err := server.GetLoginKey(config, rs.Primary.ID)
 		if err != nil {
 			return nil
 		}
@@ -97,7 +97,7 @@ func testAccCheckLoginKeyDestroyWithProvider(s *terraform.State, provider *schem
 		if rs.Type != "ncloud_login_key" {
 			continue
 		}
-		loginKey, err := loginkey.GetLoginKey(config, rs.Primary.ID)
+		loginKey, err := server.GetLoginKey(config, rs.Primary.ID)
 
 		if loginKey == nil {
 			continue


### PR DESCRIPTION
## Task List
- Change login_key resource package classification
- Modify login_key.go lint

## Test Result
```
go test ./internal/service/server/login_key_test.go -v
=== RUN   TestAccResourceNcloudLoginKey_classic_basic
--- PASS: TestAccResourceNcloudLoginKey_classic_basic (5.74s)
=== RUN   TestAccResourceNcloudLoginKey_vpc_basic
--- PASS: TestAccResourceNcloudLoginKey_vpc_basic (5.52s)
PASS
ok      command-line-arguments  11.579s
```