### PR TITLE
feat: Add Mysql Recovery Server Resource

### DIFF
--- a/docs/resources/mysql_recovery.md
+++ b/docs/resources/mysql_recovery.md
@@ -4,7 +4,7 @@ subcategory: "MySQL"
 
 # Resource: ncloud_mysql_recovery
 
-Provides a MySQL instance resource.
+Provides a MySQL recovery resource.
  
 ~> **NOTE:** This resource only supports VPC environment.
 

--- a/docs/resources/mysql_recovery.md
+++ b/docs/resources/mysql_recovery.md
@@ -1,0 +1,79 @@
+---
+subcategory: "MySQL"
+---
+
+# Resource: ncloud_mysql_recovery
+
+Provides a MySQL instance resource.
+ 
+~> **NOTE:** This resource only supports VPC environment.
+
+## Example Usage
+
+```terraform
+resource "ncloud_vpc" "test_vpc" {
+	name             = "%[1]s"
+	ipv4_cidr_block  = "10.5.0.0/16"
+}
+
+resource "ncloud_subnet" "test_subnet" {
+	vpc_no             = ncloud_vpc.test_vpc.vpc_no
+	name               = "%[1]s"
+	subnet             = "10.5.0.0/24"
+	zone               = "KR-2"
+	network_acl_no     = ncloud_vpc.test_vpc.default_network_acl_no
+	subnet_type        = "PUBLIC"
+}
+
+resource "ncloud_mysql" "mysql" {
+	subnet_no = data.ncloud_subnet.test_subnet.id
+	service_name = "%[1]s"
+	server_name_prefix = "testprefix"
+	user_name = "testusername"
+	user_password = "t123456789!a"
+	host_ip = "192.168.0.1"
+	database_name = "test_db"
+}
+
+resource "ncloud_mysql_recovery" "mysql_recovery" {
+	mysql_instance_no = ncloud_mysql.mysql.id
+	recovery_server_name = "test-recovery"
+	file_name = "20210722"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `mysql_instance_no` - (Required) the ID of the associated Mysql Instance.
+* `subnet_no` - (Optional, Required if `is_multi_zone` of MySQL Instance is true) The ID of the associate Subnet.
+* `recovery_server_name` (Required) Recovery server name to create. In order to prevent overlapping host names, random text is added. Can comprise only lower-case English alphabets, numbers and dash ( - ). The first letter must be an English alphabet and the last letter must be an English alphabet or a number. Min: 3, Max: 25
+* `file_name` - (Optional, One of `file_name` and `recovery_time` is required) The name of backup file. If you enter `file_name`, ignore the entry of `recovery_time`. 
+* `recovery_time` - (Optional, One of `file_name` and `recovery_time` is required) The time of recovery. If you enter `recovery_time`, ignore the entry of `file_name`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported
+
+* `id` - MySQL Recovery Server Instance Number.
+
+# Import
+
+### `terraform import` command
+
+* MySQL Recovery can be imported using the `id`. For example:
+```console
+$ terraform import ncloud_mysql_recovery.rsc_name 12345
+```
+
+### `import` block
+
+* In terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import MySQL Recovery using the `id`. For example:
+
+```terraform
+import {
+    to = ncloud_mysql_recovery.rsc_name
+    id = "12345"
+}
+```

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -122,6 +122,7 @@ func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 	resources = append(resources, server.NewLoginKeyResource)
 	resources = append(resources, server.NewInitScriptResource)
 	resources = append(resources, mysql.NewMysqlResource)
+	resources = append(resources, mysql.NewMysqlRecoveryResource)
 	resources = append(resources, mongodb.NewMongoDbResource)
 	resources = append(resources, hadoop.NewHadoopResource)
 	resources = append(resources, redis.NewRedisConfigGroupResource)

--- a/internal/service/mysql/mysql_recovery.go
+++ b/internal/service/mysql/mysql_recovery.go
@@ -1,0 +1,374 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vmysql"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/common"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/framework"
+)
+
+var (
+	_ resource.Resource                = &mysqlRecoveryResource{}
+	_ resource.ResourceWithConfigure   = &mysqlRecoveryResource{}
+	_ resource.ResourceWithImportState = &mysqlRecoveryResource{}
+)
+
+func NewMysqlRecoveryResource() resource.Resource {
+	return &mysqlRecoveryResource{}
+}
+
+type mysqlRecoveryResource struct {
+	config *conn.ProviderConfig
+}
+
+func (r *mysqlRecoveryResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *mysqlRecoveryResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	config, ok := req.ProviderData.(*conn.ProviderConfig)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *ProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.config = config
+}
+
+func (r *mysqlRecoveryResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_mysql_recovery"
+}
+
+func (r *mysqlRecoveryResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": framework.IDAttribute(),
+			"mysql_instance_no": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"subnet_no": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"recovery_server_name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(3, 25),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-z]+[a-z0-9-]+[a-z0-9]$`),
+						"Composed of lowercase alphabets, numbers, hyphen (-). Must start with an alphabetic character, and the last character can only be an English letter or number.",
+					),
+				},
+			},
+			"file_name": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.AtLeastOneOf(path.Expressions{
+						path.MatchRoot("recovery_time"),
+					}...),
+				},
+			},
+			"recovery_time": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *mysqlRecoveryResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan mysqlRecoveryResourceModel
+
+	if !r.config.SupportVPC {
+		resp.Diagnostics.AddError(
+			"NOT SUPPORT CLASSIC",
+			"resource does not support CLASSIC. only VPC.",
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	reqParams := &vmysql.CreateCloudMysqlRecoveryInstanceRequest{
+		RegionCode:                   &r.config.RegionCode,
+		CloudMysqlInstanceNo:         plan.MysqlInstanceNo.ValueStringPointer(),
+		CloudMysqlRecoveryServerName: plan.MysqlRecoveryServerName.ValueStringPointer(),
+	}
+
+	if !plan.FileName.IsNull() {
+		reqParams.FileName = plan.FileName.ValueStringPointer()
+	}
+
+	if !plan.RecoveryTime.IsNull() {
+		reqParams.RecoveryTime = plan.RecoveryTime.ValueStringPointer()
+	}
+
+	tflog.Info(ctx, "CreateCloudMysqlRecovery reqParams="+common.MarshalUncheckedString(reqParams))
+
+	response, err := r.config.Client.Vmysql.V2Api.CreateCloudMysqlRecoveryInstance(reqParams)
+	if err != nil {
+		resp.Diagnostics.AddError("CREATING ERROR", err.Error())
+		return
+	}
+
+	if response == nil || len(response.CloudMysqlInstanceList) < 1 {
+		resp.Diagnostics.AddError("CREATING ERROR", "response valid")
+		return
+	}
+
+	mysqlIns := response.CloudMysqlInstanceList[0]
+	serverList := mysqlIns.CloudMysqlServerInstanceList
+
+	if *mysqlIns.IsMultiZone {
+		if !plan.SubnetNo.IsNull() {
+			reqParams.SubnetNo = plan.SubnetNo.ValueStringPointer()
+		} else {
+			resp.Diagnostics.AddError(
+				"CREATING ERROR",
+				"when `is_multi_zone` is true, SubnetNo should be set",
+			)
+		}
+	}
+
+	if len(serverList) < 2 {
+		resp.Diagnostics.AddError("CREATING ERROR", "response invalid")
+		return
+	}
+
+	recoveryServer, err := GetMysqlRecovery(ctx, r.config, plan.MysqlInstanceNo.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("READ ERROR", err.Error())
+		return
+	}
+
+	plan.ID = types.StringPointerValue(recoveryServer.CloudMysqlServerInstanceNo)
+
+	output, err := waitMysqlRecoveryCreation(ctx, r.config, *mysqlIns.CloudMysqlInstanceNo)
+	if err != nil {
+		resp.Diagnostics.AddError("WAITING FOR CREATION ERROR", err.Error())
+		return
+	}
+
+	plan.refreshFromOutput(output, plan.MysqlInstanceNo.ValueStringPointer())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *mysqlRecoveryResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state mysqlRecoveryResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	output, err := GetMysqlRecovery(ctx, r.config, state.MysqlInstanceNo.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("READING ERROR", err.Error())
+		return
+	}
+
+	if output == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.refreshFromOutput(output, state.MysqlInstanceNo.ValueStringPointer())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *mysqlRecoveryResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
+}
+
+func (r *mysqlRecoveryResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state mysqlRecoveryResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	reqParams := &vmysql.DeleteCloudMysqlServerInstanceRequest{
+		RegionCode:                 &r.config.RegionCode,
+		CloudMysqlServerInstanceNo: state.ID.ValueStringPointer(),
+	}
+	tflog.Info(ctx, "DeleteMysqlRecovery reqParams="+common.MarshalUncheckedString(reqParams))
+
+	response, err := r.config.Client.Vmysql.V2Api.DeleteCloudMysqlServerInstance(reqParams)
+	if err != nil {
+		resp.Diagnostics.AddError("DELETING ERROR", err.Error())
+		return
+	}
+
+	tflog.Info(ctx, "DeleteMysqlRecovery response="+common.MarshalUncheckedString(response))
+
+	if err := waitMysqlRecoveryDeletion(ctx, r.config, state.MysqlInstanceNo.ValueString()); err != nil {
+		resp.Diagnostics.AddError("WAITING FOR DELETE ERROR", err.Error())
+	}
+}
+
+func waitMysqlRecoveryCreation(ctx context.Context, config *conn.ProviderConfig, id string) (*vmysql.CloudMysqlServerInstance, error) {
+	var mysqlInstance *vmysql.CloudMysqlServerInstance
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"creating", "settingUp"},
+		Target:  []string{"running"},
+		Refresh: func() (interface{}, string, error) {
+			instance, err := GetMysqlRecovery(ctx, config, id)
+			mysqlInstance = instance
+			if err != nil {
+				return 0, "", err
+			}
+
+			status := instance.CloudMysqlServerInstanceStatusName
+			if *status == "creating" {
+				return instance, "creating", nil
+			}
+
+			if *status == "settingUp" {
+				return instance, "settingUp", nil
+			}
+
+			if *status == "running" {
+				return instance, "running", nil
+			}
+
+			return 0, "", fmt.Errorf("error occurred while waiting to create mysql recovery")
+		},
+		Timeout:    6 * conn.DefaultCreateTimeout,
+		Delay:      2 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for mysql recovery state to be \"running\": %s", err)
+	}
+
+	return mysqlInstance, nil
+}
+
+func waitMysqlRecoveryDeletion(ctx context.Context, config *conn.ProviderConfig, id string) error {
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{"deleting"},
+		Target:  []string{"deleted"},
+		Refresh: func() (interface{}, string, error) {
+			instance, err := GetMysqlRecovery(ctx, config, id)
+			if err != nil {
+				return 0, "", err
+			}
+
+			if instance == nil {
+				return instance, "deleted", nil
+			}
+
+			status := instance.CloudMysqlServerInstanceStatusName
+
+			if *status == "deleting" {
+				return instance, "deleting", nil
+			}
+
+			if *status == "deleted" {
+				return instance, "deleted", nil
+			}
+
+			return 0, "", fmt.Errorf("error occurred while waiting to delete mysql recovery")
+		},
+		Timeout:    conn.DefaultTimeout,
+		Delay:      2 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for mysql recovery (%s) to become terminating: %s", id, err)
+	}
+
+	return nil
+}
+
+func GetMysqlRecovery(ctx context.Context, config *conn.ProviderConfig, no string) (*vmysql.CloudMysqlServerInstance, error) {
+	reqParams := &vmysql.GetCloudMysqlInstanceDetailRequest{
+		RegionCode:           &config.RegionCode,
+		CloudMysqlInstanceNo: ncloud.String(no),
+	}
+	tflog.Info(ctx, "GetMysqlDetail reqParams="+common.MarshalUncheckedString(reqParams))
+
+	resp, err := config.Client.Vmysql.V2Api.GetCloudMysqlInstanceDetail(reqParams)
+	if err != nil && !(strings.Contains(err.Error(), `"returnCode": "5001017"`)) {
+		return nil, err
+	}
+	tflog.Info(ctx, "GetMysqlDetail response="+common.MarshalUncheckedString(resp))
+
+	if resp == nil || len(resp.CloudMysqlInstanceList) < 1 {
+		return nil, nil
+	}
+
+	serverList := resp.CloudMysqlInstanceList[0].CloudMysqlServerInstanceList
+
+	for _, server := range serverList {
+		if *server.CloudMysqlServerRole.CodeName == "Recovery" {
+			return server, nil
+		}
+	}
+	return nil, nil
+}
+
+type mysqlRecoveryResourceModel struct {
+	ID                      types.String `tfsdk:"id"`
+	MysqlInstanceNo         types.String `tfsdk:"mysql_instance_no"`
+	SubnetNo                types.String `tfsdk:"subnet_no"`
+	MysqlRecoveryServerName types.String `tfsdk:"recovery_server_name"`
+	FileName                types.String `tfsdk:"file_name"`
+	RecoveryTime            types.String `tfsdk:"recovery_time"`
+}
+
+func (r *mysqlRecoveryResourceModel) refreshFromOutput(output *vmysql.CloudMysqlServerInstance, id *string) {
+	r.ID = types.StringPointerValue(output.CloudMysqlServerInstanceNo)
+	r.MysqlInstanceNo = types.StringPointerValue(id)
+	r.SubnetNo = types.StringPointerValue(output.SubnetNo)
+}

