### PR TITLE
feat: upgrade tfproto5 to 6

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -11,7 +11,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -35,6 +38,7 @@ const (
 var (
 	ProtoV5ProviderFactories        map[string]func() (tfprotov5.ProviderServer, error) = protoV5ProviderFactoriesInit(context.Background(), true, ProviderName)
 	ClassicProtoV5ProviderFactories map[string]func() (tfprotov5.ProviderServer, error) = protoV5ProviderFactoriesInit(context.Background(), false, ProviderName)
+	ProtoV6ProviderFactories 		map[string]func() (tfprotov6.ProviderServer, error) = protoV6ProviderFactoriesInit(context.Background(), true, ProviderName)
 )
 
 // TODO: deprecate testAccProviders/testAccClassicProviders
@@ -225,6 +229,54 @@ func protoV5TestProviderServerFactory(ctx context.Context, isVpc bool) (func() t
 	}
 
 	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return muxServer.ProviderServer, primary, nil
+}
+
+
+func protoV6ProviderFactoriesInit(ctx context.Context, isVpc bool, providerNames ...string) map[string]func() (tfprotov6.ProviderServer, error) {
+	factories := make(map[string]func() (tfprotov6.ProviderServer, error), len(providerNames))
+
+	for _, name := range providerNames {
+		factories[name] = func() (tfprotov6.ProviderServer, error) {
+			providerServerFactory, _, err := protoV6TestProviderServerFactory(ctx, isVpc)
+
+			if err != nil {
+				return nil, err
+			}
+
+			return providerServerFactory(), nil
+		}
+	}
+
+	return factories
+}
+
+func protoV6TestProviderServerFactory(ctx context.Context, isVpc bool) (func() tfprotov6.ProviderServer, *schema.Provider, error) {
+	primary := provider.New(ctx)
+	primary.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		d.Set("region", testAccGetRegion())
+		d.Set("support_vpc", isVpc)
+		return provider.ProviderConfigure(ctx, d)
+	}
+
+	upgradedSdkProvider, err := tf5to6server.UpgradeServer(
+		ctx,
+		primary.GRPCProvider,
+	)
+
+	servers := []func() tfprotov6.ProviderServer{
+		func() tfprotov6.ProviderServer {
+			return upgradedSdkProvider
+		},
+		providerserver.NewProtocol6(fwprovider.New(primary)),
+	}
+
+	muxServer, err := tf6muxserver.NewMuxServer(ctx, servers...)
 
 	if err != nil {
 		return nil, nil, err

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -224,6 +224,9 @@ func protoV6TestProviderServerFactory(ctx context.Context, isVpc bool) (func() t
 		ctx,
 		primary.GRPCProvider,
 	)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	servers := []func() tfprotov6.ProviderServer{
 		func() tfprotov6.ProviderServer {

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -21,6 +21,9 @@ func ProtoV6ProviderServerFactory(ctx context.Context) (func() tfprotov6.Provide
 		ctx,
 		primary.GRPCProvider,
 	)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	servers := []func() tfprotov6.ProviderServer{
 		func() tfprotov6.ProviderServer {

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -4,35 +4,16 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/provider/fwprovider"
 )
 
-// ProtoV5ProviderServerFactory returns a muxed terraform-plugin-go protocol v5 provider factory function.
+// ProtoV6ProviderServerFactory returns a muxed terraform-plugin-go protocol v6 provider factory function.
 // This factory function is suitable for use with the terraform-plugin-go Serve function.
 // The primary (Plugin SDK) provider server is also returned (useful for testing).
-func ProtoV5ProviderServerFactory(ctx context.Context) (func() tfprotov5.ProviderServer, *schema.Provider, error) {
-	primary := New(ctx)
-
-	servers := []func() tfprotov5.ProviderServer{
-		primary.GRPCProvider,
-		providerserver.NewProtocol5(fwprovider.New(primary)),
-	}
-
-	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return muxServer.ProviderServer, primary, nil
-}
-
 func ProtoV6ProviderServerFactory(ctx context.Context) (func() tfprotov6.ProviderServer, *schema.Provider, error) {
 	primary := New(ctx)
 

--- a/internal/service/autoscaling/auto_scaling_group_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_group_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNcloudAutoScalingGroup_classic_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingGroupClassicConfig(),
@@ -49,7 +49,7 @@ func TestAccDataSourceNcloudAutoScalingGroup_vpc_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingGroupVpcConfig(),

--- a/internal/service/autoscaling/auto_scaling_group_test.go
+++ b/internal/service/autoscaling/auto_scaling_group_test.go
@@ -19,7 +19,7 @@ func TestAccResourceNcloudAutoScalingGroup_classic_basic(t *testing.T) {
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckAutoScalingGroupDestroy(state, GetTestProvider(false))
 		},
@@ -50,7 +50,7 @@ func TestAccResourceNcloudAutoScalingGroup_vpc_basic(t *testing.T) {
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckAutoScalingGroupDestroy(state, GetTestProvider(true))
 		},
@@ -82,7 +82,7 @@ func TestAccResourceNcloudAutoScalingGroup_classic_zero_value(t *testing.T) {
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckAutoScalingGroupDestroy(state, GetTestProvider(false))
 		},
@@ -114,7 +114,7 @@ func TestAccResourceNcloudAutoScalingGroup_vpc_zero_value(t *testing.T) {
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckAutoScalingGroupDestroy(state, GetTestProvider(true))
 		},
@@ -146,7 +146,7 @@ func TestAccResourceNcloudAutoScalingGroup_classic_disappears(t *testing.T) {
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckAutoScalingGroupDestroy(state, GetTestProvider(false))
 		},
@@ -168,7 +168,7 @@ func TestAccResourceNcloudAutoScalingGroup_vpc_disappears(t *testing.T) {
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckAutoScalingGroupDestroy(state, GetTestProvider(true))
 		},

--- a/internal/service/autoscaling/auto_scaling_policy_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_policy_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNcloudAutoScalingPolicy_classic_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingPolicyClassicConfig(name),
@@ -42,7 +42,7 @@ func TestAccDataSourceNcloudAutoScalingPolicy_vpc_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingPolicyVpcConfig(name),

--- a/internal/service/autoscaling/auto_scaling_policy_test.go
+++ b/internal/service/autoscaling/auto_scaling_policy_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNcloudAutoScalingPolicy_classic_basic(t *testing.T) {
 	resourcePRCNT := "ncloud_auto_scaling_policy.test-policy-PRCNT"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNcloudAutoScalingPolicyDestroy(state, GetTestProvider(false))
 		},
@@ -62,7 +62,7 @@ func TestAccResourceNcloudAutoScalingPolicy_classic_zero_value(t *testing.T) {
 	resourcePRCNT := "ncloud_auto_scaling_policy.test-policy-PRCNT"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNcloudAutoScalingPolicyDestroy(state, GetTestProvider(false))
 		},
@@ -125,7 +125,7 @@ func TestAccResourceNcloudAutoScalingPolicy_vpc_zero_value(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNcloudAutoScalingPolicyDestroy(state, GetTestProvider(true))
 		},
@@ -188,7 +188,7 @@ func TestAccResourceNcloudAutoScalingPolicy_classic_disappears(t *testing.T) {
 	resourcePRCNT := "ncloud_auto_scaling_policy.test-policy-PRCNT"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNcloudAutoScalingPolicyDestroy(state, GetTestProvider(false))
 		},
@@ -218,7 +218,7 @@ func TestAccResourceNcloudAutoScalingPolicy_vpc_disappears(t *testing.T) {
 	resourcePRCNT := "ncloud_auto_scaling_policy.test-policy-PRCNT"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNcloudAutoScalingPolicyDestroy(state, GetTestProvider(true))
 		},

--- a/internal/service/autoscaling/auto_scaling_schedule_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_schedule_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNcloudAutoScalingSchedule_classic_basic(t *testing.T) {
 	end := testAccNcloudAutoscalingScheduleValidEnd(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingScheduleClassicConfig(name, start, end),
@@ -46,7 +46,7 @@ func TestAccDataSourceNcloudAutoScalingSchedule_vpc_basic(t *testing.T) {
 	end := testAccNcloudAutoscalingScheduleValidEnd(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingScheduleVpcConfig(name, start, end),

--- a/internal/service/autoscaling/auto_scaling_schedule_test.go
+++ b/internal/service/autoscaling/auto_scaling_schedule_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNcloudAutoScalingSchedule_classic_basic(t *testing.T) {
 	end := testAccNcloudAutoscalingScheduleValidEnd(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNcloudAutoScalingScheduleDestroy(state, GetTestProvider(false))
 		},
@@ -47,7 +47,7 @@ func TestAccResourceNcloudAutoScalingSchedule_vpc_basic(t *testing.T) {
 	end := testAccNcloudAutoscalingScheduleValidEnd(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNcloudAutoScalingScheduleDestroy(state, GetTestProvider(true))
 		},
@@ -70,7 +70,7 @@ func TestAccResourceNcloudAutoScalingSchedule_classic_disappears(t *testing.T) {
 	end := testAccNcloudAutoscalingScheduleValidEnd(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNcloudAutoScalingScheduleDestroy(state, GetTestProvider(false))
 		},
@@ -95,7 +95,7 @@ func TestAccResourceNcloudAutoScalingSchedule_vpc_disappears(t *testing.T) {
 	end := testAccNcloudAutoscalingScheduleValidEnd(t)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNcloudAutoScalingScheduleDestroy(state, GetTestProvider(true))
 		},

--- a/internal/service/autoscaling/launch_configuration_data_source_test.go
+++ b/internal/service/autoscaling/launch_configuration_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudLaunchConfigurationClassicConfig(),
@@ -41,7 +41,7 @@ func TestAccDataSourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudLaunchConfigurationVpcConfig(),

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
 	serverProductCode := "SPSVRSSD00000003"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLaunchConfigurationDestroy(state, GetTestProvider(false))
 		},
@@ -47,7 +47,7 @@ func TestAccResourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
 	serverImageProductCode := "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLaunchConfigurationDestroy(state, GetTestProvider(true))
 		},
@@ -74,7 +74,7 @@ func TestAccResourceNcloudLaunchConfiguration_classic_disappears(t *testing.T) {
 	serverProductCode := "SPSVRSSD00000003"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLaunchConfigurationDestroy(state, GetTestProvider(false))
 		},
@@ -97,7 +97,7 @@ func TestAccResourceNcloudLaunchConfiguration_vpc_disappears(t *testing.T) {
 	serverImageProductCode := "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLaunchConfigurationDestroy(state, GetTestProvider(true))
 		},

--- a/internal/service/classicloadbalancer/load_balancer_ssl_certificate_test.go
+++ b/internal/service/classicloadbalancer/load_balancer_ssl_certificate_test.go
@@ -84,7 +84,7 @@ GTfhUTV7jTQ0dt9U1E+oxRkjqC2HFYlpewXP0rcQxhtK7p6kiaUDIw==
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckLoadBalancerSSLCertificateDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/classicloadbalancer/load_balancer_test.go
+++ b/internal/service/classicloadbalancer/load_balancer_test.go
@@ -30,7 +30,7 @@ func TestAccNcloudLoadBalancerBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -66,7 +66,7 @@ func TestAccNcloudLoadBalancerChangeConfiguration(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/devtools/sourcebuild_project_computes_data_source_test.go
+++ b/internal/service/devtools/sourcebuild_project_computes_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudSourceBuildComputes(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceBuildComputesConfig(),

--- a/internal/service/devtools/sourcebuild_project_data_source_test.go
+++ b/internal/service/devtools/sourcebuild_project_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceNcloudSourceBuildProject(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceBuildProjectConfig(name, repoName),

--- a/internal/service/devtools/sourcebuild_project_docker_engines_data_source_test.go
+++ b/internal/service/devtools/sourcebuild_project_docker_engines_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudSourceBuildDockerEngines(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceBuildDockerEnginesConfig(),

--- a/internal/service/devtools/sourcebuild_project_os_data_source_test.go
+++ b/internal/service/devtools/sourcebuild_project_os_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudSourceBuildOs(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceBuildOsConfig(),

--- a/internal/service/devtools/sourcebuild_project_os_runtime_versions_data_source_test.go
+++ b/internal/service/devtools/sourcebuild_project_os_runtime_versions_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudSourceBuildRuntimeVersions(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceBuildRuntimeVersionsConfig(),

--- a/internal/service/devtools/sourcebuild_project_os_runtimes_data_source_test.go
+++ b/internal/service/devtools/sourcebuild_project_os_runtimes_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudSourceBuildRuntimes(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceBuildRuntimesConfig(),

--- a/internal/service/devtools/sourcebuild_project_test.go
+++ b/internal/service/devtools/sourcebuild_project_test.go
@@ -25,7 +25,7 @@ func TestAccResourceNcloudSourcebuildProject_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSourcebuildProjectDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -52,7 +52,7 @@ func TestAccResourceNcloudSourcebuildProject_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSourcebuildProjectDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/devtools/sourcebuild_projects_data_source_test.go
+++ b/internal/service/devtools/sourcebuild_projects_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceNcloudSourceBuildProjects(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceBuildProjectsConfig(name, repoName),

--- a/internal/service/devtools/sourcecommit_repositories_data_source_test.go
+++ b/internal/service/devtools/sourcecommit_repositories_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudSourceCommitRepositories(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceCommitRepositoriesConfig(),

--- a/internal/service/devtools/sourcecommit_repository_data_source_test.go
+++ b/internal/service/devtools/sourcecommit_repository_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNcloudSourceCommitRepository(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceCommitRepositoryConfig(repositoryName, repositoryDesc),

--- a/internal/service/devtools/sourcecommit_repository_test.go
+++ b/internal/service/devtools/sourcecommit_repository_test.go
@@ -26,7 +26,7 @@ func TestAccResourceNcloudSourceCommitRepository_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSourceCommitRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/devtools/sourcedeploy_project_stage_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceNcloudSourceDeploySingleStage(t *testing.T) {
 	productCode := "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceDeployStageConfig(stageNameSvr, productCode),

--- a/internal/service/devtools/sourcedeploy_project_stage_scenario_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_scenario_data_source_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceNcloudSourceDeploySingleScenario(t *testing.T) {
 	stageNameSvr := GetTestSourceDeployScenarioName() + "svr"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceDeployScenarioConfig(stageNameSvr),

--- a/internal/service/devtools/sourcedeploy_project_stage_scenario_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_scenario_test.go
@@ -46,7 +46,7 @@ func TestAccResourceNcloudSourceDeployScenario_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSourceDeployScenarioDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/devtools/sourcedeploy_project_stage_scenarios_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_scenarios_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceNcloudSourceDeployScenarios(t *testing.T) {
 	productCode := "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceDeployScenariosConfig(stageNameSvr, productCode),

--- a/internal/service/devtools/sourcedeploy_project_stage_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_test.go
@@ -42,7 +42,7 @@ func TestAccResourceNcloudSourceDeployStage_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSourceDeployStageDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/devtools/sourcedeploy_project_stages_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stages_data_source_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceNcloudSourceDeployStages(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceDeployStagesConfig(),

--- a/internal/service/devtools/sourcedeploy_project_test.go
+++ b/internal/service/devtools/sourcedeploy_project_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNcloudSourceDeployProject_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSourceDeployProjectDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/devtools/sourcedeploy_projects_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_projects_data_source_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceNcloudSourceDeployProjects(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourceDeployProjectsConfig(),

--- a/internal/service/devtools/sourcepipeline_project_data_source_test.go
+++ b/internal/service/devtools/sourcepipeline_project_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNcloudSourcePipelineProject_classic_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourcePipelineProjectConfig("test-project", "description test"),
@@ -36,7 +36,7 @@ func TestAccDataSourceNcloudSourcePipelineProject_vpc_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourcePipelineProjectConfig("test-project", "description test"),

--- a/internal/service/devtools/sourcepipeline_project_test.go
+++ b/internal/service/devtools/sourcepipeline_project_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNcloudSourcePipelineProject_classic_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckSourcePipelineProjectDestroy(state, GetTestProvider(false))
 		},
@@ -52,7 +52,7 @@ func TestAccResourceNcloudSourcePipelineProject_classic_updateTaskName(t *testin
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckSourcePipelineProjectDestroy(state, GetTestProvider(false))
 		},
@@ -89,7 +89,7 @@ func TestAccResourceNcloudSourcePipelineProject_classic_updateDescription(t *tes
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckSourcePipelineProjectDestroy(state, GetTestProvider(false))
 		},
@@ -126,7 +126,7 @@ func TestAccResourceNcloudSourcePipelineProject_vpc_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckSourcePipelineProjectDestroy(state, GetTestProvider(true))
 		},
@@ -154,7 +154,7 @@ func TestAccResourceNcloudSourcePipelineProject_vpc_updateTaskName(t *testing.T)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckSourcePipelineProjectDestroy(state, GetTestProvider(true))
 		},
@@ -191,7 +191,7 @@ func TestAccResourceNcloudSourcePipelineProject_vpc_updateDescription(t *testing
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckSourcePipelineProjectDestroy(state, GetTestProvider(true))
 		},

--- a/internal/service/devtools/sourcepipeline_projects_data_source_test.go
+++ b/internal/service/devtools/sourcepipeline_projects_data_source_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceNcloudSourcePipelineProjects_classic_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourcePipelineProjectsConfig(),
@@ -26,7 +26,7 @@ func TestAccDataSourceNcloudSourcePipelineProjects_classic_basic(t *testing.T) {
 func TestAccDataSourceNcloudSourcePipelineProjects_vpc_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourcePipelineProjectsConfig(),

--- a/internal/service/devtools/sourcepipeline_trigger_timezone_data_source_test.go
+++ b/internal/service/devtools/sourcepipeline_trigger_timezone_data_source_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceNcloudSourcePipelineTriggerTimeZone_classic_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourcePipelineTriggerTimeZoneConfig(),
@@ -26,7 +26,7 @@ func TestAccDataSourceNcloudSourcePipelineTriggerTimeZone_classic_basic(t *testi
 func TestAccDataSourceNcloudSourcePipelineTriggerTimeZone_vpc_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSourcePipelineTriggerTimeZoneConfig(),

--- a/internal/service/loadbalancer/lb_data_source_test.go
+++ b/internal/service/loadbalancer/lb_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceNcloudLb_basic(t *testing.T) {
 	resourceName := "ncloud_lb.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudLbConfig(name),

--- a/internal/service/loadbalancer/lb_listener_data_source_test.go
+++ b/internal/service/loadbalancer/lb_listener_data_source_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceNcloudLbListener_basic(t *testing.T) {
 	resourceName := "ncloud_lb_listener.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudLbListenerConfig(lbName),

--- a/internal/service/loadbalancer/lb_listener_test.go
+++ b/internal/service/loadbalancer/lb_listener_test.go
@@ -20,7 +20,7 @@ func TestAccResourceNcloudLbListener_vpc_basic(t *testing.T) {
 	resourceName := "ncloud_lb_listener.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLbListenerDestroy(state, GetTestProvider(true))
 		},

--- a/internal/service/loadbalancer/lb_target_group_attachment_test.go
+++ b/internal/service/loadbalancer/lb_target_group_attachment_test.go
@@ -22,7 +22,7 @@ func TestAccResourceNcloudLbTargetGroupAttachment_basic(t *testing.T) {
 	resourceName := "ncloud_lb_target_group_attachment.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLbTargetGroupAttachmentDestroy(state, GetTestProvider(true))
 		},

--- a/internal/service/loadbalancer/lb_target_group_data_source_test.go
+++ b/internal/service/loadbalancer/lb_target_group_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNcloudLbTargetGroup_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudLbTargetGroupConfig(name),

--- a/internal/service/loadbalancer/lb_target_group_test.go
+++ b/internal/service/loadbalancer/lb_target_group_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNcloudLbTargetGroup_basic(t *testing.T) {
 	resourceName := "ncloud_lb_target_group.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLbTargetGroupDestroy(state, GetTestProvider(true))
 		},
@@ -57,7 +57,7 @@ func TestAccResourceNcloudLbTargetGroup_emptyTargetGroupName(t *testing.T) {
 	resourceName := "ncloud_lb_target_group.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLbTargetGroupDestroy(state, GetTestProvider(true))
 		},

--- a/internal/service/loadbalancer/lb_test.go
+++ b/internal/service/loadbalancer/lb_test.go
@@ -21,7 +21,7 @@ func TestAccResourceNcloudLb_vpc_basic(t *testing.T) {
 	resourceName := "ncloud_lb.test"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLbDestroy(state, GetTestProvider(true))
 		},

--- a/internal/service/memberserverimage/member_server_image_data_source_test.go
+++ b/internal/service/memberserverimage/member_server_image_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudMemberServerImageBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudMemberServerImageConfig,
@@ -30,7 +30,7 @@ func TestAccDataSourceNcloudMemberServerImageBasic(t *testing.T) {
 func TestAccDataSourceNcloudMemberServerImageFilter(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudMemberServerImageConfigFilter,

--- a/internal/service/memberserverimage/member_server_images_data_source_test.go
+++ b/internal/service/memberserverimage/member_server_images_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudMemberServerImagesBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudMemberServerImagesConfig,
@@ -30,7 +30,7 @@ func TestAccDataSourceNcloudMemberServerImagesBasic(t *testing.T) {
 func TestAccDataSourceNcloudMemberServerImagesFilter(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudMemberServerImagesConfigFilter,

--- a/internal/service/nks/nks_cluster_data_source_test.go
+++ b/internal/service/nks/nks_cluster_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNcloudNKSCluster(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNKSClusterConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region),

--- a/internal/service/nks/nks_cluster_test.go
+++ b/internal/service/nks/nks_cluster_test.go
@@ -31,7 +31,7 @@ func TestAccResourceNcloudNKSCluster_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -72,7 +72,7 @@ func TestAccResourceNcloudNKSCluster_public_network(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -99,7 +99,7 @@ func TestAccResourceNcloudNKSCluster_InvalidSubnet(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -119,7 +119,7 @@ func TestAccResourceNcloudNKSCluster_Update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -174,7 +174,7 @@ func TestAccResourceNcloudNKSCluster_UpdateOnce(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -207,7 +207,7 @@ func TestAccResourceNcloudNKSCluster_VersionUpgrade(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -237,7 +237,7 @@ func TestAccResourceNcloudNKSCluster_OIDCSpec(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -288,7 +288,7 @@ func TestAccResourceNcloudNKSCluster_AuditLog(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -319,7 +319,7 @@ func TestAccResourceNcloudNKSCluster_AddSubnet(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/nks/nks_clusters_data_source_test.go
+++ b/internal/service/nks/nks_clusters_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudNKSClusters(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNKSClustersConfig(),

--- a/internal/service/nks/nks_node_pool_data_source_test.go
+++ b/internal/service/nks/nks_node_pool_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNcloudNKSNodePool(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNKSNodePoolConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region, productType),

--- a/internal/service/nks/nks_node_pool_test.go
+++ b/internal/service/nks/nks_node_pool_test.go
@@ -27,7 +27,7 @@ func TestAccResourceNcloudNKSNodePool_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -56,7 +56,7 @@ func TestAccResourceNcloudNKSNodePool_publicNetwork(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSClusterDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -80,7 +80,7 @@ func TestAccResourceNcloudNKSNodePool_updateNodeCountAndAutoScale(t *testing.T) 
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSNodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -113,7 +113,7 @@ func TestAccResourceNcloudNKSNodePool_upgrade(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNKSNodePoolDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -141,7 +141,7 @@ func TestAccResourceNcloudNKSNodePool_invalidNodeCount(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/nks/nks_node_pools_data_source_test.go
+++ b/internal/service/nks/nks_node_pools_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNcloudNKSNodePools(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNKSNodePoolsConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region, productType),

--- a/internal/service/nks/nks_server_images_data_source_test.go
+++ b/internal/service/nks/nks_server_images_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceNcloudNKSServerImages(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNKSServerImagesConfig,
@@ -31,7 +31,7 @@ func TestAccDataSourceNcloudNKSServerImagesFilter(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNKSServerImagestWithFilterConfig(),

--- a/internal/service/nks/nks_server_products_data_source_test.go
+++ b/internal/service/nks/nks_server_products_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNcloudNKSServerProductCodes(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNKSServerProductConfig(zone),

--- a/internal/service/nks/nks_versions_data_source_test.go
+++ b/internal/service/nks/nks_versions_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudVersions(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudVersionConfig,

--- a/internal/service/server/access_control_group_rule_test.go
+++ b/internal/service/server/access_control_group_rule_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNcloudAccessControlGroupRule_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckAccessControlGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -47,7 +47,7 @@ func TestAccResourceNcloudAccessControlGroupRule_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckAccessControlGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/server/access_control_group_test.go
+++ b/internal/service/server/access_control_group_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNcloudAccessControlGroup_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckAccessControlGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -55,7 +55,7 @@ func TestAccResourceNcloudAccessControlGroup_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckAccessControlGroupDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/server/access_control_rules_data_source_test.go
+++ b/internal/service/server/access_control_rules_data_source_test.go
@@ -21,7 +21,7 @@ func testAccDataSourceNcloudAccessControlRulesBasic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAccessControlRulesConfig(testId),

--- a/internal/service/server/block_storage_data_source_test.go
+++ b/internal/service/server/block_storage_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNcloudBlockStorage_classic_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: ComposeConfig(
@@ -52,7 +52,7 @@ func TestAccDataSourceNcloudBlockStorage_vpc_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: ComposeConfig(

--- a/internal/service/server/block_storage_snapshot_test.go
+++ b/internal/service/server/block_storage_snapshot_test.go
@@ -35,7 +35,7 @@ func ignore_TestAccResourceNcloudBlockStorageSnapshotBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckBlockStorageSnapshotDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/server/block_storage_test.go
+++ b/internal/service/server/block_storage_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNcloudBlockStorage_classic_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckBlockStorageDestroyWithProvider(state, GetTestProvider(false))
 		},
@@ -63,7 +63,7 @@ func TestAccResourceNcloudBlockStorage_vpc_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckBlockStorageDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -101,7 +101,7 @@ func TestAccResourceNcloudBlockStorage_classic_ChangeServerInstance(t *testing.T
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckBlockStorageDestroyWithProvider(state, GetTestProvider(false))
 		},
@@ -129,7 +129,7 @@ func TestAccResourceNcloudBlockStorage_vpc_ChangeServerInstance(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckBlockStorageDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -155,7 +155,7 @@ func TestAccResourceNcloudBlockStorage_classic_size(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckBlockStorageDestroyWithProvider(state, GetTestProvider(false))
 		},
@@ -203,7 +203,7 @@ func TestAccResourceNcloudBlockStorage_vpc_size(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckBlockStorageDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/server/init_script_data_source_test.go
+++ b/internal/service/server/init_script_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceNcloudInitScriptBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudInitScriptConfig,
@@ -35,7 +35,7 @@ func TestAccDataSourceNcloudInitScriptFilter(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudInitScriptConfigFilter,

--- a/internal/service/server/init_script_test.go
+++ b/internal/service/server/init_script_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNcloudInitScript_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckInitScriptDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccResourceNcloudInitScript_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckInitScriptDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/server/init_script_test.go
+++ b/internal/service/server/init_script_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNcloudInitScript_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckInitScriptDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccResourceNcloudInitScript_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckInitScriptDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/server/login_key_test.go
+++ b/internal/service/server/login_key_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -39,7 +39,7 @@ func testAccResourceNcloudLoginKeyBasic(t *testing.T, isVpc bool) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: getProvidersBasedOnVpc(isVpc),
+		ProtoV6ProviderFactories: getProvidersBasedOnVpc(isVpc),
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckLoginKeyDestroyWithProvider(state, provider)
 		},
@@ -65,11 +65,11 @@ func testAccResourceNcloudLoginKeyBasic(t *testing.T, isVpc bool) {
 	})
 }
 
-func getProvidersBasedOnVpc(isVpc bool) map[string]func() (tfprotov5.ProviderServer, error) {
+func getProvidersBasedOnVpc(isVpc bool) map[string]func() (tfprotov6.ProviderServer, error) {
 	if isVpc {
-		return ProtoV5ProviderFactories
+		return ProtoV6ProviderFactories
 	} else {
-		return ClassicProtoV5ProviderFactories
+		return ClassicProtoV6ProviderFactories
 	}
 }
 

--- a/internal/service/server/network_interface_data_source_test.go
+++ b/internal/service/server/network_interface_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNcloudNetworkInterfaceBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNetworkInterfaceConfig(name),
@@ -47,7 +47,7 @@ func TestAccDataSourceNcloudNetworkInterfaceFilter(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNetworkInterfaceConfigFilter(name),

--- a/internal/service/server/network_interface_test.go
+++ b/internal/service/server/network_interface_test.go
@@ -24,7 +24,7 @@ func TestAccresourceNcloudNetworkInterface_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -58,7 +58,7 @@ func TestAccresourceNcloudNetworkInterface_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -86,7 +86,7 @@ func TestAccresourceNcloudNetworkInterface_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/server/placement_group_test.go
+++ b/internal/service/server/placement_group_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNcloudPlacementGroup_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckPlacementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -51,7 +51,7 @@ func TestAccResourceNcloudPlacementGroup_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckPlacementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -73,7 +73,7 @@ func TestAccResourceNcloudPlacementGroup_updateName(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckPlacementGroupDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/server/port_forwarding_rule_test.go
+++ b/internal/service/server/port_forwarding_rule_test.go
@@ -27,7 +27,7 @@ func TestAccResourceNcloudPortForwardingRuleBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckPortForwardingRuleDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -62,7 +62,7 @@ func ignore_TestAccResourceNcloudPortForwardingRuleExistingServer(t *testing.T) 
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckPortForwardingRuleDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/server/server_products_data_source_test.go
+++ b/internal/service/server/server_products_data_source_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceNcloudServerProducts_classic_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		IsUnitTest:               false,
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 
 		Steps: []resource.TestStep{
 			{
@@ -30,7 +30,7 @@ func TestAccDataSourceNcloudServerProducts_vpc_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		IsUnitTest:               false,
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/server/server_test.go
+++ b/internal/service/server/server_test.go
@@ -33,7 +33,7 @@ func TestAccResourceNcloudServer_classic_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckInstanceDestroyWithProvider(state, GetTestProvider(false))
 		},
@@ -82,7 +82,7 @@ func TestAccResourceNcloudServer_vpc_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckServerDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -130,7 +130,7 @@ func TestAccResourceNcloudServer_vpc_networkInterface(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckServerDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -180,7 +180,7 @@ func TestAccResourceNcloudServer_classic_changeSpec(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckInstanceDestroyWithProvider(state, GetTestProvider(false))
 		},
@@ -219,7 +219,7 @@ func TestAccResourceNcloudServer_vpc_changeSpec(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckServerDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/ses/ses_cluster_data_source_test.go
+++ b/internal/service/ses/ses_cluster_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceNcloudSESCluster(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceSESClusterConfig(testClusterName, TF_TEST_SES_LOGIN_KEY, searchEngineVersionCode, region),

--- a/internal/service/ses/ses_cluster_test.go
+++ b/internal/service/ses/ses_cluster_test.go
@@ -26,7 +26,7 @@ func TestAccResourceNcloudSESCluster_basic(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSESClusterDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/ses/ses_clusters_data_source_test.go
+++ b/internal/service/ses/ses_clusters_data_source_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccDataSourceNcloudSESClusters(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceSESClustersConfig(),

--- a/internal/service/ses/ses_node_os_images_data_source_test.go
+++ b/internal/service/ses/ses_node_os_images_data_source_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceNcloudSESNodeOsImages(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSESNodeOsImagesConfig,
@@ -31,7 +31,7 @@ func TestAccDataSourceNcloudSESNodeOsImagesFilter(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSESNodeOsImagestWithFilterConfig(),

--- a/internal/service/ses/ses_node_products_data_source_test.go
+++ b/internal/service/ses/ses_node_products_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNcloudSESNodeProductCodes(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSESNodeProductConfig(testName, region),

--- a/internal/service/ses/ses_versions_data_source_test.go
+++ b/internal/service/ses/ses_versions_data_source_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceNcloudSESVersions(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSESVersionConfig,

--- a/internal/service/vpc/nat_gateway_data_source_test.go
+++ b/internal/service/vpc/nat_gateway_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNcloudNatGateway_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNatGatewayConfig(name),

--- a/internal/service/vpc/nat_gateway_test.go
+++ b/internal/service/vpc/nat_gateway_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNcloudNatGateway_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -61,7 +61,7 @@ func TestAccResourceNcloudNatGateway_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -83,7 +83,7 @@ func TestAccResourceNcloudNatGateway_onlyRequiredParam(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -112,7 +112,7 @@ func TestAccResourceNcloudNatGateway_updateName(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -133,7 +133,7 @@ func TestAccResourceNcloudNatGateway_description(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNatGatewayDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/vpc/network_acl_deny_allow_group_test.go
+++ b/internal/service/vpc/network_acl_deny_allow_group_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNcloudNetworkACLDenyAllowGroup_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLDenyAllowGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -52,7 +52,7 @@ func TestAccResourceNcloudNetworkACLDenyAllowGroup_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLDenyAllowGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -74,7 +74,7 @@ func TestAccResourceNcloudNetworkACLDenyAllowGroup_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLDenyAllowGroupDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -107,7 +107,7 @@ func TestAccResourceNcloudNetworkACLDenyAllowGroup_description(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLDenyAllowGroupDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/vpc/network_acl_deny_allow_groups_data_source_test.go
+++ b/internal/service/vpc/network_acl_deny_allow_groups_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNcloudNetworkACLDenyAllowGroups_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNetworkACLDenyAllowGroupsConfig(name),

--- a/internal/service/vpc/network_acl_rule_test.go
+++ b/internal/service/vpc/network_acl_rule_test.go
@@ -25,7 +25,7 @@ func TestAccResourceNcloudNetworkACLRule_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -48,7 +48,7 @@ func TestAccResourceNcloudNetworkACLRule_AssociatedSubnet(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -68,7 +68,7 @@ func TestAccResourceNcloudNetworkACLRule_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLRuleDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/vpc/network_acl_test.go
+++ b/internal/service/vpc/network_acl_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNcloudNetworkACL_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -51,7 +51,7 @@ func TestAccResourceNcloudNetworkACL_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -73,7 +73,7 @@ func TestAccResourceNcloudNetworkACL_onlyRequiredParam(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -101,7 +101,7 @@ func TestAccResourceNcloudNetworkACL_updateName(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -126,7 +126,7 @@ func TestAccResourceNcloudNetworkACL_description(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckNetworkACLDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/vpc/network_acls_data_source_test.go
+++ b/internal/service/vpc/network_acls_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceNcloudNetworkAclsBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNetworkAclsConfig(),
@@ -34,7 +34,7 @@ func TestAccDataSourceNcloudNetworkAclsBasic(t *testing.T) {
 func TestAccDataSourceNcloudNetworkAclsName(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNetworkAclsConfigName("default"),
@@ -50,7 +50,7 @@ func TestAccDataSourceNcloudNetworkAclsName(t *testing.T) {
 func TestAccDataSourceNcloudNetworkAclsVpcNo(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNetworkAclsConfigVpcNo(),

--- a/internal/service/vpc/route_table_association_test.go
+++ b/internal/service/vpc/route_table_association_test.go
@@ -26,7 +26,7 @@ func TestAccresourceNcloudRouteTableAssociation_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -55,7 +55,7 @@ func TestAccresourceNcloudRouteTableAssociation_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckRouteTableAssociationDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/vpc/route_table_data_source_test.go
+++ b/internal/service/vpc/route_table_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceNcloudRouteTable_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudRouteTableConfig(name),

--- a/internal/service/vpc/route_table_test.go
+++ b/internal/service/vpc/route_table_test.go
@@ -23,7 +23,7 @@ func TestAccResourceNcloudRouteTable_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -51,7 +51,7 @@ func TestAccResourceNcloudRouteTable_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -73,7 +73,7 @@ func TestAccResourceNcloudRouteTable_onlyRequiredParam(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -101,7 +101,7 @@ func TestAccResourceNcloudRouteTable_updateName(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -126,7 +126,7 @@ func TestAccResourceNcloudRouteTable_description(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/vpc/route_tables_data_source_test.go
+++ b/internal/service/vpc/route_tables_data_source_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccDataSourceNcloudRouteTablesBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudRouteTablesConfig(),
@@ -32,7 +32,7 @@ func TestAccDataSourceNcloudRouteTablesFilter(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudRouteTablesConfigFilter(name),
@@ -51,7 +51,7 @@ func TestAccDataSourceNcloudRouteTablesFilter(t *testing.T) {
 func TestAccDataSourceNcloudRouteTablesName(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudRouteTablesConfigName("test"),
@@ -68,7 +68,7 @@ func TestAccDataSourceNcloudRouteTablesVpcNo(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudRouteTablesConfigVpcNo(name),

--- a/internal/service/vpc/route_test.go
+++ b/internal/service/vpc/route_test.go
@@ -24,7 +24,7 @@ func TestAccresourceNcloudRoute_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -50,7 +50,7 @@ func TestAccresourceNcloudRoute_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckRouteDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/vpc/subnet_data_source_test.go
+++ b/internal/service/vpc/subnet_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNcloudSubnet(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSubnetConfig(name, cidr),

--- a/internal/service/vpc/subnet_test.go
+++ b/internal/service/vpc/subnet_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNcloudSubnet_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -55,7 +55,7 @@ func TestAccResourceNcloudSubnet_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -78,7 +78,7 @@ func TestAccResourceNcloudSubnet_updateName(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -105,7 +105,7 @@ func TestAccResourceNcloudSubnet_updateNetworkACL(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -130,7 +130,7 @@ func TestAccResourceNcloudSubnet_InvalidCIDR(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSubnetDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/vpc/subnets_data_source_test.go
+++ b/internal/service/vpc/subnets_data_source_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceNcloudSubnetsBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSubnetsConfig(),
@@ -27,7 +27,7 @@ func TestAccDataSourceNcloudSubnetsBasic(t *testing.T) {
 func TestAccDataSourceNcloudSubnetsName(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSubnetsConfigSubnet("10.2.1.0"),
@@ -42,7 +42,7 @@ func TestAccDataSourceNcloudSubnetsName(t *testing.T) {
 func TestAccDataSourceNcloudSubnetsVpcNo(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudSubnetsConfigVpcNo("502"),

--- a/internal/service/vpc/vpc_data_source_test.go
+++ b/internal/service/vpc/vpc_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceNcloudVpc(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudVpcConfig(name, cidr),

--- a/internal/service/vpc/vpc_peering_data_source_test.go
+++ b/internal/service/vpc/vpc_peering_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccDataSourceNcloudVpcPeering_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudVpcPeeringConfig(name),

--- a/internal/service/vpc/vpc_peering_test.go
+++ b/internal/service/vpc/vpc_peering_test.go
@@ -24,7 +24,7 @@ func TestAccResourceNcloudVpcPeering_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckVpcPeeringDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -54,7 +54,7 @@ func TestAccResourceNcloudVpcPeering_Peering(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckVpcPeeringDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -79,7 +79,7 @@ func TestAccResourceNcloudVpcPeering_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckVpcPeeringDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -101,8 +101,8 @@ func TestAccResourceNcloudVpcPeering_description(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckVpcPeeringDestroy,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceNcloudVpcPeeringConfigDescription(name, "foo"),

--- a/internal/service/vpc/vpc_test.go
+++ b/internal/service/vpc/vpc_test.go
@@ -26,7 +26,7 @@ func TestAccResourceNcloudVpc_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -55,7 +55,7 @@ func TestAccResourceNcloudVpc_disappears(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -79,7 +79,7 @@ func TestAccResourceNcloudVpc_updateName(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/internal/service/vpc/vpcs_data_source_test.go
+++ b/internal/service/vpc/vpcs_data_source_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceNcloudVpcsBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudVpcsConfig(),
@@ -27,7 +27,7 @@ func TestAccDataSourceNcloudVpcsBasic(t *testing.T) {
 func TestAccDataSourceNcloudVpcsName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudVpcsConfigName("test"),
@@ -42,7 +42,7 @@ func TestAccDataSourceNcloudVpcsName(t *testing.T) {
 func TestAccDataSourceNcloudVpcsVpcNo(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudVpcsConfigVpcNo("446"),

--- a/internal/zone/zone_test.go
+++ b/internal/zone/zone_test.go
@@ -26,7 +26,7 @@ func TestParseZoneNoParameterBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: zonesConfig,
@@ -49,7 +49,7 @@ func TestParseZoneNoParameterBasic(t *testing.T) {
 func TestParseZoneNoParameterInputNil(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: zonesConfig,
@@ -68,7 +68,7 @@ func TestParseZoneNoParameterInputNil(t *testing.T) {
 func TestParseZoneNoParameterInputUnknownZoneCode(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: `data "ncloud_zones" "zones" {}`,
@@ -92,7 +92,7 @@ func TestGetZoneNoByCodeBasic(t *testing.T) {
 	testZoneCode := "KR-2"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: zonesConfig,
@@ -112,7 +112,7 @@ func TestGetZoneNoByCodeInputUnknownZoneCode(t *testing.T) {
 	testZoneCode := "unknown-zone-code"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ClassicProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: zonesConfig,
@@ -132,7 +132,7 @@ func TestGetZoneByCodeBasic(t *testing.T) {
 	testZoneCode := "KR-2"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: zonesConfig,
@@ -152,7 +152,7 @@ func TestGetZoneByCodeInputUnknownZoneCode(t *testing.T) {
 	testZoneCode := "unknown-zone-code"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: zonesConfig,
@@ -171,7 +171,7 @@ func TestGetZoneByCodeInputUnknownZoneCode(t *testing.T) {
 func TestGetZonesBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: ProtoV5ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: zonesConfig,

--- a/main.go
+++ b/main.go
@@ -19,10 +19,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	var serveOpts []tf5server.ServeOpt
+	var serveOpts []tf6server.ServeOpt
 
 	if *debugFlag {
-		serveOpts = append(serveOpts, tf5server.WithManagedDebug())
+		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
 	}
 
 	err = tf6server.Serve(

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf6server"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/provider"
 )
 
@@ -13,7 +13,7 @@ func main() {
 	debugFlag := flag.Bool("debug", false, "Sset to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	serverFactory, _, err := provider.ProtoV5ProviderServerFactory(context.Background())
+	serverFactory, _, err := provider.ProtoV6ProviderServerFactory(context.Background())
 
 	if err != nil {
 		log.Fatal(err)
@@ -25,7 +25,7 @@ func main() {
 		serveOpts = append(serveOpts, tf5server.WithManagedDebug())
 	}
 
-	err = tf5server.Serve(
+	err = tf6server.Serve(
 		"registry.terraform.io/NaverCloudPlatform/ncloud",
 		serverFactory,
 		serveOpts...,

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf6server"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/provider"
 )
 


### PR DESCRIPTION
### Description
- Upgrade tfprotocol version 5 to 6
- Add ProtoV6ProviderFactories in acctest
- For using NestedAttribute interface

### References
- https://developer.hashicorp.com/terraform/plugin/mux/translating-protocol-version-5-to-6