### PR TITLE
feat(lb): Restrict throughput_type value for Network Load Balancer

### DIFF
--- a/docs/resources/lb.md
+++ b/docs/resources/lb.md
@@ -10,7 +10,8 @@ Provides a Load Balancer resource.
 ~> **NOTE:** This resource only supports VPC environment.
 
 ## Example Usage
-```hcl
+
+```terraform
 resource "ncloud_lb" "test" {
   name = "tf-lb-test"
   network_type = "PUBLIC"
@@ -24,12 +25,12 @@ resource "ncloud_lb" "test" {
 The following arguments are supported:
 
 * `name` - (Optional) The name of the load balancer.
-* `description` - (Optional) The description of the load balancer.
+* `type` - (Required) The type of load balancer to create. Accepted values: `APPLICATION` | `NETWORK` | `NETWORK_PROXY`.
+* `subnet_no_list` - (Required) A list of IDs in the associated Subnets.
 * `network_type` - (Optional) The network type of load balancer to create. Accepted values: `PUBLIC` | `PRIVATE`. Default: `PUBLIC`.
 * `idle_timeout` - (Optional) The time in seconds that the idle timeout. Valid only if the load balancer type is not `NETWORK`. Default: 60.
-* `type` - (Required) The type of load balancer to create. Accepted values: `APPLICATION` | `NETWORK` | `NETWORK_PROXY`.
-* `throughput_type` - (Optional) The performance type code of load balancer. Accepted values: `SMALL` | `MEDIUM` | `LARGE`. If the load balancer type is `NETWORK` and the load balancer network type is `PRIVATE`, only `SMALL` can be selected. Default: `SMALL`.
-* `subnet_no_list` - (Required) A list of IDs in the associated Subnets.
+* `throughput_type` - (Optional) The performance type code of load balancer. `SMALL` | `MEDIUM` | `LARGE` | `DYNAMIC`. If the `type` is `APPLICATION` or `NETWORK_PROXY` Options : `SMALL` | `MEDIUM` | `LARGE`, Default : `SMALL`. If the `type` is `NETWORK` Options : `DYNAMIC`, Default : `DYNAMIC`.
+* `description` - (Optional) The description of the load balancer.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description
- VPC Load Balancer : Network type only. Application type and network proxy type remain unchanged.
  - AS-IS throughput_type : Small, Medium, Large type supported.
  - TO-BE throughput_type : only Dynamic type support.