### PR TITLE
chore: Move memberServerImage into the server service

### DIFF
--- a/docs/data-sources/member_server_image.md
+++ b/docs/data-sources/member_server_image.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Member Server Image"
+subcategory: "Server"
 ---
 
 

--- a/docs/data-sources/member_server_images.md
+++ b/docs/data-sources/member_server_images.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Member Server Image"
+subcategory: "Server"
 ---
 
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -15,7 +15,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/classicloadbalancer"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/devtools"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/loadbalancer"
-	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/memberserverimage"
 	cloudmssql "github.com/terraform-providers/terraform-provider-ncloud/internal/service/mssql"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/nasvolume"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/nks"
@@ -49,8 +48,8 @@ func New(ctx context.Context) *schema.Provider {
 		"ncloud_lb":                                      loadbalancer.DataSourceNcloudLb(),
 		"ncloud_lb_listener":                             loadbalancer.DataSourceNcloudLbListener(),
 		"ncloud_lb_target_group":                         loadbalancer.DataSourceNcloudLbTargetGroup(),
-		"ncloud_member_server_image":                     memberserverimage.DataSourceNcloudMemberServerImage(),
-		"ncloud_member_server_images":                    memberserverimage.DataSourceNcloudMemberServerImages(),
+		"ncloud_member_server_image":                     server.DataSourceNcloudMemberServerImage(),
+		"ncloud_member_server_images":                    server.DataSourceNcloudMemberServerImages(),
 		"ncloud_nas_volume":                              nasvolume.DataSourceNcloudNasVolume(),
 		"ncloud_nas_volumes":                             nasvolume.DataSourceNcloudNasVolumes(),
 		"ncloud_network_acls":                            vpc.DataSourceNcloudNetworkAcls(),

--- a/internal/service/server/member_server_image_data_source.go
+++ b/internal/service/server/member_server_image_data_source.go
@@ -1,4 +1,4 @@
-package memberserverimage
+package server
 
 import (
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"

--- a/internal/service/server/member_server_image_data_source_test.go
+++ b/internal/service/server/member_server_image_data_source_test.go
@@ -1,4 +1,4 @@
-package memberserverimage_test
+package server_test
 
 import (
 	"testing"
@@ -8,50 +8,49 @@ import (
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/acctest"
 )
 
-func TestAccDataSourceNcloudMemberServerImagesBasic(t *testing.T) {
+func TestAccDataSourceNcloudMemberServerImageBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudMemberServerImagesConfig,
+				Config: testAccDataSourceNcloudMemberServerImageConfig,
 				// ignore check: may be empty created data
 				SkipFunc: func() (bool, error) {
 					return SkipNoResultsTest, nil
 				},
 				Check: resource.ComposeTestCheckFunc(
-					TestAccCheckDataSourceID("data.ncloud_member_server_images.member_server_images"),
+					TestAccCheckDataSourceID("data.ncloud_member_server_image.test"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccDataSourceNcloudMemberServerImagesFilter(t *testing.T) {
+func TestAccDataSourceNcloudMemberServerImageFilter(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudMemberServerImagesConfigFilter,
-				// ignore check: may be empty created data
+				Config: testAccDataSourceNcloudMemberServerImageConfigFilter,
 				SkipFunc: func() (bool, error) {
 					return SkipNoResultsTest, nil
 				},
 				Check: resource.ComposeTestCheckFunc(
-					TestAccCheckDataSourceID("data.ncloud_member_server_images.member_server_images"),
+					TestAccCheckDataSourceID("data.ncloud_member_server_image.test"),
 				),
 			},
 		},
 	})
 }
 
-var testAccDataSourceNcloudMemberServerImagesConfig = `
-data "ncloud_member_server_images" "member_server_images" {}
+var testAccDataSourceNcloudMemberServerImageConfig = `
+data "ncloud_member_server_image" "test" {}
 `
 
-var testAccDataSourceNcloudMemberServerImagesConfigFilter = `
-data "ncloud_member_server_images" "member_server_images" {
+var testAccDataSourceNcloudMemberServerImageConfigFilter = `
+data "ncloud_member_server_image" "member_server_images" {
 	filter {
 		name   = "platform_type"
 		values = ["LNX64"]

--- a/internal/service/server/member_server_images_data_source.go
+++ b/internal/service/server/member_server_images_data_source.go
@@ -1,4 +1,4 @@
-package memberserverimage
+package server
 
 import (
 	"fmt"

--- a/internal/service/server/member_server_images_data_source_test.go
+++ b/internal/service/server/member_server_images_data_source_test.go
@@ -1,4 +1,4 @@
-package memberserverimage_test
+package server_test
 
 import (
 	"testing"
@@ -8,49 +8,50 @@ import (
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/acctest"
 )
 
-func TestAccDataSourceNcloudMemberServerImageBasic(t *testing.T) {
+func TestAccDataSourceNcloudMemberServerImagesBasic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudMemberServerImageConfig,
+				Config: testAccDataSourceNcloudMemberServerImagesConfig,
 				// ignore check: may be empty created data
 				SkipFunc: func() (bool, error) {
 					return SkipNoResultsTest, nil
 				},
 				Check: resource.ComposeTestCheckFunc(
-					TestAccCheckDataSourceID("data.ncloud_member_server_image.test"),
+					TestAccCheckDataSourceID("data.ncloud_member_server_images.member_server_images"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccDataSourceNcloudMemberServerImageFilter(t *testing.T) {
+func TestAccDataSourceNcloudMemberServerImagesFilter(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudMemberServerImageConfigFilter,
+				Config: testAccDataSourceNcloudMemberServerImagesConfigFilter,
+				// ignore check: may be empty created data
 				SkipFunc: func() (bool, error) {
 					return SkipNoResultsTest, nil
 				},
 				Check: resource.ComposeTestCheckFunc(
-					TestAccCheckDataSourceID("data.ncloud_member_server_image.test"),
+					TestAccCheckDataSourceID("data.ncloud_member_server_images.member_server_images"),
 				),
 			},
 		},
 	})
 }
 
-var testAccDataSourceNcloudMemberServerImageConfig = `
-data "ncloud_member_server_image" "test" {}
+var testAccDataSourceNcloudMemberServerImagesConfig = `
+data "ncloud_member_server_images" "member_server_images" {}
 `
 
-var testAccDataSourceNcloudMemberServerImageConfigFilter = `
-data "ncloud_member_server_image" "member_server_images" {
+var testAccDataSourceNcloudMemberServerImagesConfigFilter = `
+data "ncloud_member_server_images" "member_server_images" {
 	filter {
 		name   = "platform_type"
 		values = ["LNX64"]


### PR DESCRIPTION
# Description
- MemberServerImage belongs to the server service but it was mistakenly located under the memberServiceImage service. It moves the memberServiceImage data sources under the server service.