### PR TITLE
ci: Increase golangci-lint timeout

### DIFF
--- a/.github/workflows/testAndLint.yml
+++ b/.github/workflows/testAndLint.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - '**'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   lint:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,6 @@
+run:
+  timeout: 10m
+
 issues:
   exclude-rules:
     - linters:


### PR DESCRIPTION
Increase the timeout setting to prevent the linter from failing to complete within the default timeout.
https://github.com/NaverCloudPlatform/terraform-provider-ncloud/actions/runs/6428690050/job/17456316878

In addition, It changes to enable GitHub action ci for linting and testing for pull requests.