### PR TITLE
fix: Don't set the state when error responded

### DIFF
--- a/internal/service/mongodb/mongodb_image_products_data_source.go
+++ b/internal/service/mongodb/mongodb_image_products_data_source.go
@@ -135,8 +135,10 @@ func (m *mongodbImageProductsDataSource) Read(ctx context.Context, req datasourc
 
 		if convertedList, err := convertToJsonStruct(data.ImageProductList.Elements()); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		} else if err := common.WriteToFile(outputPath, convertedList); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		}
 	}
 

--- a/internal/service/mongodb/mongodb_products_data_source.go
+++ b/internal/service/mongodb/mongodb_products_data_source.go
@@ -161,8 +161,10 @@ func (m *mongodbProductsDataSource) Read(ctx context.Context, req datasource.Rea
 
 		if convertedList, err := convertProductsToJsonStruct(data.ProductList.Elements()); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		} else if err := common.WriteToFile(outputPath, convertedList); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		}
 	}
 

--- a/internal/service/mssql/mssql_image_products_data_source.go
+++ b/internal/service/mssql/mssql_image_products_data_source.go
@@ -133,8 +133,10 @@ func (m *mssqlImageProductsDataSource) Read(ctx context.Context, req datasource.
 
 		if convertedList, err := convertToJsonStruct(data.ImageProductList.Elements()); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		} else if err := common.WriteToFile(outputPath, convertedList); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		}
 	}
 

--- a/internal/service/mssql/mssql_products_data_source.go
+++ b/internal/service/mssql/mssql_products_data_source.go
@@ -145,8 +145,10 @@ func (m *mssqlProductsDataSource) Read(ctx context.Context, req datasource.ReadR
 
 		if convertedList, err := convertProductsToJsonStruct(data.ProductList.Elements()); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		} else if err := common.WriteToFile(outputPath, convertedList); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		}
 	}
 

--- a/internal/service/mysql/mysql_image_products_data_source.go
+++ b/internal/service/mysql/mysql_image_products_data_source.go
@@ -133,8 +133,10 @@ func (m *mysqlImageProductsDataSource) Read(ctx context.Context, req datasource.
 
 		if convertedList, err := convertToJsonStruct(data.ImageProductList.Elements()); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		} else if err := common.WriteToFile(outputPath, convertedList); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		}
 	}
 

--- a/internal/service/mysql/mysql_products_data_source.go
+++ b/internal/service/mysql/mysql_products_data_source.go
@@ -145,8 +145,10 @@ func (m *mysqlProductsDataSource) Read(ctx context.Context, req datasource.ReadR
 
 		if convertedList, err := convertProductsToJsonStruct(data.ProductList.Elements()); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		} else if err := common.WriteToFile(outputPath, convertedList); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		}
 	}
 

--- a/internal/service/redis/redis_image_products_data_source.go
+++ b/internal/service/redis/redis_image_products_data_source.go
@@ -133,8 +133,10 @@ func (r *redisImageProductsDataSource) Read(ctx context.Context, req datasource.
 
 		if convertedList, err := convertToJsonStruct(data.ImageProductList.Elements()); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		} else if err := common.WriteToFile(outputPath, convertedList); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		}
 	}
 

--- a/internal/service/redis/redis_products_data_source.go
+++ b/internal/service/redis/redis_products_data_source.go
@@ -145,8 +145,10 @@ func (r *redisProductsDataSource) Read(ctx context.Context, req datasource.ReadR
 
 		if convertedList, err := convertProductsToJsonStruct(data.ProductList.Elements()); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		} else if err := common.WriteToFile(outputPath, convertedList); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		}
 	}
 

--- a/internal/service/server/login_key_data_source.go
+++ b/internal/service/server/login_key_data_source.go
@@ -110,8 +110,10 @@ func (d *loginKeyDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 		if convertedList, err := convertToJsonStruct(data.KeyList.Elements()); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		} else if err := common.WriteToFile(outputPath, convertedList); err != nil {
 			resp.Diagnostics.AddError("OUTPUT FILE ERROR", err.Error())
+			return
 		}
 	}
 


### PR DESCRIPTION
- Add missing return statement to avoid performing State.Set() on error