--- a/internal/service/mysql/mysql_recovery_test.go
+++ b/internal/service/mysql/mysql_recovery_test.go
@@ -1,0 +1,113 @@
+package mysql_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vmysql"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	. "github.com/terraform-providers/terraform-provider-ncloud/internal/acctest"
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
+	mysqlservice "github.com/terraform-providers/terraform-provider-ncloud/internal/service/mysql"
+)
+
+func TestAccResourceNcloudMysqlRecovery_vpc_basic(t *testing.T) {
+	var mysqlSErverInstance vmysql.CloudMysqlServerInstance
+	testName := fmt.Sprintf("tf-mysqlsv-%s", acctest.RandString(5))
+	resourceName := "ncloud_mysql_recovery.mysql_recovery"
+	testDate := "20240920"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMysqlRecoveryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMysqlRecoveryConfig(testName, testDate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMysqlRecoveryExists(resourceName, &mysqlSErverInstance, GetTestProvider(true)),
+					resource.TestCheckResourceAttrSet(resourceName, "mysql_instance_no"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMysqlRecoveryConfig(testName string, testDate string) string {
+	return fmt.Sprintf(`
+data "ncloud_vpc" "test_vpc" {
+	id = "75658"
+}
+data "ncloud_subnet" "test_subnet" {
+	id = "172709"
+}
+
+resource "ncloud_mysql" "mysql" {
+	subnet_no = data.ncloud_subnet.test_subnet.id
+	service_name = "%[1]s"
+	server_name_prefix = "testprefix"
+	user_name = "testusername"
+	user_password = "t123456789!a"
+	host_ip = "192.168.0.1"
+	database_name = "test_db"
+}
+
+resource "ncloud_mysql_recovery" "mysql_recovery" {
+	mysql_instance_no = ncloud_mysql.mysql.id
+	recovery_server_name = "test-recovery"
+	file_name = "%[2]s"
+}
+`, testName, testDate)
+}
+
+func testAccCheckMysqlRecoveryExists(n string, recovery *vmysql.CloudMysqlServerInstance, provider *schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resource, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found %s", n)
+		}
+
+		if resource.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := provider.Meta().(*conn.ProviderConfig)
+		mysqlRecovery, err := mysqlservice.GetMysqlRecovery(context.Background(), config, resource.Primary.Attributes["mysql_instance_no"])
+		if err != nil {
+			return nil
+		}
+
+		if mysqlRecovery != nil {
+			*recovery = *mysqlRecovery
+			return nil
+		}
+
+		return fmt.Errorf("mysql recovery not found")
+	}
+}
+
+func testAccCheckMysqlRecoveryDestroy(s *terraform.State) error {
+	config := GetTestProvider(true).Meta().(*conn.ProviderConfig)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ncloud_mysql_recovery" {
+			continue
+		}
+		instance, err := mysqlservice.GetMysqlRecovery(context.Background(), config, rs.Primary.Attributes["mysql_instance_no"])
+		if err != nil && !strings.Contains(err.Error(), "5001017") {
+			return nil
+		}
+
+		if instance != nil {
+			return errors.New("mysql recovery still exists")
+		}
+	}
+
+	return nil
+}

