### PR TITLE
Refactor: Login Key Resource to Framework

### DIFF
--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/server"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/vpc"
 )
 
@@ -87,6 +88,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 	resources = append(resources, vpc.NewVpcResource)
 	resources = append(resources, vpc.NewSubnetResource)
 	resources = append(resources, vpc.NewNatGatewayResource)
+	resources = append(resources, server.NewLoginKeyResource)
 
 	if err := errs.ErrorOrNil(); err != nil {
 		tflog.Warn(ctx, "registering resources", map[string]interface{}{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -123,7 +123,6 @@ func New(ctx context.Context) *schema.Provider {
 		"ncloud_lb":                                  loadbalancer.ResourceNcloudLb(),
 		"ncloud_load_balancer_ssl_certificate":       classicloadbalancer.ResourceNcloudLoadBalancerSSLCertificate(),
 		"ncloud_load_balancer":                       classicloadbalancer.ResourceNcloudLoadBalancer(),
-		"ncloud_login_key":                           server.ResourceNcloudLoginKey(),
 		"ncloud_nas_volume":                          nasvolume.ResourceNcloudNasVolume(),
 		"ncloud_network_acl":                         vpc.ResourceNcloudNetworkACL(),
 		"ncloud_network_acl_deny_allow_group":        vpc.ResourceNcloudNetworkACLDenyAllowGroup(),

--- a/internal/service/server/login_key_test.go
+++ b/internal/service/server/login_key_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -37,8 +38,8 @@ func testAccResourceNcloudLoginKeyBasic(t *testing.T, isVpc bool) {
 	provider := GetTestProvider(isVpc)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: getProvidersBasedOnVpc(isVpc),
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLoginKeyDestroyWithProvider(state, provider)
 		},
@@ -62,6 +63,14 @@ func testAccResourceNcloudLoginKeyBasic(t *testing.T, isVpc bool) {
 			},
 		},
 	})
+}
+
+func getProvidersBasedOnVpc(isVpc bool) map[string]func() (tfprotov5.ProviderServer, error) {
+	if isVpc {
+		return ProtoV5ProviderFactories
+	} else {
+		return ClassicProtoV5ProviderFactories
+	}
 }
 
 func testAccCheckLoginKeyExistsWithProvider(n string, l *server.LoginKey, provider *schema.Provider) resource.TestCheckFunc {


### PR DESCRIPTION
## Description
Resolve #355 
Refactoring Login Key Resource from SDK2 plugin to Framework Plugin.

## Task File
* internal/service/server/login_key.go
* internal/service/server/login_key_test.go
* internal/provider/fwprovider/provider.go
* internal/provider/provider.go

## Test Result
```
 go test ./internal/service/server/login_key_test.go -v
=== RUN   TestAccResourceNcloudLoginKey_classic_basic
--- PASS: TestAccResourceNcloudLoginKey_classic_basic (6.48s)
=== RUN   TestAccResourceNcloudLoginKey_vpc_basic
--- PASS: TestAccResourceNcloudLoginKey_vpc_basic (6.31s)
PASS
ok      command-line-arguments  13.250s
```