### PR TITLE
chore: Fix golang linter warnings (golangci-lint)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,9 @@
+issues:
+  exclude-rules:
+    - linters:
+      - staticcheck
+      text: "SA1019:"
+    - linters:
+      - errcheck
+      text: "Error return value of `d.Set` is not checked"
+

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -87,16 +87,6 @@ func LogCommonResponse(tag string, commonResponse *CommonResponse, logs ...strin
 	log.Printf("[INFO] %s success response=%s %s", tag, result, strings.Join(logs, " "))
 }
 
-func isRetryableErr(commResp *CommonResponse, code []string) bool {
-	for _, c := range code {
-		if commResp != nil && commResp.ReturnCode != nil && ncloud.StringValue(commResp.ReturnCode) == c {
-			return true
-		}
-	}
-
-	return false
-}
-
 func ContainsInStringList(str string, s []string) bool {
 	for _, v := range s {
 		if v == str {

--- a/internal/common/convert_types.go
+++ b/internal/common/convert_types.go
@@ -150,9 +150,9 @@ func StringListPtrOrNil(i interface{}, ok bool) []*string {
 	il := i.([]interface{})
 	vs := make([]*string, 0, len(il))
 	for _, v := range il {
-		switch v.(type) {
+		switch v := v.(type) {
 		case *string:
-			vs = append(vs, v.(*string))
+			vs = append(vs, v)
 		default:
 			// TODO: if the value is "" in list, occur crash error.
 			vs = append(vs, ncloud.String(v.(string)))
@@ -198,7 +198,7 @@ func ConvertToMap(i interface{}) map[string]interface{} {
 		return nil
 	}
 	var m map[string]interface{}
-	json.Unmarshal(b, &m)
+	_ = json.Unmarshal(b, &m)
 
 	return m
 }
@@ -214,7 +214,7 @@ func ConvertToArrayMap(i interface{}) []map[string]interface{} {
 		return nil
 	}
 	var m []map[string]interface{}
-	json.Unmarshal(b, &m)
+	_ = json.Unmarshal(b, &m)
 
 	return m
 }

--- a/internal/common/data_source.go
+++ b/internal/common/data_source.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 )
@@ -23,7 +22,7 @@ func DataResourceIdHash(ids []string) string {
 func WriteToFile(filePath string, data interface{}) error {
 	log.Printf("[INFO] WriteToFile FilePath: %s", filePath)
 
-	if err := os.Remove(filePath); err != nil && os.IsNotExist(err) != true {
+	if err := os.Remove(filePath); err != nil && os.IsExist(err) {
 		return err
 	}
 
@@ -32,5 +31,5 @@ func WriteToFile(filePath string, data interface{}) error {
 		return err
 	}
 	str := string(bs)
-	return ioutil.WriteFile(filePath, []byte(str), 777)
+	return os.WriteFile(filePath, []byte(str), 0777)
 }

--- a/internal/common/filters.go
+++ b/internal/common/filters.go
@@ -77,7 +77,6 @@ func ApplyFilters(filters *schema.Set, items []map[string]interface{}, resourceS
 		var pathElements []string
 		var err error
 		if pathElements, err = getFieldPathElements(resourceSchema, keyword); err != nil {
-			log.Printf(err.Error())
 			pathElements = []string{keyword}
 		}
 
@@ -191,7 +190,7 @@ func isValidSchemaType(fieldSchema *schema.Schema) bool {
 
 func getValueFromPath(item map[string]interface{}, path []string) (targetVal interface{}, targetValOk bool) {
 	workingMap := item
-	tempWorkingMap := item
+	var tempWorkingMap map[string]interface{}
 	var conversionOk bool
 	for _, pathElement := range path[:len(path)-1] {
 		// Defensive check for non existent values

--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -152,7 +152,7 @@ func SetSingularResourceDataFromMapSchema(resourceSchema *schema.Resource, d *sc
 		}
 	}
 
-	for k, _ := range resources {
+	for k := range resources {
 		if k == "id" {
 			continue
 		}

--- a/internal/common/structures.go
+++ b/internal/common/structures.go
@@ -13,9 +13,9 @@ import (
 func ExpandStringInterfaceList(i []interface{}) []*string {
 	vs := make([]*string, 0, len(i))
 	for _, v := range i {
-		switch v.(type) {
+		switch v := v.(type) {
 		case *string:
-			vs = append(vs, v.(*string))
+			vs = append(vs, v)
 		default:
 			vs = append(vs, ncloud.String(v.(string)))
 		}

--- a/internal/conn/region.go
+++ b/internal/conn/region.go
@@ -39,27 +39,6 @@ func ParseRegionNoParameter(d *schema.ResourceData) (*string, error) {
 	return nil, nil
 }
 
-func parseRegionCodeParameter(client *NcloudAPIClient, d *schema.ResourceData) (*string, error) {
-	if regionCode, regionCodeOk := d.GetOk("region"); regionCodeOk {
-		region, err := GetRegionByCode(client, regionCode.(string))
-		if region == nil || err != nil {
-			return nil, fmt.Errorf("no region data for region_code `%s`. please change region_code and try again", regionCode.(string))
-		}
-		return region.RegionCode, nil
-	}
-
-	// provider region
-	if regionCode := os.Getenv("NCLOUD_REGION"); regionCode != "" {
-		region, err := GetRegionByCode(client, regionCode)
-		if region == nil || err != nil {
-			return nil, fmt.Errorf("no region data for region_code `%s`. please change region_code and try again", regionCode)
-		}
-		return region.RegionCode, nil
-	}
-
-	return nil, nil
-}
-
 func GetRegionNoByCode(code string) *string {
 	if region, ok := regionCacheByCode[code]; ok {
 		return region.RegionNo

--- a/internal/region/regions_data_source.go
+++ b/internal/region/regions_data_source.go
@@ -42,7 +42,7 @@ func dataSourceNcloudRegionsRead(d *schema.ResourceData, meta interface{}) error
 	var regions []*conn.Region
 	var err error
 
-	if meta.(*conn.ProviderConfig).SupportVPC == true {
+	if meta.(*conn.ProviderConfig).SupportVPC {
 		regions, err = getVpcRegions(d, meta.(*conn.ProviderConfig))
 	} else {
 		regions, err = getClassicRegions(d, meta.(*conn.ProviderConfig))

--- a/internal/service/autoscaling/auto_scaling_adjustment_types_data_source.go
+++ b/internal/service/autoscaling/auto_scaling_adjustment_types_data_source.go
@@ -60,7 +60,7 @@ func getAutoScalingAdjustmentListFiltered(d *schema.ResourceData, config *conn.P
 	var resources []map[string]interface{}
 	var err error
 
-	if config.SupportVPC == true {
+	if config.SupportVPC {
 		resources, err = getVpcAutoScalingAdjustmentTypeList(config)
 	} else {
 		resources, err = getClassicAutoScalingAdjustmentTypeList(config)

--- a/internal/service/autoscaling/auto_scaling_group.go
+++ b/internal/service/autoscaling/auto_scaling_group.go
@@ -752,6 +752,10 @@ func waitForAutoScalingGroupCapacity(d *schema.ResourceData, config *conn.Provid
 func waitForVpcAutoScalingGroupCapacity(d *schema.ResourceData, config *conn.ProviderConfig, wait time.Duration) error {
 	return resource.Retry(wait, func() *resource.RetryError {
 		asg, err := getVpcAutoScalingGroup(config, d.Id())
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
 		asgServerInstanceList, err := getVpcInAutoScalingGroupServerInstanceList(config, d.Id())
 		if err != nil {
 			return resource.NonRetryableError(err)
@@ -785,6 +789,10 @@ func waitForVpcAutoScalingGroupCapacity(d *schema.ResourceData, config *conn.Pro
 func waitForClassicAutoScalingGroupCapacity(d *schema.ResourceData, config *conn.ProviderConfig, wait time.Duration) error {
 	return resource.Retry(wait, func() *resource.RetryError {
 		asg, err := getClassicAutoScalingGroup(config, d.Id())
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
 		asgServerInstanceList, err := getClassicInAutoScalingGroupServerInstanceList(config, d.Id())
 		if err != nil {
 			return resource.NonRetryableError(err)

--- a/internal/service/autoscaling/auto_scaling_group_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_group_data_source_test.go
@@ -1,7 +1,6 @@
 package autoscaling_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -76,7 +75,7 @@ func TestAccDataSourceNcloudAutoScalingGroup_vpc_basic(t *testing.T) {
 }
 
 func testAccDataSourceNcloudAutoScalingGroupClassicConfig() string {
-	return fmt.Sprintf(`
+	return `
 	resource "ncloud_launch_configuration" "lc" {
 		server_image_product_code = "SPSW0LINUX000046"
 	}
@@ -91,11 +90,11 @@ func testAccDataSourceNcloudAutoScalingGroupClassicConfig() string {
 	data "ncloud_auto_scaling_group" "auto" {
 		id = ncloud_auto_scaling_group.auto.auto_scaling_group_no
 	}
-`)
+`
 }
 
 func testAccDataSourceNcloudAutoScalingGroupVpcConfig() string {
-	return fmt.Sprintf(`
+	return `
 resource "ncloud_vpc" "test" {
 	ipv4_cidr_block    = "10.0.0.0/16"
 }
@@ -124,5 +123,5 @@ resource "ncloud_auto_scaling_group" "auto" {
 data "ncloud_auto_scaling_group" "auto" {
 	id = ncloud_auto_scaling_group.auto.auto_scaling_group_no
 }
-`)
+`
 }

--- a/internal/service/autoscaling/auto_scaling_policy_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_policy_data_source_test.go
@@ -61,21 +61,21 @@ func TestAccDataSourceNcloudAutoScalingPolicy_vpc_basic(t *testing.T) {
 }
 
 func testAccDataSourceNcloudAutoScalingPolicyClassicConfig(name string) string {
-	return testAccNcloudAutoScalingPolicyClassicConfig(name) + fmt.Sprintf(`
+	return testAccNcloudAutoScalingPolicyClassicConfig(name) + `
 data "ncloud_auto_scaling_policy" "policy" {
 	id = ncloud_auto_scaling_policy.test-policy-CHANG.name
 	auto_scaling_group_no = ncloud_auto_scaling_group.test.auto_scaling_group_no
 	depends_on = [ncloud_auto_scaling_policy.test-policy-CHANG]
 }
-`)
+`
 }
 
 func testAccDataSourceNcloudAutoScalingPolicyVpcConfig(name string) string {
-	return testAccNcloudAutoScalingPolicyVpcConfig(name) + fmt.Sprintf(`
+	return testAccNcloudAutoScalingPolicyVpcConfig(name) + `
 data "ncloud_auto_scaling_policy" "policy" {
 	id = ncloud_auto_scaling_policy.test-policy-CHANG.name
 	auto_scaling_group_no = ncloud_auto_scaling_group.test.auto_scaling_group_no
 	depends_on = [ncloud_auto_scaling_policy.test-policy-CHANG]
 }
-`)
+`
 }

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -332,7 +332,7 @@ func GetClassicLaunchConfigurationByNo(no *string, config *conn.ProviderConfig) 
 }
 
 type LaunchConfiguration struct {
-	LaunchConfigurationNo       *string   `json:"launch_configuration_no,omitempty,omitempty"`
+	LaunchConfigurationNo       *string   `json:"launch_configuration_no,omitempty"`
 	LaunchConfigurationName     *string   `json:"name,omitempty"`
 	ServerImageProductCode      *string   `json:"server_image_product_code,omitempty"`
 	MemberServerImageInstanceNo *string   `json:"member_server_image_no,omitempty"`

--- a/internal/service/autoscaling/launch_configuration_data_source_test.go
+++ b/internal/service/autoscaling/launch_configuration_data_source_test.go
@@ -1,7 +1,6 @@
 package autoscaling_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -64,7 +63,7 @@ func TestAccDataSourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
 }
 
 func testAccDataSourceNcloudLaunchConfigurationClassicConfig() string {
-	return fmt.Sprintf(`
+	return `
 resource "ncloud_launch_configuration" "lc" {
 	server_image_product_code = "SPSW0LINUX000046"
 }
@@ -72,11 +71,11 @@ resource "ncloud_launch_configuration" "lc" {
 data "ncloud_launch_configuration" "lc" {
 	id = ncloud_launch_configuration.lc.launch_configuration_no
 }
-`)
+`
 }
 
 func testAccDataSourceNcloudLaunchConfigurationVpcConfig() string {
-	return fmt.Sprintf(`
+	return `
 resource "ncloud_launch_configuration" "lc" {
 	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
 }
@@ -84,5 +83,5 @@ resource "ncloud_launch_configuration" "lc" {
 data "ncloud_launch_configuration" "lc" {
 	id = ncloud_launch_configuration.lc.launch_configuration_no
 }
-`)
+`
 }

--- a/internal/service/classicloadbalancer/list.go
+++ b/internal/service/classicloadbalancer/list.go
@@ -3,7 +3,6 @@ package classicloadbalancer
 import (
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/loadbalancer"
-	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
 )
 
 func expandLoadBalancerRuleParams(list []interface{}) ([]*loadbalancer.LoadBalancerRuleParameter, error) {
@@ -60,23 +59,4 @@ func flattenLoadBalancedServerInstanceList(loadBalancedServerInstanceList []*loa
 	}
 
 	return list
-}
-
-func expandTagListParams(tl []interface{}) ([]*server.InstanceTagParameter, error) {
-	tagList := make([]*server.InstanceTagParameter, 0, len(tl))
-
-	for _, v := range tl {
-		tag := new(server.InstanceTagParameter)
-		for key, value := range v.(map[string]interface{}) {
-			switch key {
-			case "tag_key":
-				tag.TagKey = ncloud.String(value.(string))
-			case "tag_value":
-				tag.TagValue = ncloud.String(value.(string))
-			}
-		}
-		tagList = append(tagList, tag)
-	}
-
-	return tagList, nil
 }

--- a/internal/service/devtools/sourcedeploy_project_stages_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stages_data_source_test.go
@@ -1,7 +1,6 @@
 package devtools_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -25,7 +24,7 @@ func TestAccDataSourceNcloudSourceDeployStages(t *testing.T) {
 }
 
 func testAccDataSourceNcloudSourceDeployStagesConfig() string {
-	return fmt.Sprintf(`
+	return `
 resource "ncloud_sourcedeploy_project" "sd_project" {
 	name = "tf-test-project"
 }
@@ -33,5 +32,5 @@ resource "ncloud_sourcedeploy_project" "sd_project" {
 data "ncloud_sourcedeploy_project_stages" stages{
 	project_id = ncloud_sourcedeploy_project.sd_project.id
 }
-`)
+`
 }

--- a/internal/service/devtools/sourcedeploy_projects_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_projects_data_source_test.go
@@ -1,7 +1,6 @@
 package devtools_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -25,8 +24,8 @@ func TestAccDataSourceNcloudSourceDeployProjects(t *testing.T) {
 }
 
 func testAccDataSourceNcloudSourceDeployProjectsConfig() string {
-	return fmt.Sprintf(`
+	return `
 data "ncloud_sourcedeploy_projects" "projects" {
 }
-`)
+`
 }

--- a/internal/service/devtools/sourcepipeline_project.go
+++ b/internal/service/devtools/sourcepipeline_project.go
@@ -774,7 +774,7 @@ func checkVpcDeployTaskConfig(taskConfig *PipelineTaskConfig, deployTarget *vsou
 		return diag.Diagnostic{
 			Severity: diag.Warning,
 			Summary:  "Deploy target configuration have changed in SourceDeploy Project.",
-			Detail:   fmt.Sprintf("Linked manifest file has changed from %s to %s. Please check.", *taskConfig.Target.Info.FullManifest, strings.Join(ncloud.StringListValue(*&deployTarget.Config.Manifest.Path), " / ")),
+			Detail:   fmt.Sprintf("Linked manifest file has changed from %s to %s. Please check.", *taskConfig.Target.Info.FullManifest, strings.Join(ncloud.StringListValue(deployTarget.Config.Manifest.Path), " / ")),
 		}
 	}
 	return diag.Diagnostic{}

--- a/internal/service/devtools/sourcepipeline_projects_data_source_test.go
+++ b/internal/service/devtools/sourcepipeline_projects_data_source_test.go
@@ -1,7 +1,6 @@
 package devtools_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -39,8 +38,8 @@ func TestAccDataSourceNcloudSourcePipelineProjects_vpc_basic(t *testing.T) {
 }
 
 func testAccDataSourceNcloudSourcePipelineProjectsConfig() string {
-	return fmt.Sprintf(`
+	return `
 data "ncloud_sourcepipeline_projects" "projects" {
 }
-`)
+`
 }

--- a/internal/service/devtools/sourcepipeline_trigger_timezone_data_source_test.go
+++ b/internal/service/devtools/sourcepipeline_trigger_timezone_data_source_test.go
@@ -1,7 +1,6 @@
 package devtools_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -39,8 +38,8 @@ func TestAccDataSourceNcloudSourcePipelineTriggerTimeZone_vpc_basic(t *testing.T
 }
 
 func testAccDataSourceNcloudSourcePipelineTriggerTimeZoneConfig() string {
-	return fmt.Sprintf(`
+	return `
 data "ncloud_sourcepipeline_trigger_timezone" "time_zone" {
 }
-`)
+`
 }

--- a/internal/service/loadbalancer/lb_data_source_test.go
+++ b/internal/service/loadbalancer/lb_data_source_test.go
@@ -37,9 +37,9 @@ func TestAccDataSourceNcloudLb_basic(t *testing.T) {
 }
 
 func testAccDataSourceNcloudLbConfig(name string) string {
-	return testAccResourceNcloudLbConfig(name) + fmt.Sprintf(`
+	return testAccResourceNcloudLbConfig(name) + `
 data "ncloud_lb" "test" {
 	id = ncloud_lb.test.load_balancer_no
 }
-`)
+`
 }

--- a/internal/service/loadbalancer/lb_listener_data_source_test.go
+++ b/internal/service/loadbalancer/lb_listener_data_source_test.go
@@ -33,10 +33,10 @@ func TestAccDataSourceNcloudLbListener_basic(t *testing.T) {
 }
 
 func testAccDataSourceNcloudLbListenerConfig(name string) string {
-	return testAccResourceNcloudLbListenerConfig(name) + fmt.Sprintf(`
+	return testAccResourceNcloudLbListenerConfig(name) + `
 data "ncloud_lb_listener" "test" {
 	id = ncloud_lb_listener.test.listener_no
 	load_balancer_no = ncloud_lb.test.load_balancer_no
 }
-`)
+`
 }

--- a/internal/service/loadbalancer/lb_listener_test.go
+++ b/internal/service/loadbalancer/lb_listener_test.go
@@ -87,12 +87,12 @@ func testAccCheckLbListenerDestroy(s *terraform.State, provider *schema.Provider
 }
 
 func testAccResourceNcloudLbListenerConfig(lbName string) string {
-	return testAccResourceNcloudLbConfig(lbName) + fmt.Sprintf(`
+	return testAccResourceNcloudLbConfig(lbName) + `
 resource "ncloud_lb_listener" "test" {
     load_balancer_no = ncloud_lb.test.load_balancer_no
     protocol = "HTTP"
     port = 8080
     target_group_no = ncloud_lb_target_group.test.target_group_no
 }
-`)
+`
 }

--- a/internal/service/loadbalancer/lb_target_group_attachment.go
+++ b/internal/service/loadbalancer/lb_target_group_attachment.go
@@ -119,7 +119,7 @@ func resourceNcloudLbTargetGroupAttachmentUpdate(ctx context.Context, d *schema.
 		removeTargetNoList := make([]string, 0)
 		addTargetNoList := make([]string, 0)
 
-		for key, _ := range newTargetNoMap {
+		for key := range newTargetNoMap {
 			if oldTargetNoMap[key] {
 				delete(oldTargetNoMap, key)
 			} else {
@@ -127,7 +127,7 @@ func resourceNcloudLbTargetGroupAttachmentUpdate(ctx context.Context, d *schema.
 			}
 		}
 
-		for key, _ := range oldTargetNoMap {
+		for key := range oldTargetNoMap {
 			removeTargetNoList = append(removeTargetNoList, key)
 		}
 

--- a/internal/service/loadbalancer/lb_target_group_data_source_test.go
+++ b/internal/service/loadbalancer/lb_target_group_data_source_test.go
@@ -39,9 +39,9 @@ func TestAccDataSourceNcloudLbTargetGroup_basic(t *testing.T) {
 }
 
 func testAccDataSourceNcloudLbTargetGroupConfig(name string) string {
-	return testAccResourceNcloudLbTargetGroupConfig(name) + fmt.Sprintf(`
+	return testAccResourceNcloudLbTargetGroupConfig(name) + `
 data "ncloud_lb_target_group" "test" {
 	id = ncloud_lb_target_group.test.target_group_no
 }
-`)
+`
 }

--- a/internal/service/loadbalancer/lb_target_group_test.go
+++ b/internal/service/loadbalancer/lb_target_group_test.go
@@ -175,7 +175,7 @@ resource "ncloud_lb_target_group" "test" {
 }
 
 func testAccResourceNcloudLbTargetGroupEmptyTargetGroupNameConfig() string {
-	return fmt.Sprintf(`
+	return `
 resource "ncloud_vpc" "test" {
 	ipv4_cidr_block    = "10.0.0.0/16"
 }
@@ -209,5 +209,5 @@ resource "ncloud_lb_target_group" "test" {
   algorithm_type = "RR"
   use_sticky_session = true
 }
-`)
+`
 }

--- a/internal/service/memberserverimage/member_server_images_data_source.go
+++ b/internal/service/memberserverimage/member_server_images_data_source.go
@@ -92,7 +92,7 @@ func memberServerImagesAttributes(d *schema.ResourceData, memberServerImages []m
 	}
 
 	d.SetId(DataResourceIdHash(ids))
-	d.Set("member_server_images", ids)
+	_ = d.Set("member_server_images", ids)
 
 	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
 		return WriteToFile(output.(string), d.Get("member_server_images"))

--- a/internal/service/nks/nks_cluster.go
+++ b/internal/service/nks/nks_cluster.go
@@ -613,7 +613,7 @@ func getSubnetDiff(oldList interface{}, newList interface{}) (added []*int32, re
 		newMap[*v] += 1
 	}
 
-	for subnet, _ := range oldMap {
+	for subnet := range oldMap {
 		if _, exist := newMap[subnet]; !exist {
 			intV, err := strconv.Atoi(subnet)
 			if err == nil {
@@ -622,7 +622,7 @@ func getSubnetDiff(oldList interface{}, newList interface{}) (added []*int32, re
 		}
 	}
 
-	for subnet, _ := range newMap {
+	for subnet := range newMap {
 		if _, exist := oldMap[subnet]; !exist {
 			intV, err := strconv.Atoi(subnet)
 			if err == nil {

--- a/internal/service/nks/nks_node_pool.go
+++ b/internal/service/nks/nks_node_pool.go
@@ -227,6 +227,9 @@ func resourceNcloudNKSNodePoolRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	clusterUuid, nodePoolName, err := NodePoolParseResourceID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	nodePool, err := GetNKSNodePool(ctx, config, clusterUuid, nodePoolName)
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/service/nks/nks_server_images_data_source_test.go
+++ b/internal/service/nks/nks_server_images_data_source_test.go
@@ -1,7 +1,6 @@
 package nks_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -49,12 +48,12 @@ data "ncloud_nks_server_images" "images" {}
 `
 
 func testAccDataSourceNcloudNKSServerImagestWithFilterConfig() string {
-	return fmt.Sprintf(`
+	return `
 data "ncloud_nks_server_images" "filter"{
   filter {
     name = "label"
     values = ["ubuntu-20.04-64-server"]
   }
 }
-`)
+`
 }

--- a/internal/service/server/access_control_rule_data_source.go
+++ b/internal/service/server/access_control_rule_data_source.go
@@ -117,9 +117,7 @@ func dataSourceNcloudAccessControlRuleRead(d *schema.ResourceData, meta interfac
 			if err != nil {
 				return err
 			}
-			for _, rule := range resp.AccessControlRuleList {
-				allAccessControlRuleList = append(allAccessControlRuleList, rule)
-			}
+			allAccessControlRuleList = append(allAccessControlRuleList, resp.AccessControlRuleList...)
 		}
 	} else {
 		groupConfigNo := configNo.(string)
@@ -127,9 +125,7 @@ func dataSourceNcloudAccessControlRuleRead(d *schema.ResourceData, meta interfac
 		if err != nil {
 			return err
 		}
-		for _, rule := range resp.AccessControlRuleList {
-			allAccessControlRuleList = append(allAccessControlRuleList, rule)
-		}
+		allAccessControlRuleList = append(allAccessControlRuleList, resp.AccessControlRuleList...)
 	}
 
 	var filteredAccessControlRuleList []*server.AccessControlRule

--- a/internal/service/server/access_control_rules_data_source_test.go
+++ b/internal/service/server/access_control_rules_data_source_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 // ignore test : should use real access_control_group_configuration_no
+//
+//nolint:unused
 func testAccDataSourceNcloudAccessControlRulesBasic(t *testing.T) {
 	testId := os.Getenv("TEST_ID")
 	if testId == "" {
@@ -33,6 +35,7 @@ func testAccDataSourceNcloudAccessControlRulesBasic(t *testing.T) {
 	})
 }
 
+//nolint:unused
 func testAccDataSourceNcloudAccessControlRulesConfig(testConfigNo string) string {
 	return fmt.Sprintf(`
 data "ncloud_access_control_rules" "test" {

--- a/internal/service/server/block_storage_snapshot_test.go
+++ b/internal/service/server/block_storage_snapshot_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 // TODO: Fix TestAcc ErrorTestAccResourceNcloudBlockStorageBasic
+//
+//nolint:unused
 func ignore_TestAccResourceNcloudBlockStorageSnapshotBasic(t *testing.T) {
 	var snapshotInstance server.BlockStorageSnapshotInstance
 	prefix := GetTestPrefix()
@@ -59,10 +61,12 @@ func ignore_TestAccResourceNcloudBlockStorageSnapshotBasic(t *testing.T) {
 	})
 }
 
+//nolint:unused
 func testAccCheckBlockStorageSnapshotExists(n string, i *server.BlockStorageSnapshotInstance) resource.TestCheckFunc {
 	return testAccCheckBlockStorageSnapshotExistsWithProvider(n, i, func() *schema.Provider { return GetTestProvider(false) })
 }
 
+//nolint:unused
 func testAccCheckBlockStorageSnapshotExistsWithProvider(n string, i *server.BlockStorageSnapshotInstance, providerF func() *schema.Provider) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -92,10 +96,12 @@ func testAccCheckBlockStorageSnapshotExistsWithProvider(n string, i *server.Bloc
 	}
 }
 
+//nolint:unused
 func testAccCheckBlockStorageSnapshotDestroy(s *terraform.State) error {
 	return testAccCheckBlockStorageSnapshotDestroyWithProvider(s, GetTestProvider(false))
 }
 
+//nolint:unused
 func testAccCheckBlockStorageSnapshotDestroyWithProvider(s *terraform.State, provider *schema.Provider) error {
 	client := provider.Meta().(*conn.ProviderConfig).Client
 
@@ -122,6 +128,7 @@ func testAccCheckBlockStorageSnapshotDestroyWithProvider(s *terraform.State, pro
 	return nil
 }
 
+//nolint:unused
 func testAccBlockStorageSnapshotConfig(testLoginKeyName string, serverInstanceName string, blockStorageName string, snapshotName string) string {
 	return fmt.Sprintf(`
 resource "ncloud_login_key" "key" {

--- a/internal/service/server/block_storage_test.go
+++ b/internal/service/server/block_storage_test.go
@@ -321,7 +321,6 @@ func testAccBlockStorageClassicConfig(name string) string {
 }
 
 func testAccBlockStorageVpcConfigWithSize(name string, size int) string {
-	fmt.Printf(name)
 	return fmt.Sprintf(`
 resource "ncloud_login_key" "loginkey" {
 	key_name = "%[1]s-key"

--- a/internal/service/server/network_interface.go
+++ b/internal/service/server/network_interface.go
@@ -376,7 +376,7 @@ func attachNetworkInterface(d *schema.ResourceData, config *conn.ProviderConfig)
 		return err
 	}
 
-	waitForPublicIpDisassociate(d, config)
+	_ = waitForPublicIpDisassociate(d, config)
 
 	return nil
 }

--- a/internal/service/server/network_interfaces_data_source.go
+++ b/internal/service/server/network_interfaces_data_source.go
@@ -51,7 +51,7 @@ func dataSourceNcloudNetworkInterfacesRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	if resources == nil || len(resources) == 0 {
+	if len(resources) == 0 {
 		return errors.New("no matching Network Interfaces found")
 	}
 

--- a/internal/service/server/port_forwarding_rule.go
+++ b/internal/service/server/port_forwarding_rule.go
@@ -93,6 +93,10 @@ func resourceNcloudPortForwardingRuleCreate(d *schema.ResourceData, meta interfa
 
 	serverInstanceNo := d.Get("server_instance_no").(string)
 	zoneNo, err := getServerZoneNo(config, serverInstanceNo)
+	if err != nil {
+		return err
+	}
+
 	newPortForwardingRuleId := PortForwardingRuleId(portForwardingConfigurationNo, zoneNo, portForwardingExternalPort)
 	log.Printf("[DEBUG] AddPortForwardingRules newPortForwardingRuleId: %s", newPortForwardingRuleId)
 

--- a/internal/service/server/port_forwarding_rule_test.go
+++ b/internal/service/server/port_forwarding_rule_test.go
@@ -54,6 +54,8 @@ func generateExternalPort(min, max int32) int32 {
 }
 
 // TODO: ignore test: may be empty created data
+//
+//nolint:unused
 func ignore_TestAccResourceNcloudPortForwardingRuleExistingServer(t *testing.T) {
 	var portForwarding server.PortForwardingRule
 
@@ -168,6 +170,7 @@ resource "ncloud_port_forwarding_rule" "test" {
 }`, testServerName, testServerName, externalPort)
 }
 
+//nolint:unused
 func testAccPortForwardingRuleExistingServerConfig(externalPort int) string {
 	return fmt.Sprintf(`
 resource "ncloud_port_forwarding_rule" "test" {

--- a/internal/service/server/public_ip.go
+++ b/internal/service/server/public_ip.go
@@ -585,8 +585,8 @@ func resourceNcloudPublicIpCustomizeDiff(_ context.Context, diff *schema.Resourc
 
 	if config.SupportVPC {
 		if v, ok := diff.GetOk("zone"); ok {
-			diff.Clear("zone")
-			return fmt.Errorf("You don't use 'zone' if SupportVPC is true. Please remove this value [%s]", v)
+			_ = diff.Clear("zone")
+			return fmt.Errorf("you don't use 'zone' if SupportVPC is true. Please remove this value [%s]", v)
 		}
 	}
 	return nil

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -287,7 +287,7 @@ func resourceNcloudServerRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if config.SupportVPC {
-		buildNetworkInterfaceList(config, r)
+		_ = buildNetworkInterfaceList(config, r)
 	}
 
 	instance := ConvertToMap(r)

--- a/internal/service/server/server_image_data_source.go
+++ b/internal/service/server/server_image_data_source.go
@@ -102,7 +102,7 @@ func getServerImageProductListFiltered(d *schema.ResourceData, config *conn.Prov
 	var resources []map[string]interface{}
 	var err error
 
-	if config.SupportVPC == true {
+	if config.SupportVPC {
 		resources, err = getVpcServerImageProductList(d, config)
 	} else {
 		resources, err = getClassicServerImageProductList(d, config)

--- a/internal/service/server/server_product_data_source.go
+++ b/internal/service/server/server_product_data_source.go
@@ -115,7 +115,7 @@ func getServerProductListFiltered(d *schema.ResourceData, config *conn.ProviderC
 	var resources []map[string]interface{}
 	var err error
 
-	if config.SupportVPC == true {
+	if config.SupportVPC {
 		resources, err = getVpcServerProductList(d, config)
 	} else {
 		resources, err = getClassicServerProductList(d, config)

--- a/internal/service/server/server_products_data_source.go
+++ b/internal/service/server/server_products_data_source.go
@@ -72,7 +72,7 @@ func dataSourceNcloudServerProductsRead(d *schema.ResourceData, meta interface{}
 	var resources []map[string]interface{}
 	var err error
 
-	if meta.(*conn.ProviderConfig).SupportVPC == true {
+	if meta.(*conn.ProviderConfig).SupportVPC {
 		resources, err = getVpcServerProductList(d, meta.(*conn.ProviderConfig))
 	} else {
 		resources, err = getClassicServerProductList(d, meta.(*conn.ProviderConfig))

--- a/internal/service/ses/ses_node_os_images_data_source_test.go
+++ b/internal/service/ses/ses_node_os_images_data_source_test.go
@@ -1,7 +1,6 @@
 package ses_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -49,12 +48,12 @@ data "ncloud_ses_node_os_images" "images" {}
 `
 
 func testAccDataSourceNcloudSESNodeOsImagestWithFilterConfig() string {
-	return fmt.Sprintf(`
+	return `
 data "ncloud_ses_node_os_images" "filter" {
 	filter {
 		name = "id"
 		values = ["SW.VELST.OS.LNX64.CNTOS.0708.B050"]
 	}
 }
-`)
+`
 }

--- a/internal/service/vpc/nat_gateway_test.go
+++ b/internal/service/vpc/nat_gateway_test.go
@@ -205,22 +205,6 @@ resource "ncloud_nat_gateway" "nat_gateway_private" {
 `, name, description)
 }
 
-func testAccResourceNcloudNatGatewayConfigUpdate(name, updateName string) string {
-	return fmt.Sprintf(`
-resource "ncloud_vpc" "vpc" {
-	name            = "%s"
-	ipv4_cidr_block = "10.3.0.0/16"
-}
-
-resource "ncloud_nat_gateway" "nat_gateway" {
-  vpc_no      = ncloud_vpc.vpc.vpc_no
-  zone        = "KR-1"
-  name        = "%s"
-  description = "description"
-}
-`, name, updateName)
-}
-
 func testAccResourceNcloudNatGatewayConfigOnlyRequiredParam(name string) string {
 	return fmt.Sprintf(`
 resource "ncloud_vpc" "vpc" {

--- a/internal/service/vpc/network_acl_rule.go
+++ b/internal/service/vpc/network_acl_rule.go
@@ -213,7 +213,7 @@ func resourceNcloudNetworkACLRuleDelete(d *schema.ResourceData, meta interface{}
 	i := d.Get("inbound").(*schema.Set)
 	o := d.Get("outbound").(*schema.Set)
 
-	waitForNcloudNetworkACLRunning(config, d.Id())
+	_ = waitForNcloudNetworkACLRunning(config, d.Id())
 
 	if len(i.List()) > 0 {
 		if err := removeNetworkACLRule(d, config, "inbound", expandRemoveNetworkAclRule(i.List())); err != nil {
@@ -244,7 +244,7 @@ func waitForNcloudNetworkACLRunning(config *conn.ProviderConfig, id string) erro
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for Network ACL (%s) to become termintaing: %s", id, err)
+		return fmt.Errorf("error waiting for Network ACL (%s) to become termintaing: %s", id, err)
 	}
 
 	return nil

--- a/internal/service/vpc/route_tables_data_source_test.go
+++ b/internal/service/vpc/route_tables_data_source_test.go
@@ -81,9 +81,9 @@ func TestAccDataSourceNcloudRouteTablesVpcNo(t *testing.T) {
 }
 
 func testAccDataSourceNcloudRouteTablesConfig() string {
-	return fmt.Sprintf(`
+	return `
 data "ncloud_route_tables" "all" {}
-`)
+`
 }
 
 func testAccDataSourceNcloudRouteTablesConfigFilter(name string) string {

--- a/internal/service/vpc/vpcs_data_source_test.go
+++ b/internal/service/vpc/vpcs_data_source_test.go
@@ -56,9 +56,9 @@ func TestAccDataSourceNcloudVpcsVpcNo(t *testing.T) {
 }
 
 func testAccDataSourceNcloudVpcsConfig() string {
-	return fmt.Sprintf(`
+	return `
 data "ncloud_vpcs" "all" {}
-`)
+`
 }
 
 func testAccDataSourceNcloudVpcsConfigName(name string) string {

--- a/internal/service/vpc/waiter_state.go
+++ b/internal/service/vpc/waiter_state.go
@@ -21,7 +21,9 @@ func VpcCommonStateRefreshFunc(instance interface{}, err error, statusName strin
 		return nil, "", err
 	}
 	var m map[string]interface{}
-	json.Unmarshal(b, &m)
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, "", err
+	}
 
 	a := []rune(statusName)
 	a[0] = unicode.ToLower(a[0])

--- a/internal/zone/zone.go
+++ b/internal/zone/zone.go
@@ -44,33 +44,6 @@ func GetZoneNoByCode(config *conn.ProviderConfig, code string) string {
 	return ""
 }
 
-func getZoneCodeByNo(config *conn.ProviderConfig, no string) string {
-	if zoneCode := zoneCache[no]; zoneCode != "" {
-		return zoneCode
-	}
-	if zone, err := getZoneByNo(config, no); err == nil && zone != nil {
-		zoneCache[no] = *zone.ZoneCode
-		return *zone.ZoneCode
-	}
-	return ""
-}
-
-func getZoneByNo(config *conn.ProviderConfig, no string) (*Zone, error) {
-	zonesList, err := GetZones(config)
-	if err != nil {
-		return nil, err
-	}
-
-	var filteredZone *Zone
-	for _, zone := range zonesList {
-		if zone.ZoneNo != nil && no == *zone.ZoneNo {
-			filteredZone = zone
-			break
-		}
-	}
-	return filteredZone, nil
-}
-
 func GetZoneByCode(config *conn.ProviderConfig, code string) (*Zone, error) {
 	zonesList, err := GetZones(config)
 	if err != nil {
@@ -91,7 +64,7 @@ func GetZones(config *conn.ProviderConfig) ([]*Zone, error) {
 	var zones []*Zone
 	var err error
 
-	if config.SupportVPC == true {
+	if config.SupportVPC {
 		zones, err = getVpcZones(config)
 	} else {
 		zones, err = getClassicZones(config)

--- a/internal/zone/zones_data_source.go
+++ b/internal/zone/zones_data_source.go
@@ -42,7 +42,7 @@ func dataSourceNcloudZonesRead(d *schema.ResourceData, meta interface{}) error {
 	var zones []*Zone
 	var err error
 
-	if meta.(*conn.ProviderConfig).SupportVPC == true {
+	if meta.(*conn.ProviderConfig).SupportVPC {
 		zones, err = getVpcZones(meta.(*conn.ProviderConfig))
 	} else {
 		zones, err = getClassicZones(meta.(*conn.ProviderConfig))


### PR DESCRIPTION
It fixes most of the linter errors based on the default golangci-lint option with several exceptions.
This will help to keep the consistent code base and can help to apply ci github action (https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/347)