--- a/internal/service/mysql/mysql_recovery_test.go
+++ b/internal/service/mysql/mysql_recovery_test.go
@@ -42,15 +42,22 @@ func TestAccResourceNcloudMysqlRecovery_vpc_basic(t *testing.T) {
 
 func testAccMysqlRecoveryConfig(testName string, testDate string) string {
 	return fmt.Sprintf(`
-data "ncloud_vpc" "test_vpc" {
-	id = "75658"
+resource "ncloud_vpc" "test_vpc" {
+	name               = "%[1]s"
+	ipv4_cidr_block    = "10.5.0.0/16"
 }
-data "ncloud_subnet" "test_subnet" {
-	id = "172709"
+
+resource "ncloud_subnet" "test_subnet" {
+	vpc_no             = ncloud_vpc.test_vpc.vpc_no
+	name               = "%[1]s"
+	subnet             = "10.5.0.0/24"
+	zone               = "KR-2"
+	network_acl_no     = ncloud_vpc.test_vpc.default_network_acl_no
+	subnet_type        = "PUBLIC"
 }
 
 resource "ncloud_mysql" "mysql" {
-	subnet_no = data.ncloud_subnet.test_subnet.id
+	subnet_no = ncloud_subnet.test_subnet.id
 	service_name = "%[1]s"
 	server_name_prefix = "testprefix"
 	user_name = "testusername"

--- a/internal/service/mysql/mysql_recovery_test.go
+++ b/internal/service/mysql/mysql_recovery_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vmysql"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -18,10 +19,10 @@ import (
 )
 
 func TestAccResourceNcloudMysqlRecovery_vpc_basic(t *testing.T) {
-	var mysqlSErverInstance vmysql.CloudMysqlServerInstance
+	var mysqlServerInstance vmysql.CloudMysqlServerInstance
 	testName := fmt.Sprintf("tf-mysqlsv-%s", acctest.RandString(5))
 	resourceName := "ncloud_mysql_recovery.mysql_recovery"
-	testDate := "20240920"
+	testDate := time.Now().Format("20060102")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
@@ -31,7 +32,7 @@ func TestAccResourceNcloudMysqlRecovery_vpc_basic(t *testing.T) {
 			{
 				Config: testAccMysqlRecoveryConfig(testName, testDate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMysqlRecoveryExists(resourceName, &mysqlSErverInstance, GetTestProvider(true)),
+					testAccCheckMysqlRecoveryExists(resourceName, &mysqlServerInstance, GetTestProvider(true)),
 					resource.TestCheckResourceAttrSet(resourceName, "mysql_instance_no"),
 				),
 			},


### PR DESCRIPTION
mysql recovery 리소스 작성

- mysql recovery
- mysql recovery test
- mysql recovery docs

```
user@AL02398918 terraform-provider-ncloud % go test ./internal/service/mysql/... -v -run=TestAccResourceNcloudMysqlRecovery_vpc_basic -timeout=1h
=== RUN   TestAccResourceNcloudMysqlRecovery_vpc_basic
--- PASS: TestAccResourceNcloudMysqlRecovery_vpc_basic (1492.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ncloud/internal/service/mysql	1493.227s
```