### PR TITLE
chore: Drop provider binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ website/node_modules
 *.iml
 binary/
 test/
-
+terraform-provider-ncloud
 
 website/vendor
 


### PR DESCRIPTION
terraform provider binary accidentally included in the git since https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/365. Let's drop it