### PR TITLE
fix(redis): Apply omitempty to user_name and user_password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/terraform-providers/terraform-provider-ncloud
 go 1.19
 
 require (
-	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.9
+	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.10
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-framework v1.3.2
 	github.com/hashicorp/terraform-plugin-go v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.9 h1:i9LTZXONA/u7x6ewdfScfOCzHqK5JArVep6k0G2gijs=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.9/go.mod h1:jRp8KZ64MUevBWNqehghhG2oF5/JU3Dmt/Cu7dp1mQE=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.10 h1:DT3zE1158NECPmkyLxZQV73yN4J8vbB7H5hK5TkpFlI=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.10/go.mod h1:jRp8KZ64MUevBWNqehghhG2oF5/JU3Dmt/Cu7dp1mQE=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=


### PR DESCRIPTION
### Description
- Update ncloud-sdk-go-v2 : v1.6.9 -> v1.6.10
  - Apply the omitempty setting to the user_name and user_password to prevent sending null in the request message