### PR TITLE
fix(natGateway): Suppress force replacement on update

### DIFF
--- a/internal/service/vpc/nat_gateway.go
+++ b/internal/service/vpc/nat_gateway.go
@@ -3,6 +3,8 @@ package vpc
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -12,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	sdkresource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/framework"
-	"time"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
@@ -87,19 +88,32 @@ func (n *natGatewayResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"public_ip_no": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"nat_gateway_no": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"public_ip": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"subnet_name": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
# Issue
After NatGateway is refactored for framework, a change of attribute can cause unintentional force replacement of `private_ip`.
This change adds the `UseStateForUnknown` Modifier to the attributes to keep the same behavior.

When changing nat_gateway's description,
Before
```
Terraform will perform the following actions:

  # ncloud_nat_gateway.nat_gateway must be replaced
-/+ resource "ncloud_nat_gateway" "nat_gateway" {
      ~ description    = "wow" -> "wows"
      ~ id             = "22293251" -> (known after apply)
        name           = "testgw"
      ~ nat_gateway_no = "22293251" -> (known after apply)
      ~ private_ip     = "10.3.1.6" # forces replacement -> (known after apply) # forces replacement
      ~ public_ip      = "101.79.9.219" -> (known after apply)
      ~ public_ip_no   = "22293252" -> (known after apply)
      ~ subnet_name    = "sn18d2e7660d5" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

After
```
erraform will perform the following actions:

  # ncloud_nat_gateway.nat_gateway will be updated in-place
  ~ resource "ncloud_nat_gateway" "nat_gateway" {
      ~ description    = "wow" -> "wows"
        id             = "22293251"
        name           = "testgw"
        # (8 unchanged attributes hidden)
    }
```