### PR TITLE
fix: Prevent panic to access nil in cloud DB resources

### DIFF
--- a/internal/common/convert_types.go
+++ b/internal/common/convert_types.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
 
@@ -234,4 +235,11 @@ func ExpandStringList(configured []interface{}) []*string {
 		}
 	}
 	return vs
+}
+
+func Int64ValueFromInt32(value *int32) basetypes.Int64Value {
+	if value == nil {
+		return basetypes.NewInt64Null()
+	}
+	return basetypes.NewInt64Value(int64(*value))
 }

--- a/internal/service/hadoop/hadoop.go
+++ b/internal/service/hadoop/hadoop.go
@@ -925,9 +925,9 @@ func listValueFromHadoopServerInatanceList(ctx context.Context, serverInatances 
 			VpcNo:             types.StringPointerValue(serverInstance.VpcNo),
 			SubnetNo:          types.StringPointerValue(serverInstance.SubnetNo),
 			IsPublicSubnet:    types.BoolPointerValue(serverInstance.IsPublicSubnet),
-			DataStorageSize:   types.Int64Value(*serverInstance.DataStorageSize),
-			CpuCount:          types.Int64Value(int64(*serverInstance.CpuCount)),
-			MemorySize:        types.Int64Value(*serverInstance.MemorySize),
+			DataStorageSize:   types.Int64PointerValue(serverInstance.DataStorageSize),
+			CpuCount:          common.Int64ValueFromInt32(serverInstance.CpuCount),
+			MemorySize:        types.Int64PointerValue(serverInstance.MemorySize),
 		})
 	}
 

--- a/internal/service/hadoop/hadoop_products_data_source.go
+++ b/internal/service/hadoop/hadoop_products_data_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vhadoop"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -250,7 +251,7 @@ func (h *hadoopProductModel) refreshFromOutput(output *vhadoop.Product) {
 	h.ProductDescription = types.StringPointerValue(output.ProductDescription)
 	h.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
 	h.InfraResourceDetailType = types.StringPointerValue(output.InfraResourceDetailType.Code)
-	h.CpuCount = types.Int64Value(int64(*output.CpuCount))
+	h.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
 	h.MemorySize = types.Int64PointerValue(output.MemorySize)
 	h.DiskType = types.StringPointerValue(output.DiskType.Code)
 }

