### PR TITLE
fix(SourceBuild): Remove not permitted empty string

### DIFF
--- a/internal/service/devtools/sourcebuild_project_test.go
+++ b/internal/service/devtools/sourcebuild_project_test.go
@@ -185,7 +185,7 @@ resource "ncloud_sourcebuild_project" "test-project" {
 		}
 	}
 	build_command {
-		pre_build   = [""]
+		pre_build   = []
 		in_build = ["pwd", "ls"]
 		post_build  = ["pwd", "ls"]
 	}


### PR DESCRIPTION
https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/342 의 변경 사항으로 인해 테스트 코드 동작 시 에러가 발생하던 부분을 수정하였습니다.

### error message

```
$ go test ./internal/service/devtools/... -run=TestAccResourceNcloudSourcebuildProject_update -v

=== RUN   TestAccResourceNcloudSourcebuildProject_update
...
    sourcebuild_project_test.go:53: Step 2/3 error: Error running apply: exit status 1
        
        Error: build_command.pre_build cannot contain an empty string element
        
          with ncloud_sourcebuild_project.test-project,
          on terraform_plugin_test.tf line 9, in resource "ncloud_sourcebuild_project" "test-project":
           9: resource "ncloud_sourcebuild_project" "test-project" {
        
--- FAIL: TestAccResourceNcloudSourcebuildProject_update (6.22s)
```