### PR TITLE
[Fix] fix endpoint configuration

### DIFF
--- a/docs/resources/object_storage_object.md
+++ b/docs/resources/object_storage_object.md
@@ -40,7 +40,9 @@ The following arguments are required:
 
 The following arguments are optional:
 
-* `content_type` - (Optional) Standard MIME type describing the format of the object data, e.g., application/octet-stream. All Valid MIME Types are valid for this input.
+* `content_type` - (Optional) Standard MIME type describing the format of the object data, e.g., application/octet-stream. All Valid MIME Types are valid for this input. 
+
+~> **NOTE:** Specially in `JPN` region, updating resource with only `content_type` changed will be blocked. 
 
 ## Attribute Reference.
 

--- a/docs/resources/object_storage_object_copy.md
+++ b/docs/resources/object_storage_object_copy.md
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 * `content_type` - (Optional) Standard MIME type describing the format of the object data, e.g., application/octet-stream. All Valid MIME Types are valid for this input. This attribute is only available in update operation.
 
+~> **NOTE:** Specially in `JPN` region, updating resource with only `content_type` changed will be blocked. 
+
 ## Attribute Reference.
 
 ~> **NOTE:** Since Ncloud Object Stroage uses S3 Compatible SDK, these arguments are served as best-effort.

--- a/internal/conn/api_client.go
+++ b/internal/conn/api_client.go
@@ -48,7 +48,7 @@ func genEndpointWithCode(region, site string) string {
 	case "gov":
 		s3Endpoint = fmt.Sprintf("https://%[1]s.object.gov-ncloudstorage.com", strings.ToLower(region))
 	case "fin":
-		s3Endpoint = fmt.Sprintf("https://%[1]s.object.fin-ncloudstorage.com", strings.ToLower(region))
+		s3Endpoint = "https://kr.object.fin-ncloudstorage.com"
 	default:
 		s3Endpoint = fmt.Sprintf("https://%[1]s.object.ncloudstorage.com", strings.ToLower(region[:2]))
 	}

--- a/internal/service/objectstorage/objectstorage_object.go
+++ b/internal/service/objectstorage/objectstorage_object.go
@@ -234,6 +234,12 @@ func (o *objectResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 		reqParams.Body = file
 	} else {
+		// Prevent wasting of GetObject operation
+		if !plan.ContentType.Equal(state.ContentType) && o.config.RegionCode == "JPN" {
+			resp.Diagnostics.AddError("UPDATING ERROR", "updating object Content-Type is unavailable in this region")
+			return
+		}
+
 		getReqParams := &s3.GetObjectInput{
 			Bucket: state.Bucket.ValueStringPointer(),
 			Key:    state.Key.ValueStringPointer(),

--- a/internal/service/objectstorage/objectstorage_object_copy.go
+++ b/internal/service/objectstorage/objectstorage_object_copy.go
@@ -276,6 +276,11 @@ func (o *objectCopyResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	if !plan.ContentType.Equal(state.ContentType) {
 
+		if o.config.RegionCode == "JPN" {
+			resp.Diagnostics.AddError("UPDATING ERROR", "updating object Content-Type is unavailable in this region")
+			return
+		}
+
 		getReqParams := &s3.GetObjectInput{
 			Bucket: state.Bucket.ValueStringPointer(),
 			Key:    state.Key.ValueStringPointer(),
@@ -296,9 +301,10 @@ func (o *objectCopyResource) Update(ctx context.Context, req resource.UpdateRequ
 		tflog.Info(ctx, "GetObject at update operation response="+common.MarshalUncheckedString(getOutput))
 
 		reqParams := &s3.PutObjectInput{
-			Bucket:      plan.Bucket.ValueStringPointer(),
-			Key:         plan.Key.ValueStringPointer(),
-			Body:        getOutput.Body,
+			Bucket: plan.Bucket.ValueStringPointer(),
+			Key:    plan.Key.ValueStringPointer(),
+			Body:   getOutput.Body,
+			// this option is only available in KR region
 			ContentType: plan.ContentType.ValueStringPointer(),
 		}
 

--- a/internal/service/objectstorage/objectstorage_object_copy.go
+++ b/internal/service/objectstorage/objectstorage_object_copy.go
@@ -304,7 +304,7 @@ func (o *objectCopyResource) Update(ctx context.Context, req resource.UpdateRequ
 			Bucket: plan.Bucket.ValueStringPointer(),
 			Key:    plan.Key.ValueStringPointer(),
 			Body:   getOutput.Body,
-			// this option is only available in KR region
+			// this option is unavailable in JPN region
 			ContentType: plan.ContentType.ValueStringPointer(),
 		}
 


### PR DESCRIPTION
- fix endpoint with "https://kr.object.fin-ncloudstorage.com" at `fin` site.

- prevent PutObject with ContentType parameter in JPN region since it's unavailable when Body is derived from GetObject operation.