### PR TITLE
test: Apply provider factories on acceptance test

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -38,10 +38,6 @@ var (
 	ClassicProtoV6ProviderFactories map[string]func() (tfprotov6.ProviderServer, error) = protoV6ProviderFactoriesInit(context.Background(), false, ProviderName)
 )
 
-// TODO: deprecate testAccProviders/testAccClassicProviders
-var testAccProviders map[string]*schema.Provider
-var testAccClassicProviders map[string]*schema.Provider
-
 var testAccProvider *schema.Provider
 var testAccClassicProvider *schema.Provider
 
@@ -58,14 +54,13 @@ var regionEnvVar = "NCLOUD_REGION"
 func init() {
 	testAccProvider = getTestAccProvider(true)
 	testAccClassicProvider = getTestAccProvider(false)
+}
 
-	testAccProviders = map[string]*schema.Provider{
-		ProviderName: testAccProvider,
+func GetTestProviderFactories(isVpc bool) map[string]func() (tfprotov6.ProviderServer, error) {
+	if isVpc {
+		return ProtoV6ProviderFactories
 	}
-
-	testAccClassicProviders = map[string]*schema.Provider{
-		ProviderName: testAccClassicProvider,
-	}
+	return ClassicProtoV6ProviderFactories
 }
 
 func GetTestProvider(isVpc bool) *schema.Provider {
@@ -74,14 +69,6 @@ func GetTestProvider(isVpc bool) *schema.Provider {
 	}
 
 	return testAccClassicProvider
-}
-
-func GetTestAccProviders(isVpc bool) map[string]*schema.Provider {
-	if isVpc {
-		return testAccProviders
-	}
-
-	return testAccClassicProviders
 }
 
 func getTestAccProvider(isVpc bool) *schema.Provider {

--- a/internal/region/regions_data_source_test.go
+++ b/internal/region/regions_data_source_test.go
@@ -18,8 +18,8 @@ func TestAccDataSourceNcloudRegions_vpc_basic(t *testing.T) {
 
 func testAccDataSourceNcloudRegionsBasic(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudRegionsConfig,

--- a/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
@@ -15,8 +15,8 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic(t *testing.
 	dataName := "data.ncloud_auto_scaling_adjustment_types.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig(lcName, policyName),
@@ -34,8 +34,8 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic(t *testing.T) {
 	dataName := "data.ncloud_auto_scaling_adjustment_types.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(lcName, policyName),
@@ -51,8 +51,8 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_byFilterCode(t *t
 	dataName := "data.ncloud_auto_scaling_adjustment_types.by_filter"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesByFilterCodeConfig("EXACT"),
@@ -68,8 +68,8 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_byFilterCode(t *testi
 	dataName := "data.ncloud_auto_scaling_adjustment_types.by_filter"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesByFilterCodeConfig("EXACT"),

--- a/internal/service/nasvolume/nas_volume_data_source_test.go
+++ b/internal/service/nasvolume/nas_volume_data_source_test.go
@@ -23,8 +23,8 @@ func testAccDataSourceNcloudNasVolumeBasic(t *testing.T, isVpc bool) {
 	postfix := GetTestPrefix()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNasVolumeConfig(postfix),

--- a/internal/service/nasvolume/nas_volume_test.go
+++ b/internal/service/nasvolume/nas_volume_test.go
@@ -29,8 +29,8 @@ func testAccResourceNcloudNasVolumeBasic(t *testing.T, isVpc bool) {
 	provider := GetTestProvider(isVpc)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNasVolumeDestroy(state, provider)
 		},
@@ -75,8 +75,8 @@ func testAccResourceNcloudNasVolumeResize(t *testing.T, isVpc bool) {
 	provider := GetTestProvider(isVpc)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNasVolumeDestroy(state, provider)
 		},
@@ -111,8 +111,8 @@ func TestAccResourceNcloudNasVolume_classic_changeAccessControl(t *testing.T) {
 	resourceName := "ncloud_nas_volume.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNasVolumeDestroy(state, GetTestProvider(false))
 		},
@@ -147,8 +147,8 @@ func TestAccResourceNcloudNasVolume_vpc_changeAccessControl(t *testing.T) {
 	resourceName := "ncloud_nas_volume.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			return testAccCheckNasVolumeDestroy(state, GetTestProvider(true))
 		},

--- a/internal/service/nasvolume/nas_volumes_data_source_test.go
+++ b/internal/service/nasvolume/nas_volumes_data_source_test.go
@@ -21,8 +21,8 @@ func testAccDataSourceNcloudNasVolumesBasic(t *testing.T, isVpc bool) {
 	postfix := GetTestPrefix()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNasVolumesConfig(postfix),

--- a/internal/service/nks/nks_kube_config_data_source_test.go
+++ b/internal/service/nks/nks_kube_config_data_source_test.go
@@ -16,8 +16,8 @@ func TestAccDataSourceNcloudNKSKubeConfig(t *testing.T) {
 	region, clusterType, _, k8sVersion := getRegionAndNKSType()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNKSKubeConfigConfig(testClusterName, clusterType, TF_TEST_NKS_LOGIN_KEY, k8sVersion, region),

--- a/internal/service/server/access_control_group_data_source_test.go
+++ b/internal/service/server/access_control_group_data_source_test.go
@@ -18,8 +18,8 @@ func TestAccDataSourceNcloudVpcAccessControlGroupBasic(t *testing.T) {
 	resourceName := "ncloud_access_control_group.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudVpcAccessControlGroupConfig(name),
@@ -41,8 +41,8 @@ func TestAccDataSourceNcloudVpcAccessControlGroupBasic(t *testing.T) {
 func TestAccDataSourceNcloudClassicAccessControlGroup_basic(t *testing.T) {
 	dataName := "data.ncloud_access_control_group.by_name"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudClassicAccessControlConfig,

--- a/internal/service/server/access_control_groups_data_source_test.go
+++ b/internal/service/server/access_control_groups_data_source_test.go
@@ -26,8 +26,8 @@ func TestAccDataSourceNcloudAccessControlGroups_vpc_default(t *testing.T) {
 
 func testAccDataSourceNcloudAccessControlGroupsBasic(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAccessControlGroupsConfig,
@@ -41,8 +41,8 @@ func testAccDataSourceNcloudAccessControlGroupsBasic(t *testing.T, isVpc bool) {
 
 func testAccDataSourceNcloudAccessControlGroupsDefault(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAccessControlGroupsDefaultConfig,

--- a/internal/service/server/access_control_rule_data_source_test.go
+++ b/internal/service/server/access_control_rule_data_source_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestAccDataSourceNcloudAccessControlRuleBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAccessControlRuleConfig,

--- a/internal/service/server/block_storage_snapshot_data_source_test.go
+++ b/internal/service/server/block_storage_snapshot_data_source_test.go
@@ -13,8 +13,8 @@ func TestAccDataSourceNcloudBlockStorageSnapshot_basic(t *testing.T) {
 	dataName := "data.ncloud_block_storage_snapshot.by_id"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				// ignore check: may be empty created data

--- a/internal/service/server/network_interfaces_data_source_test.go
+++ b/internal/service/server/network_interfaces_data_source_test.go
@@ -15,8 +15,8 @@ func TestAccDataSourceNcloudNetworkInterfaces_basic(t *testing.T) {
 	dataName := "data.ncloud_network_interfaces.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNetworkInterfacesConfig(),
@@ -39,8 +39,8 @@ func TestAccDataSourceNcloudNetworkInterfaces_privateIp(t *testing.T) {
 	dataName := "data.ncloud_network_interfaces.by_private_ip"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNetworkInterfacesConfigPrivateIp(name),
@@ -67,8 +67,8 @@ func TestAccDataSourceNcloudNetworkInterfaces_filter(t *testing.T) {
 	dataName := "data.ncloud_network_interfaces.by_filter"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudNetworkInterfacesConfigFilter(name),

--- a/internal/service/server/placement_group_data_source_test.go
+++ b/internal/service/server/placement_group_data_source_test.go
@@ -17,8 +17,8 @@ func TestAccDataSourceNcloudPlacementGroup_basic(t *testing.T) {
 	dataNameFilter := "data.ncloud_placement_group.by_filter"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudPlacementGroupConfig(name),

--- a/internal/service/server/port_forwarding_rule_data_source_test.go
+++ b/internal/service/server/port_forwarding_rule_data_source_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestAccDataSourceNcloudPortForwardingRuleBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudPortForwardingRuleConfig,

--- a/internal/service/server/port_forwarding_rules_data_source_test.go
+++ b/internal/service/server/port_forwarding_rules_data_source_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestAccDataSourceNcloudPortForwardingRulesBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudPortForwardingRulesConfig,

--- a/internal/service/server/public_ip_data_source_test.go
+++ b/internal/service/server/public_ip_data_source_test.go
@@ -18,8 +18,8 @@ func TestAccDataSourceNcloudPublicIp_classic_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-public-ip-basic-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudPublicIpClassicConfig(name),
@@ -46,8 +46,8 @@ func TestAccDataSourceNcloudPublicIp_vpc_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-public-ip-basic-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudPublicIpVpcConfig(name),
@@ -66,8 +66,8 @@ func TestAccDataSourceNcloudPublicIp_vpc_basic(t *testing.T) {
 
 func TestAccDataSourceNcloudPublicIpIsAssociated(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudPublicIpAssociatedConfig,
@@ -85,8 +85,8 @@ func TestAccDataSourceNcloudPublicIpIsAssociated(t *testing.T) {
 
 func TestAccDataSourceNcloudPublicIpSearch(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudPublicIpSearchConfig,

--- a/internal/service/server/public_ip_test.go
+++ b/internal/service/server/public_ip_test.go
@@ -22,8 +22,8 @@ func TestAccResourceNcloudPublicIpInstance_classic_basic(t *testing.T) {
 	resourceName := "ncloud_public_ip.public_ip"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(s *terraform.State) error {
 			return testAccCheckPublicIpInstanceDestroy(s, GetTestProvider(false))
 		},
@@ -55,8 +55,8 @@ func TestAccResourceNcloudPublicIpInstance_vpc_basic(t *testing.T) {
 	resourceName := "ncloud_public_ip.public_ip"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(s *terraform.State) error {
 			return testAccCheckPublicIpInstanceDestroy(s, GetTestProvider(true))
 		},
@@ -88,8 +88,8 @@ func TestAccResourceNcloudPublicIpInstance_classic_updateServerInstanceNo(t *tes
 	resourceName := "ncloud_public_ip.public_ip"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		CheckDestroy: func(s *terraform.State) error {
 			return testAccCheckPublicIpInstanceDestroy(s, GetTestProvider(false))
 		},
@@ -121,8 +121,8 @@ func TestAccResourceNcloudPublicIpInstance_vpc_updateServerInstanceNo(t *testing
 	resourceName := "ncloud_public_ip.public_ip"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		CheckDestroy: func(s *terraform.State) error {
 			return testAccCheckPublicIpInstanceDestroy(s, GetTestProvider(true))
 		},

--- a/internal/service/server/root_password_data_source_test.go
+++ b/internal/service/server/root_password_data_source_test.go
@@ -15,8 +15,8 @@ func TestAccDataSourceNcloudRootPassword_classic_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-passwd-basic-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceRootPasswordClassicConfig(name),
@@ -34,8 +34,8 @@ func TestAccDataSourceNcloudRootPassword_vpc_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-passwd-basic-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceRootPasswordVpcConfig(name),

--- a/internal/service/server/server_data_source_test.go
+++ b/internal/service/server/server_data_source_test.go
@@ -16,8 +16,8 @@ func TestAccDataSourceNcloudServer_vpc_basic(t *testing.T) {
 	testServerName := GetTestServerName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceServerVpcConfig(testServerName),
@@ -57,8 +57,8 @@ func TestAccDataSourceNcloudServer_classic_basic(t *testing.T) {
 	testServerName := GetTestServerName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceServerClassicConfig(testServerName),

--- a/internal/service/server/server_image_data_source_test.go
+++ b/internal/service/server/server_image_data_source_test.go
@@ -13,8 +13,8 @@ func TestAccDataSourceNcloudServerImage_classic_byCode(t *testing.T) {
 	dataName := "data.ncloud_server_image.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImageByCodeConfig("SPSW0LINUX000046"),
@@ -37,8 +37,8 @@ func TestAccDataSourceNcloudServerImage_vpc_byCode(t *testing.T) {
 	dataName := "data.ncloud_server_image.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImageByCodeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
@@ -59,8 +59,8 @@ func TestAccDataSourceNcloudServerImage_vpc_byCode(t *testing.T) {
 
 func TestAccDataSourceNcloudServerImage_classic_byFilterProductCode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImageByFilterProductCodeConfig("SPSW0LINUX000139"),
@@ -74,8 +74,8 @@ func TestAccDataSourceNcloudServerImage_classic_byFilterProductCode(t *testing.T
 
 func TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImageByFilterProductCodeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
@@ -97,8 +97,8 @@ func TestAccDataSourceNcloudServerImage_vpc_byFilterProductName(t *testing.T) {
 
 func testAccDataSourceNcloudServerImageByFilterProductName(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImageByFilterProductNameConfig,
@@ -120,8 +120,8 @@ func TestAccDataSourceNcloudServerImage_vpc_byBlockStorageSize(t *testing.T) {
 
 func testAccDataSourceNcloudServerImageByBlockStorageSize(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImageByBlockStorageSizeConfig,
@@ -137,8 +137,8 @@ func TestAccDataSourceNcloudServerImage_vpc_byPlatformType(t *testing.T) {
 	dataName := "data.ncloud_server_image.test5"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImageByPlatformTypeConfig("LNX64"),

--- a/internal/service/server/server_images_data_source_test.go
+++ b/internal/service/server/server_images_data_source_test.go
@@ -18,8 +18,8 @@ func TestAccDataSourceNcloudServerImages_vpc_basic(t *testing.T) {
 
 func testAccDataSourceNcloudServerImagesBasic(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImagesConfig,
@@ -41,8 +41,8 @@ func TestAccDataSourceNcloudServerImages_vpc_linux(t *testing.T) {
 
 func testAccDataSourceNcloudServerImagesLinux(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImagesLinuxConfig,
@@ -64,8 +64,8 @@ func TestAccDataSourceNcloudServerImages_vpc_windows(t *testing.T) {
 
 func testAccDataSourceNcloudServerImagesWindows(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImagesWindowsConfig,
@@ -87,8 +87,8 @@ func TestAccDataSourceNcloudServerImages_vpc_bareMetal(t *testing.T) {
 
 func testAccDataSourceNcloudServerImagesBareMetal(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImagesBareMetalConfig,
@@ -110,8 +110,8 @@ func TestAccDataSourceNcloudServerImages_vpc_blockStorageSize(t *testing.T) {
 
 func testAccDataSourceNcloudServerImagesBlockStorageSize(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerImagesBlockStorageSizeConfig,

--- a/internal/service/server/server_product_data_source_test.go
+++ b/internal/service/server/server_product_data_source_test.go
@@ -12,8 +12,8 @@ import (
 func TestAccDataSourceNcloudServerProduct_classic_basic(t *testing.T) {
 	dataName := "data.ncloud_server_product.test1"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerProductConfig("SPSW0LINUX000045", "SPSVRSTAND000004"),
@@ -39,8 +39,8 @@ func TestAccDataSourceNcloudServerProduct_vpc_basic(t *testing.T) {
 	dataName := "data.ncloud_server_product.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerProductConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050", "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"),
@@ -64,8 +64,8 @@ func TestAccDataSourceNcloudServerProduct_vpc_basic(t *testing.T) {
 
 func TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerProductFilterByProductCodeConfig("SPSW0LINUX000045", "SPSVRSTAND000056"),
@@ -79,8 +79,8 @@ func TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode(t *testing
 
 func TestAccDataSourceNcloudServerProduct_vpc_FilterByProductCode(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerProductFilterByProductCodeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050", "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"),
@@ -94,8 +94,8 @@ func TestAccDataSourceNcloudServerProduct_vpc_FilterByProductCode(t *testing.T) 
 
 func TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig("SPSW0LINUX000045", "G1"),
@@ -109,8 +109,8 @@ func TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType
 
 func TestAccDataSourceNcloudServerProduct_vpc_FilterByProductNameProductType(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050", "G2"),

--- a/internal/service/server/servers_data_source_test.go
+++ b/internal/service/server/servers_data_source_test.go
@@ -21,8 +21,8 @@ func TestAccDataSourceNcloudServers_vpc_basic(t *testing.T) {
 	testServerName2 := GetTestServerName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(true),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceServersVpcConfig(testServerName, testServerName2),
@@ -44,8 +44,8 @@ func TestAccDataSourceNcloudServers_classic_basic(t *testing.T) {
 	testServerName2 := GetTestServerName()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(false),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceServersClassicConfig(testServerName, testServerName2),

--- a/internal/zone/zones_data_source_test.go
+++ b/internal/zone/zones_data_source_test.go
@@ -18,8 +18,8 @@ func TestAccDataSourceNcloudZones_vpc_basic(t *testing.T) {
 
 func testAccDataSourceNcloudZonesBasic(t *testing.T, isVpc bool) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { TestAccPreCheck(t) },
-		Providers: GetTestAccProviders(isVpc),
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: GetTestProviderFactories(isVpc),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudZonesConfig,


### PR DESCRIPTION
Some tests don't apply the use of providerFactories, which were used after the framework was introduced. This PR fixes all of test to use providerFactories.