--- a/internal/service/mongodb/mongodb.go
+++ b/internal/service/mongodb/mongodb.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/common"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
@@ -987,13 +986,13 @@ func (m *mongodbResourceModel) refreshFromOutput(ctx context.Context, output *vm
 	m.SubnetNo = types.StringPointerValue(output.CloudMongoDbServerInstanceList[0].SubnetNo)
 	m.ClusterTypeCode = types.StringPointerValue(output.ClusterType.Code)
 	m.ImageProductCode = types.StringPointerValue(output.CloudMongoDbImageProductCode)
-	m.ShardCount = int32PointerValue(output.ShardCount)
-	m.BackupFileRetentionPeriod = int32PointerValue(output.BackupFileRetentionPeriod)
+	m.ShardCount = common.Int64ValueFromInt32(output.ShardCount)
+	m.BackupFileRetentionPeriod = common.Int64ValueFromInt32(output.BackupFileRetentionPeriod)
 	m.BackupTime = types.StringPointerValue(output.BackupTime)
-	m.ArbiterPort = int32PointerValue(output.ArbiterPort)
-	m.MemberPort = int32PointerValue(output.MemberPort)
-	m.MongosPort = int32PointerValue(output.MongosPort)
-	m.ConfigPort = int32PointerValue(output.ConfigPort)
+	m.ArbiterPort = common.Int64ValueFromInt32(output.ArbiterPort)
+	m.MemberPort = common.Int64ValueFromInt32(output.MemberPort)
+	m.MongosPort = common.Int64ValueFromInt32(output.MongosPort)
+	m.ConfigPort = common.Int64ValueFromInt32(output.ConfigPort)
 	m.DataStorageType = types.StringPointerValue(output.CloudMongoDbServerInstanceList[0].DataStorageType.Code)
 	m.CompressCode = types.StringPointerValue(output.Compress.Code)
 	m.EngineVersion = types.StringPointerValue(output.EngineVersion)
@@ -1014,9 +1013,9 @@ func (m *mongodbResourceModel) refreshFromOutput(ctx context.Context, output *vm
 			PrivateDomain:   types.StringPointerValue(server.PrivateDomain),
 			PublicDomain:    types.StringPointerValue(server.PublicDomain),
 			ReplicaSetName:  types.StringPointerValue(server.ReplicaSetName),
-			MemorySize:      types.Int64Value(*server.MemorySize),
-			CpuCount:        types.Int64Value(*server.CpuCount),
-			DataStorageSize: types.Int64Value(*server.DataStorageSize),
+			MemorySize:      types.Int64PointerValue(server.MemorySize),
+			CpuCount:        types.Int64PointerValue(server.CpuCount),
+			DataStorageSize: types.Int64PointerValue(server.DataStorageSize),
 			Uptime:          types.StringPointerValue(server.Uptime),
 			CreateDate:      types.StringPointerValue(server.CreateDate),
 		}
@@ -1027,13 +1026,4 @@ func (m *mongodbResourceModel) refreshFromOutput(ctx context.Context, output *vm
 
 	m.MongoDbServerList = mongoServers
 
-}
-
-func int32PointerValue(value *int32) basetypes.Int64Value {
-	if value == nil {
-		return basetypes.NewInt64Null()
-	}
-	newVal := int64(*value)
-
-	return basetypes.NewInt64Value(newVal)
 }

--- a/internal/service/mongodb/mongodb_data_source.go
+++ b/internal/service/mongodb/mongodb_data_source.go
@@ -303,14 +303,14 @@ func (m *mongodbDataSourceModel) refreshFromOutput(ctx context.Context, output *
 	m.ClusterTypeCode = types.StringPointerValue(output.ClusterType.Code)
 	m.EngineVersion = types.StringPointerValue(output.EngineVersion)
 	m.ImageProductCode = types.StringPointerValue(output.CloudMongoDbImageProductCode)
-	m.BackupFileRetentionPeriod = int32PointerValue(output.BackupFileRetentionPeriod)
+	m.BackupFileRetentionPeriod = common.Int64ValueFromInt32(output.BackupFileRetentionPeriod)
 	m.BackupTime = types.StringPointerValue(output.BackupTime)
-	m.ShardCount = int32PointerValue(output.ShardCount)
+	m.ShardCount = common.Int64ValueFromInt32(output.ShardCount)
 	m.DataStorageType = types.StringPointerValue(output.CloudMongoDbServerInstanceList[0].DataStorageType.Code)
-	m.MemberPort = int32PointerValue(output.MemberPort)
-	m.ArbiterPort = int32PointerValue(output.ArbiterPort)
-	m.MongosPort = int32PointerValue(output.MongosPort)
-	m.ConfigPort = int32PointerValue(output.ConfigPort)
+	m.MemberPort = common.Int64ValueFromInt32(output.MemberPort)
+	m.ArbiterPort = common.Int64ValueFromInt32(output.ArbiterPort)
+	m.MongosPort = common.Int64ValueFromInt32(output.MongosPort)
+	m.ConfigPort = common.Int64ValueFromInt32(output.ConfigPort)
 	m.CompressCode = types.StringPointerValue(output.Compress.Code)
 	m.RegionCode = types.StringPointerValue(output.CloudMongoDbServerInstanceList[0].RegionCode)
 	m.ZoneCode = types.StringPointerValue(output.CloudMongoDbServerInstanceList[0].ZoneCode)
@@ -329,9 +329,9 @@ func (m *mongodbDataSourceModel) refreshFromOutput(ctx context.Context, output *
 			PrivateDomain:   types.StringPointerValue(server.PrivateDomain),
 			PublicDomain:    types.StringPointerValue(server.PublicDomain),
 			ReplicaSetName:  types.StringPointerValue(server.ReplicaSetName),
-			MemorySize:      types.Int64Value(*server.MemorySize),
-			CpuCount:        types.Int64Value(*server.CpuCount),
-			DataStorageSize: types.Int64Value(*server.DataStorageSize),
+			MemorySize:      types.Int64PointerValue(server.MemorySize),
+			CpuCount:        types.Int64PointerValue(server.CpuCount),
+			DataStorageSize: types.Int64PointerValue(server.DataStorageSize),
 			Uptime:          types.StringPointerValue(server.Uptime),
 			CreateDate:      types.StringPointerValue(server.CreateDate),
 		}

--- a/internal/service/mongodb/mongodb_products_data_source.go
+++ b/internal/service/mongodb/mongodb_products_data_source.go
@@ -255,7 +255,7 @@ func (m *mongodbProductModel) refreshFromOutput(ctx context.Context, output *vmo
 	m.ProductDescription = types.StringPointerValue(output.ProductDescription)
 	m.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
 	m.InfraResourceDetailType = types.StringPointerValue(output.InfraResourceDetailType.Code)
-	m.CpuCount = types.Int64Value(int64(*output.CpuCount))
-	m.MemorySize = types.Int64Value(int64(*output.MemorySize))
+	m.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
+	m.MemorySize = types.Int64PointerValue(output.MemorySize)
 	m.DiskType = types.StringPointerValue(output.DiskType.Code)
 }

--- a/internal/service/mssql/mssql.go
+++ b/internal/service/mssql/mssql.go
@@ -626,10 +626,10 @@ func (m *mssqlResourceModel) refreshFromOutput(ctx context.Context, output *vmss
 	m.ImageProductCode = types.StringPointerValue(output.CloudMssqlImageProductCode)
 	m.DataStorageTypeCode = types.StringPointerValue(output.CloudMssqlServerInstanceList[0].DataStorageType.Code)
 	m.IsHa = types.BoolPointerValue(output.IsHa)
-	m.BackupFileRetentionPeriod = types.Int64Value(int64(*output.BackupFileRetentionPeriod))
+	m.BackupFileRetentionPeriod = common.Int64ValueFromInt32(output.BackupFileRetentionPeriod)
 	m.BackupTime = types.StringPointerValue(output.BackupTime)
 	m.ConfigGroupNo = types.StringPointerValue(output.ConfigGroupNo)
-	m.Port = types.Int64Value(int64(*output.CloudMssqlPort))
+	m.Port = common.Int64ValueFromInt32(output.CloudMssqlPort)
 	m.EngineVersion = types.StringPointerValue(output.EngineVersion)
 	m.CharacterSetName = types.StringPointerValue(output.DbCollation)
 	m.RegionCode = types.StringPointerValue(output.CloudMssqlServerInstanceList[0].RegionCode)
@@ -649,9 +649,9 @@ func (m *mssqlResourceModel) refreshFromOutput(ctx context.Context, output *vmss
 			ProductCode:      types.StringPointerValue(server.CloudMssqlProductCode),
 			IsPublicSubnet:   types.BoolPointerValue(server.IsPublicSubnet),
 			PrivateDomain:    types.StringPointerValue(server.PrivateDomain),
-			DataStorageSize:  types.Int64Value(*server.DataStorageSize),
-			CpuCount:         types.Int64Value(int64(*server.CpuCount)),
-			MemorySize:       types.Int64Value(*server.MemorySize),
+			DataStorageSize:  types.Int64PointerValue(server.DataStorageSize),
+			CpuCount:         common.Int64ValueFromInt32(server.CpuCount),
+			MemorySize:       types.Int64PointerValue(server.MemorySize),
 			Uptime:           types.StringPointerValue(server.Uptime),
 			CreateDate:       types.StringPointerValue(server.CreateDate),
 		}
@@ -661,7 +661,7 @@ func (m *mssqlResourceModel) refreshFromOutput(ctx context.Context, output *vmss
 		}
 
 		if server.UsedDataStorageSize != nil {
-			mssqlServerInstance.UsedDataStorageSize = types.Int64Value(*server.UsedDataStorageSize)
+			mssqlServerInstance.UsedDataStorageSize = types.Int64PointerValue(server.UsedDataStorageSize)
 		}
 		serverList = append(serverList, mssqlServerInstance)
 	}

--- a/internal/service/mssql/mssql_data_source.go
+++ b/internal/service/mssql/mssql_data_source.go
@@ -289,10 +289,10 @@ func (m *mssqlDataSourceModel) refreshFromOutput(ctx context.Context, output *vm
 	m.ImageProductCode = types.StringPointerValue(output.CloudMssqlImageProductCode)
 	m.DataStorageTypeCode = types.StringPointerValue(output.CloudMssqlServerInstanceList[0].DataStorageType.Code)
 	m.IsHa = types.BoolPointerValue(output.IsHa)
-	m.BackupFileRetentionPeriod = types.Int64Value(int64(*output.BackupFileRetentionPeriod))
+	m.BackupFileRetentionPeriod = common.Int64ValueFromInt32(output.BackupFileRetentionPeriod)
 	m.BackupTime = types.StringPointerValue(output.BackupTime)
 	m.ConfigGroupNo = types.StringPointerValue(output.ConfigGroupNo)
-	m.Port = types.Int64Value(int64(*output.CloudMssqlPort))
+	m.Port = common.Int64ValueFromInt32(output.CloudMssqlPort)
 	m.EngineVersion = types.StringPointerValue(output.EngineVersion)
 	m.CharacterSetName = types.StringPointerValue(output.DbCollation)
 	m.RegionCode = types.StringPointerValue(output.CloudMssqlServerInstanceList[0].RegionCode)
@@ -312,9 +312,9 @@ func (m *mssqlDataSourceModel) refreshFromOutput(ctx context.Context, output *vm
 			ProductCode:      types.StringPointerValue(server.CloudMssqlProductCode),
 			IsPublicSubnet:   types.BoolPointerValue(server.IsPublicSubnet),
 			PrivateDomain:    types.StringPointerValue(server.PrivateDomain),
-			DataStorageSize:  types.Int64Value(*server.DataStorageSize),
-			CpuCount:         types.Int64Value(int64(*server.CpuCount)),
-			MemorySize:       types.Int64Value(*server.MemorySize),
+			DataStorageSize:  types.Int64PointerValue(server.DataStorageSize),
+			CpuCount:         common.Int64ValueFromInt32(server.CpuCount),
+			MemorySize:       types.Int64PointerValue(server.MemorySize),
 			Uptime:           types.StringPointerValue(server.Uptime),
 			CreateDate:       types.StringPointerValue(server.CreateDate),
 		}
@@ -324,7 +324,7 @@ func (m *mssqlDataSourceModel) refreshFromOutput(ctx context.Context, output *vm
 		}
 
 		if server.UsedDataStorageSize != nil {
-			mssqlServerInstance.UsedDataStorageSize = types.Int64Value(*server.UsedDataStorageSize)
+			mssqlServerInstance.UsedDataStorageSize = types.Int64PointerValue(server.UsedDataStorageSize)
 		}
 		serverList = append(serverList, mssqlServerInstance)
 	}

--- a/internal/service/mssql/mssql_products_data_source.go
+++ b/internal/service/mssql/mssql_products_data_source.go
@@ -232,7 +232,7 @@ func (m *mssqlProductModel) refreshFromOutput(output *vmssql.Product) {
 	m.ProductType = types.StringPointerValue(output.ProductType.Code)
 	m.ProductDescription = types.StringPointerValue(output.ProductDescription)
 	m.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
-	m.CpuCount = types.Int64Value(int64(*output.CpuCount))
+	m.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
 	m.MemorySize = types.Int64PointerValue(output.MemorySize)
 	m.DiskType = types.StringPointerValue(output.DiskType.Code)
 }

--- a/internal/service/mysql/mysql.go
+++ b/internal/service/mysql/mysql.go
@@ -747,9 +747,9 @@ func (m *mysqlResourceModel) refreshFromOutput(ctx context.Context, output *vmys
 	m.IsMultiZone = types.BoolPointerValue(output.IsMultiZone)
 	m.IsStorageEncryption = types.BoolPointerValue(output.CloudMysqlServerInstanceList[0].IsStorageEncryption)
 	m.IsBackup = types.BoolPointerValue(output.IsBackup)
-	m.BackupFileRetentionPeriod = types.Int64Value(int64(*output.BackupFileRetentionPeriod))
+	m.BackupFileRetentionPeriod = common.Int64ValueFromInt32(output.BackupFileRetentionPeriod)
 	m.BackupTime = types.StringPointerValue(output.BackupTime)
-	m.Port = types.Int64Value(int64(*output.CloudMysqlPort))
+	m.Port = common.Int64ValueFromInt32(output.CloudMysqlPort)
 	m.EngineVersionCode = types.StringPointerValue(output.EngineVersion)
 	m.RegionCode = types.StringPointerValue(output.CloudMysqlServerInstanceList[0].RegionCode)
 	m.VpcNo = types.StringPointerValue(output.CloudMysqlServerInstanceList[0].VpcNo)
@@ -770,9 +770,9 @@ func (m *mysqlResourceModel) refreshFromOutput(ctx context.Context, output *vmys
 			ProductCode:      types.StringPointerValue(server.CloudMysqlProductCode),
 			IsPublicSubnet:   types.BoolPointerValue(server.IsPublicSubnet),
 			PrivateDomain:    types.StringPointerValue(server.PrivateDomain),
-			DataStorageSize:  types.Int64Value(*server.DataStorageSize),
-			CpuCount:         types.Int64Value(int64(*server.CpuCount)),
-			MemorySize:       types.Int64Value(*server.MemorySize),
+			DataStorageSize:  types.Int64PointerValue(server.DataStorageSize),
+			CpuCount:         common.Int64ValueFromInt32(server.CpuCount),
+			MemorySize:       types.Int64PointerValue(server.MemorySize),
 			Uptime:           types.StringPointerValue(server.Uptime),
 			CreateDate:       types.StringPointerValue(server.CreateDate),
 		}
@@ -782,7 +782,7 @@ func (m *mysqlResourceModel) refreshFromOutput(ctx context.Context, output *vmys
 		}
 
 		if server.UsedDataStorageSize != nil {
-			mysqlServerInstance.UsedDataStorageSize = types.Int64Value(*server.UsedDataStorageSize)
+			mysqlServerInstance.UsedDataStorageSize = types.Int64PointerValue(server.UsedDataStorageSize)
 		}
 		serverList = append(serverList, mysqlServerInstance)
 	}

--- a/internal/service/mysql/mysql_data_source.go
+++ b/internal/service/mysql/mysql_data_source.go
@@ -301,9 +301,9 @@ func (m *mysqlDataSourceModel) refreshFromOutput(ctx context.Context, output *vm
 	m.IsMultiZone = types.BoolPointerValue(output.IsMultiZone)
 	m.IsStorageEncryption = types.BoolPointerValue(output.CloudMysqlServerInstanceList[0].IsStorageEncryption)
 	m.IsBackup = types.BoolPointerValue(output.IsBackup)
-	m.BackupFileRetentionPeriod = types.Int64Value(int64(*output.BackupFileRetentionPeriod))
+	m.BackupFileRetentionPeriod = common.Int64ValueFromInt32(output.BackupFileRetentionPeriod)
 	m.BackupTime = types.StringPointerValue(output.BackupTime)
-	m.Port = types.Int64Value(int64(*output.CloudMysqlPort))
+	m.Port = common.Int64ValueFromInt32(output.CloudMysqlPort)
 	m.EngineVersionCode = types.StringPointerValue(output.EngineVersion)
 	m.RegionCode = types.StringPointerValue(output.CloudMysqlServerInstanceList[0].RegionCode)
 	m.VpcNo = types.StringPointerValue(output.CloudMysqlServerInstanceList[0].VpcNo)
@@ -324,9 +324,9 @@ func (m *mysqlDataSourceModel) refreshFromOutput(ctx context.Context, output *vm
 			ProductCode:      types.StringPointerValue(server.CloudMysqlProductCode),
 			IsPublicSubnet:   types.BoolPointerValue(server.IsPublicSubnet),
 			PrivateDomain:    types.StringPointerValue(server.PrivateDomain),
-			DataStorageSize:  types.Int64Value(*server.DataStorageSize),
-			CpuCount:         types.Int64Value(int64(*server.CpuCount)),
-			MemorySize:       types.Int64Value(*server.MemorySize),
+			DataStorageSize:  types.Int64PointerValue(server.DataStorageSize),
+			CpuCount:         common.Int64ValueFromInt32(server.CpuCount),
+			MemorySize:       types.Int64PointerValue(server.MemorySize),
 			Uptime:           types.StringPointerValue(server.Uptime),
 			CreateDate:       types.StringPointerValue(server.CreateDate),
 		}
@@ -336,7 +336,7 @@ func (m *mysqlDataSourceModel) refreshFromOutput(ctx context.Context, output *vm
 		}
 
 		if server.UsedDataStorageSize != nil {
-			mysqlServerInstance.UsedDataStorageSize = types.Int64Value(*server.UsedDataStorageSize)
+			mysqlServerInstance.UsedDataStorageSize = types.Int64PointerValue(server.UsedDataStorageSize)
 		}
 		serverList = append(serverList, mysqlServerInstance)
 	}

--- a/internal/service/mysql/mysql_products_data_source.go
+++ b/internal/service/mysql/mysql_products_data_source.go
@@ -232,7 +232,7 @@ func (m *mysqlProductModel) refreshFromOutput(output *vmysql.Product) {
 	m.ProductType = types.StringPointerValue(output.ProductType.Code)
 	m.ProductDescription = types.StringPointerValue(output.ProductDescription)
 	m.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
-	m.CpuCount = types.Int64Value(int64(*output.CpuCount))
+	m.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
 	m.MemorySize = types.Int64PointerValue(output.MemorySize)
 	m.DiskType = types.StringPointerValue(output.DiskType.Code)
 }

--- a/internal/service/redis/redis.go
+++ b/internal/service/redis/redis.go
@@ -689,11 +689,11 @@ func (r *redisResourceModel) refreshFromOutput(ctx context.Context, output *vred
 	r.RegionCode = types.StringPointerValue(output.CloudRedisServerInstanceList[0].RegionCode)
 
 	if output.BackupFileRetentionPeriod != nil {
-		r.BackupFileRetentionPeriod = types.Int64Value(int64(*output.BackupFileRetentionPeriod))
+		r.BackupFileRetentionPeriod = common.Int64ValueFromInt32(output.BackupFileRetentionPeriod)
 	}
 
 	if output.CloudRedisPort != nil {
-		r.Port = types.Int64Value(int64(*output.CloudRedisPort))
+		r.Port = common.Int64ValueFromInt32(output.CloudRedisPort)
 	}
 
 	acgList, _ := types.ListValueFrom(ctx, types.StringType, output.AccessControlGroupNoList)
@@ -706,8 +706,8 @@ func (r *redisResourceModel) refreshFromOutput(ctx context.Context, output *vred
 			RedisServerName: types.StringPointerValue(server.CloudRedisServerName),
 			RedisServerRole: types.StringPointerValue(server.CloudRedisServerRole.CodeName),
 			PrivateDomain:   types.StringPointerValue(server.PrivateDomain),
-			MemorySize:      types.Int64Value(*server.MemorySize),
-			OsMemorySize:    types.Int64Value(*server.OsMemorySize),
+			MemorySize:      types.Int64PointerValue(server.MemorySize),
+			OsMemorySize:    types.Int64PointerValue(server.OsMemorySize),
 			Uptime:          types.StringPointerValue(server.Uptime),
 			CreateDate:      types.StringPointerValue(server.CreateDate),
 		}

--- a/internal/service/redis/redis_data_source.go
+++ b/internal/service/redis/redis_data_source.go
@@ -279,11 +279,11 @@ func (r *redisDataSourceModel) refreshFromOutput(ctx context.Context, output *vr
 	r.RegionCode = types.StringPointerValue(output.CloudRedisServerInstanceList[0].RegionCode)
 
 	if output.BackupFileRetentionPeriod != nil {
-		r.BackupFileRetentionPeriod = types.Int64Value(int64(*output.BackupFileRetentionPeriod))
+		r.BackupFileRetentionPeriod = common.Int64ValueFromInt32(output.BackupFileRetentionPeriod)
 	}
 
 	if output.CloudRedisPort != nil {
-		r.Port = types.Int64Value(int64(*output.CloudRedisPort))
+		r.Port = common.Int64ValueFromInt32(output.CloudRedisPort)
 	}
 
 	acgList, _ := types.ListValueFrom(ctx, types.StringType, output.AccessControlGroupNoList)
@@ -296,8 +296,8 @@ func (r *redisDataSourceModel) refreshFromOutput(ctx context.Context, output *vr
 			RedisServerName: types.StringPointerValue(server.CloudRedisServerName),
 			RedisServerRole: types.StringPointerValue(server.CloudRedisServerRole.CodeName),
 			PrivateDomain:   types.StringPointerValue(server.PrivateDomain),
-			MemorySize:      types.Int64Value(*server.MemorySize),
-			OsMemorySize:    types.Int64Value(*server.OsMemorySize),
+			MemorySize:      types.Int64PointerValue(server.MemorySize),
+			OsMemorySize:    types.Int64PointerValue(server.OsMemorySize),
 			Uptime:          types.StringPointerValue(server.Uptime),
 			CreateDate:      types.StringPointerValue(server.CreateDate),
 		}

--- a/internal/service/redis/redis_products_data_source.go
+++ b/internal/service/redis/redis_products_data_source.go
@@ -234,7 +234,7 @@ func (r *redisProductModel) refreshFromOutput(output *vredis.Product) {
 	r.ProductType = types.StringPointerValue(output.ProductType.Code)
 	r.ProductDescription = types.StringPointerValue(output.ProductDescription)
 	r.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
-	r.CpuCount = types.Int64Value(int64(*output.CpuCount))
+	r.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
 	r.MemorySize = types.Int64PointerValue(output.MemorySize)
 	r.DiskType = types.StringPointerValue(output.DiskType.Code)
 }


### PR DESCRIPTION
# Description
- When the response of an API request is of type int32 pointer, it can cause panic by dereferencing a nil pointer while casting to type int64. So it improves to use the int64 type provided by the framework to prevent nil dereferencing in Cloud DB resources