### PR TITLE
fix(vpc): Fix error to pass AccTest

### DIFF
--- a/internal/service/vpc/vpc_test.go
+++ b/internal/service/vpc/vpc_test.go
@@ -30,7 +30,7 @@ func TestAccResourceNcloudVpc_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudVpcConfig(name, cidr),
+				Config: testAccResourceNcloudVpcConfig(name, cidr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVpcExists(resourceName, &vpc),
 					resource.TestCheckResourceAttr(resourceName, "ipv4_cidr_block", cidr),


### PR DESCRIPTION
### Affected File
- vpc_test.go

### Related Issue
#387 

### Description
- Fix typo in `TestAccResourceNcloudVpc_basic`.
### Error output
```
$ TF_ACC=1 go test ./internal/service/vpc/vpc_test.go -run=TestAccResourceNcloudVpc_basic -v
# command-line-arguments_test [command-line-arguments.test]
internal\service\vpc\vpc_test.go:33:13: undefined: testAccDataSourceNcloudVpcConfig
FAIL    command-line-arguments [build failed]
FAIL
```

### Test Result
```
$ TF_ACC=1 go test ./internal/service/vpc/vpc_test.go -run=TestAccResourceNcloudVpc_basic -v
=== RUN   TestAccResourceNcloudVpc_basic
--- PASS: TestAccResourceNcloudVpc_basic (28.30s)
PASS
ok      command-line-arguments  28.993s
```