### PR TITLE
refactor: Update Error Message to Reflect Resource Instead of DataSource

### DIFF
--- a/internal/service/hadoop/hadoop.go
+++ b/internal/service/hadoop/hadoop.go
@@ -419,7 +419,7 @@ func (r *hadoopResource) Configure(ctx context.Context, req resource.ConfigureRe
 
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
+			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return

--- a/internal/service/mongodb/mongodb.go
+++ b/internal/service/mongodb/mongodb.go
@@ -392,7 +392,7 @@ func (m *mongodbResource) Configure(_ context.Context, req resource.ConfigureReq
 
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
+			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return

--- a/internal/service/mssql/mssql.go
+++ b/internal/service/mssql/mssql.go
@@ -290,7 +290,7 @@ func (r *mssqlResource) Configure(_ context.Context, req resource.ConfigureReque
 
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
+			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return

--- a/internal/service/mysql/mysql.go
+++ b/internal/service/mysql/mysql.go
@@ -336,7 +336,7 @@ func (r *mysqlResource) Configure(_ context.Context, req resource.ConfigureReque
 
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
+			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return

--- a/internal/service/server/init_script.go
+++ b/internal/service/server/init_script.go
@@ -96,7 +96,7 @@ func (i *initScriptResource) Configure(_ context.Context, req resource.Configure
 
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
+			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return

--- a/internal/service/server/login_key.go
+++ b/internal/service/server/login_key.go
@@ -89,7 +89,7 @@ func (l *loginKeyResource) Configure(_ context.Context, req resource.ConfigureRe
 
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
+			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return

--- a/internal/service/vpc/nat_gateway.go
+++ b/internal/service/vpc/nat_gateway.go
@@ -128,7 +128,7 @@ func (n *natGatewayResource) Configure(_ context.Context, req resource.Configure
 
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
+			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return

--- a/internal/service/vpc/subnet.go
+++ b/internal/service/vpc/subnet.go
@@ -122,7 +122,7 @@ func (s *subnetResource) Configure(_ context.Context, req resource.ConfigureRequ
 
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
+			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return

--- a/internal/service/vpc/vpc.go
+++ b/internal/service/vpc/vpc.go
@@ -93,7 +93,7 @@ func (r *vpcResource) Configure(_ context.Context, req resource.ConfigureRequest
 
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
+			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return

--- a/internal/service/vpc/vpc_peering.go
+++ b/internal/service/vpc/vpc_peering.go
@@ -129,7 +129,7 @@ func (v *vpcPeeringResource) Configure(_ context.Context, req resource.Configure
 
 	if !ok {
 		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
+			"Unexpected Resource Configure Type",
 			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return


### PR DESCRIPTION
### Description
Framework로 전환된 일부 리소스 중 Data Source로 에러 메시지에 표시된 부분 수정하였습니다. 

### Related Issue
#432 