### PR TITLE
fix(SourcePipeline): Add 1 min time Sleep in func of check destroy

### DIFF
--- a/internal/service/devtools/sourcepipeline_project_test.go
+++ b/internal/service/devtools/sourcepipeline_project_test.go
@@ -805,6 +805,9 @@ func testAccCheckSourcePipelineProjectDestroy(s *terraform.State, provider *sche
 		}
 	}
 
+	// FIXME: When testing, time gap is required between each test to create
+	// resource without any issues. It should guarantee to deletion and creation
+	// of the resource without problem from the PipelineProject API
 	time.Sleep(1 * time.Minute)
 
 	return nil

--- a/internal/service/devtools/sourcepipeline_project_test.go
+++ b/internal/service/devtools/sourcepipeline_project_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -803,6 +804,8 @@ func testAccCheckSourcePipelineProjectDestroy(s *terraform.State, provider *sche
 			return errors.New("SourcePipeline project still exists")
 		}
 	}
+
+	time.Sleep(1 * time.Minute)
 
 	return nil
 }


### PR DESCRIPTION
Related Issues
#286

Changes
- Put 1 minute in testAccCheckSourcePipelineProjectDestroy()