### PR TITLE
fix(BlockStorage): Fixing errors to pass AccTest

### DIFF
--- a/internal/service/server/block_storage.go
+++ b/internal/service/server/block_storage.go
@@ -193,6 +193,10 @@ func resourceNcloudBlockStorageUpdate(d *schema.ResourceData, meta interface{}) 
 			if err := detachBlockStorage(config, d.Id()); err != nil {
 				return err
 			}
+
+			if err := detachThenWaitServerInstance(config, o.(string)); err != nil {
+				return err
+			}
 		}
 
 		if len(n.(string)) > 0 {
@@ -219,6 +223,10 @@ func resourceNcloudBlockStorageUpdate(d *schema.ResourceData, meta interface{}) 
 			}
 
 			if err := detachBlockStorage(config, d.Id()); err != nil {
+				return err
+			}
+
+			if err := detachThenWaitServerInstance(config, d.Get("server_instance_no").(string)); err != nil {
 				return err
 			}
 		}
@@ -405,7 +413,7 @@ func deleteBlockStorage(d *schema.ResourceData, config *conn.ProviderConfig, id 
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{BlockStorageStatusCodeInit, BlockStorageStatusCodeAttach},
+		Pending: []string{BlockStorageStatusCodeCreate, BlockStorageStatusCodeInit, BlockStorageStatusCodeAttach},
 		Target:  []string{"TERMINATED"},
 		Refresh: func() (interface{}, string, error) {
 			instance, err := GetBlockStorage(config, id)
@@ -435,6 +443,8 @@ func deleteClassicBlockStorage(d *schema.ResourceData, config *conn.ProviderConf
 		BlockStorageInstanceNoList: []*string{ncloud.String(id)},
 	}
 
+	LogCommonRequest("deleteClassicBlockStorage", reqParams)
+
 	resp, err := config.Client.Server.V2Api.DeleteBlockStorageInstances(&reqParams)
 
 	if err != nil {
@@ -451,6 +461,8 @@ func deleteVpcBlockStorage(d *schema.ResourceData, config *conn.ProviderConfig, 
 		RegionCode:                 &config.RegionCode,
 		BlockStorageInstanceNoList: []*string{ncloud.String(id)},
 	}
+
+	LogCommonRequest("deleteVpcBlockStorage", reqParams)
 
 	resp, err := config.Client.Vserver.V2Api.DeleteBlockStorageInstances(&reqParams)
 

--- a/internal/service/server/block_storage_test.go
+++ b/internal/service/server/block_storage_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
@@ -32,7 +31,7 @@ func TestAccResourceNcloudBlockStorage_classic_basic(t *testing.T) {
 			{
 				Config: testAccBlockStorageClassicConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClassicBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`^\d+$`)),
 					resource.TestCheckResourceAttr(resourceName, "name", name+"-tf"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ATTAC"),
@@ -110,13 +109,13 @@ func TestAccResourceNcloudBlockStorage_classic_ChangeServerInstance(t *testing.T
 			{
 				Config: testAccBlockStorageClassicConfigUpdate(name, "ncloud_server.foo.id"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClassicBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
 				),
 			},
 			{
 				Config: testAccBlockStorageClassicConfigUpdate(name, "ncloud_server.bar.id"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClassicBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
 				),
 			},
 		},
@@ -168,14 +167,14 @@ func TestAccResourceNcloudBlockStorage_classic_size(t *testing.T) {
 			{
 				Config: testAccBlockStorageClassicConfigWithSize(name, 10),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClassicBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
 					resource.TestCheckResourceAttr(resourceName, "size", "10"),
 				),
 			},
 			{
 				Config: testAccBlockStorageClassicConfigWithSize(name, 20),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClassicBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
 					resource.TestCheckResourceAttr(resourceName, "size", "20"),
 				),
 			},
@@ -186,7 +185,7 @@ func TestAccResourceNcloudBlockStorage_classic_size(t *testing.T) {
 			{
 				Config: testAccBlockStorageClassicConfigWithSize(name, 2000),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClassicBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
+					testAccCheckBlockStorageExistsWithProvider(resourceName, &storageInstance, GetTestProvider(false)),
 					resource.TestCheckResourceAttr(resourceName, "size", "2000"),
 				),
 			},
@@ -247,34 +246,6 @@ func testAccCheckBlockStorageExistsWithProvider(n string, i *server.BlockStorage
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-
-		config := provider.Meta().(*conn.ProviderConfig)
-		storage, err := server.GetBlockStorage(config, rs.Primary.ID)
-		if err != nil {
-			return nil
-		}
-
-		if storage != nil {
-			*i = *storage
-			return nil
-		}
-
-		return fmt.Errorf("block storage not found")
-	}
-}
-
-func testAccCheckClassicBlockStorageExistsWithProvider(n string, i *server.BlockStorage, provider *schema.Provider) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no ID is set")
-		}
-
-		time.Sleep(time.Second * 10)
 
 		config := provider.Meta().(*conn.ProviderConfig)
 		storage, err := server.GetBlockStorage(config, rs.Primary.ID)

--- a/internal/service/server/block_storage_test.go
+++ b/internal/service/server/block_storage_test.go
@@ -163,7 +163,7 @@ func TestAccResourceNcloudBlockStorage_classic_size(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBlockStorageClassicConfigWithSize(name, 2500),
-				ExpectError: regexp.MustCompile("expected size to be in the range \\(10 - 2000\\), got 2500"),
+				ExpectError: regexp.MustCompile(`expected size to be in the range \(10 - 2000\), got 2500`),
 			},
 			{
 				Config: testAccBlockStorageClassicConfigWithSize(name, 10),
@@ -206,7 +206,7 @@ func TestAccResourceNcloudBlockStorage_vpc_size(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccBlockStorageVpcConfigWithSize(name+acctest.RandString(5), 2500),
-				ExpectError: regexp.MustCompile("expected size to be in the range \\(10 - 2000\\), got 2500"),
+				ExpectError: regexp.MustCompile(`expected size to be in the range \(10 - 2000\), got 2500`),
 			},
 			{
 				Config: testAccBlockStorageVpcConfigWithSize(name, 10),

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -1129,6 +1129,8 @@ func getVpcAdditionalBlockStorageList(config *conn.ProviderConfig, id string) ([
 		return nil, err
 	}
 
+	LogResponse("getVpcAdditionalBlockStorageList", resp)
+
 	if len(resp.BlockStorageInstanceList) < 1 {
 		return nil, nil
 	}
@@ -1151,6 +1153,8 @@ func getClassicAdditionalBlockStorageList(config *conn.ProviderConfig, id string
 	if err != nil {
 		return nil, err
 	}
+
+	LogResponse("getClassicAdditionalBlockStorageList", resp)
 
 	if len(resp.BlockStorageInstanceList) < 1 {
 		return nil, nil


### PR DESCRIPTION
### Affected Resource
ncloud_block_storage

### Related
https://github.com/NaverCloudPlatform/terraform-provider-ncloud/issues/339
https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/187

### Description
#### 1) BlockStorage detach or delete API error
  - Relate AccTest
    - TestAccResourceNcloudBlockStorage_classic_basic
    - TestAccResourceNcloudBlockStorage_classic_ChangeServerInstance
    - TestAccResourceNcloudBlockStorage_classic_size
  - Error Output
```
2023/10/24 11:19:41 [ERROR] deleteClassicBlockStorage error params={"blockStorageInstanceNoList":["20176946"]}, err=Status: 500 Internal Server Error, Body: {
   "responseError": {
     "returnCode": "24002",
     "returnMessage": "It seems that storage tf-storage-update-80g06-tf is mounted to server tf-storage-update-80g06-bar. Please unmount the storage and try again."
```
  - Cause : Only in AccTest in the classic environment, it seems that an error occurs if detach is executed immediately after block storage attach while server internal logic is being performed.
~~Resolve : Currently, there is no way to know if the server's internal logic is working. Temporarily add a 10-second delay to pass the ACC test~~
  - To Do  : Modify AccTest to pass after server API improvement
 
#### 2) Status check error when deleting Blockstorage
  - Resolve : Added pending processing even when the status value is 'CREAT'

#### 3) ExpectError check not working well
  - Relate AccTest
    - TestAccResourceNcloudBlockStorage_classic_size
    - TestAccResourceNcloudBlockStorage_vpc_size
  - Error Output
```
=== RUN   TestAccResourceNcloudBlockStorage_classic_size
    testing_new.go:82: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: expected size to be in the range (10 - 2000), got 2500

          with ncloud_block_storage.storage,
          on terraform_plugin_test.tf line 16, in resource "ncloud_block_storage" "storage":
          16:     size = "2500"

--- FAIL: TestAccResourceNcloudBlockStorage_classic_size (396.42s)
FAIL
exit status 1
```
  - Resolve
    - Modify regexp.MustCompile("")
    - The cause is unknown, but an error occurs when ExpectError is in the last order of resource.TestStep. Moving it to the first caused no error and the test passed.

### Steps to Reproduce
go test -run TestAccResourceNcloudBlockStorage -v -timeout=50m

### Test Result
```
=== RUN   TestAccResourceNcloudBlockStorage_classic_basic
--- PASS: TestAccResourceNcloudBlockStorage_classic_basic (385.01s)
=== RUN   TestAccResourceNcloudBlockStorage_vpc_basic
--- PASS: TestAccResourceNcloudBlockStorage_vpc_basic (360.95s)
=== RUN   TestAccResourceNcloudBlockStorage_classic_ChangeServerInstance
--- FAIL: TestAccResourceNcloudBlockStorage_classic_ChangeServerInstance (428.85s)
=== RUN   TestAccResourceNcloudBlockStorage_vpc_ChangeServerInstance
--- PASS: TestAccResourceNcloudBlockStorage_vpc_ChangeServerInstance (415.64s)
=== RUN   TestAccResourceNcloudBlockStorage_classic_size
--- FAIL: TestAccResourceNcloudBlockStorage_classic_size (428.40s)
=== RUN   TestAccResourceNcloudBlockStorage_vpc_size
--- PASS: TestAccResourceNcloudBlockStorage_vpc_size (738.03s)
FAIL

```