### PR TITLE
fix(MySQL): Fix incorrect resource diff 

### DIFF
--- a/internal/service/mysql/mysql.go
+++ b/internal/service/mysql/mysql.go
@@ -174,6 +174,7 @@ func (m *mysqlResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Computed: true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.RequiresReplace(),
+					boolplanmodifier.UseStateForUnknown(),
 				},
 				Description: "default: false",
 			},
@@ -182,6 +183,7 @@ func (m *mysqlResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Computed: true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.RequiresReplace(),
+					boolplanmodifier.UseStateForUnknown(),
 				},
 				Description: "default: false",
 			},

--- a/internal/service/mysql/mysql.go
+++ b/internal/service/mysql/mysql.go
@@ -486,6 +486,15 @@ func (r *mysqlResource) Create(ctx context.Context, req resource.CreateRequest, 
 			}
 			reqParams.BackupTime = plan.BackupTime.ValueStringPointer()
 		}
+	} else {
+		backupTimeHasValue := !plan.BackupTime.IsNull() && !plan.BackupTime.IsUnknown()
+		if reqParams.IsAutomaticBackup != nil || backupTimeHasValue {
+			resp.Diagnostics.AddError(
+				"CREATING ERROR",
+				"`is_automatic_backup` or `backup_time` should not be specified when `is_backup` has enabled",
+			)
+			return
+		}
 	}
 
 	tflog.Info(ctx, "CreateMysql reqParams="+common.MarshalUncheckedString(reqParams))


### PR DESCRIPTION
# Description
- When `is_backup` is not enabled, the values `backup_time` and `is_automatic_backup` are unnecessary. If the user enters these values, an error could occur due to the state mismatch, so prohibit the input in this case.
- Suppress unnecessary diff on `is_multi_zone` and `is_storage_encryption` attribute