### PR TITLE
ci: Add contents read permission for ci action

### DIFF
--- a/.github/workflows/testAndLint.yml
+++ b/.github/workflows/testAndLint.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
It adds contents read permission to show golangci-lint errors on the code lines.