### PR TITLE
fix(mysql): Modify to string length for valid schema validators 

### DIFF
--- a/internal/service/mysql/mysql.go
+++ b/internal/service/mysql/mysql.go
@@ -60,7 +60,7 @@ func (m *mysqlResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.LengthBetween(3, 20),
+					stringvalidator.LengthBetween(3, 30),
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^[ㄱ-ㅣ가-힣A-Za-z0-9-]+$`),
 						"Composed of alphabets, numbers, hyphen (-).",
@@ -74,7 +74,7 @@ func (m *mysqlResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.LengthBetween(3, 30),
+					stringvalidator.LengthBetween(3, 20),
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^[a-z]+[a-z0-9-]+[a-z0-9]$`),
 						"Composed of lowercase alphabets, numbers, hyphen (-). Must start with an alphabetic character, and the last character can only be an English letter or number.",


### PR DESCRIPTION
- cloud_mysql_service_name과 cloud_mysql_server_name_prefix Schema 속성의 유효성 검사에서 길이 제한이 바뀌어 있어, api 문서 참고하여 수정하였습니다.

![image](https://github.com/user-attachments/assets/357993c9-a3f8-45cd-8f6f-d11e46a95833)
https://api.ncloud-docs.com/docs/database-vmysql-createcloudmysqlinstance

=== RUN TestAccDataSourceNcloudMysql_vpc_basic
--- PASS: TestAccDataSourceNcloudMysql_vpc_basic (831.88s)
=== RUN TestAccDataSourceNcloudMysqlImageProduct_basic
--- PASS: TestAccDataSourceNcloudMysqlImageProduct_basic (1.59s)
=== RUN TestAccDataSourceNcloudMysqlImageProducts_basic
--- PASS: TestAccDataSourceNcloudMysqlImageProducts_basic (1.36s)
=== RUN TestAccDataSourceNcloudMysqlProduct_basic
--- PASS: TestAccDataSourceNcloudMysqlProduct_basic (1.28s)
=== RUN TestAccDataSourceNcloudMysqlProducts_basic
--- PASS: TestAccDataSourceNcloudMysqlProducts_basic (1.75s)
=== RUN TestAccResourceNcloudMysql_vpc_basic
--- PASS: TestAccResourceNcloudMysql_vpc_basic (255.19s)
=== RUN TestAccResourceNcloudMysql_vpc_isHa
--- PASS: TestAccResourceNcloudMysql_vpc_isHa (869.12s)
=== RUN TestAccResourceNcloudMysql_vpc_isHa_options
--- PASS: TestAccResourceNcloudMysql_vpc_isHa_options (1137.92s)
=== RUN TestAccResourceNcloudMysql_vpc_auto_backup
--- PASS: TestAccResourceNcloudMysql_vpc_auto_backup (611.88s)
=== RUN TestAccResourceNcloudMysql_vpc_not_auto_backup
--- PASS: TestAccResourceNcloudMysql_vpc_not_auto_backup (653.62s)
=== RUN TestAccResourceNcloudMysql_error_case
--- PASS: TestAccResourceNcloudMysql_error_case (49.09s)