### PR TITLE
Fix(CloudDB): Add exception handling for return code 5001017 when looking up instance

### DIFF
--- a/internal/service/mongodb/mongodb.go
+++ b/internal/service/mongodb/mongodb.go
@@ -776,6 +776,7 @@ func GetCloudMongoDbInstance(ctx context.Context, config *conn.ProviderConfig, n
 	tflog.Info(ctx, "GetMongoDbDetail reqParams="+common.MarshalUncheckedString(reqParams))
 
 	resp, err := config.Client.Vmongodb.V2Api.GetCloudMongoDbInstanceDetail(reqParams)
+	// If the lookup result is 0 or already deleted, it will respond with a 400 error with a 5001017 return code.
 	if err != nil && !(strings.Contains(err.Error(), `"returnCode": "5001017"`)) {
 		return nil, err
 	}
@@ -796,7 +797,7 @@ func waitMongoDbCreated(ctx context.Context, config *conn.ProviderConfig, id str
 		Refresh: func() (interface{}, string, error) {
 			instance, err := GetCloudMongoDbInstance(ctx, config, id)
 			mongodbInstance = instance
-			if err != nil && !strings.Contains(err.Error(), `"returnCode": "5001017"`) {
+			if err != nil {
 				return 0, "", err
 			}
 
@@ -882,8 +883,7 @@ func waitMongoDbDeleted(ctx context.Context, config *conn.ProviderConfig, id str
 		Target:  []string{"deleted"},
 		Refresh: func() (interface{}, string, error) {
 			instance, err := GetCloudMongoDbInstance(ctx, config, id)
-
-			if err != nil && !strings.Contains(err.Error(), `"returnCode": "5001017"`) {
+			if err != nil {
 				return 0, "", err
 			}
 

--- a/internal/service/mssql/mssql.go
+++ b/internal/service/mssql/mssql.go
@@ -469,7 +469,8 @@ func GetMssqlInstance(ctx context.Context, config *conn.ProviderConfig, no strin
 	tflog.Info(ctx, "GetMssqlDetail reqParams="+common.MarshalUncheckedString(reqParams))
 
 	resp, err := config.Client.Vmssql.V2Api.GetCloudMssqlInstanceDetail(reqParams)
-	if err != nil {
+	// If the lookup result is 0 or already deleted, it will respond with a 400 error with a 5001017 return code.
+	if err != nil && !(strings.Contains(err.Error(), `"returnCode": "5001017"`)) {
 		return nil, err
 	}
 	tflog.Info(ctx, "GetMssqlDetail response="+common.MarshalUncheckedString(resp))
@@ -528,7 +529,7 @@ func waitMssqlDeletion(ctx context.Context, config *conn.ProviderConfig, id stri
 		Target:  []string{"deleted"},
 		Refresh: func() (interface{}, string, error) {
 			instance, err := GetMssqlInstance(ctx, config, id)
-
+			// MSSQL deleted, it will respond with a 400 error with a 5001269 return code.
 			if err != nil && !strings.Contains(err.Error(), `"returnCode": "5001269"`) {
 				return 0, "", err
 			}


### PR DESCRIPTION
### Affected Resource
ncloud_mysql
ncloud_mssql
ncloud_mongodb
ncloud_redis

### Issue
- For the CloudDB service(MYSQL, MSSQL, MONGODB, REDIS), if the result of the instance search is 0 or already deleted, a 400 error response with a 5001017 return code is returned. 
- In this case, add exception handling to treat it as no search result instead of an error.