### PR TITLE
fix(blockStorage): Prevent panic while detaching block storage

### DIFF
--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -1030,6 +1030,17 @@ func detachThenWaitServerInstance(config *conn.ProviderConfig, id string) error 
 				return 0, "", err
 			}
 
+			// FIXME: When deleting a server if user detach block storage what they attached by themself
+			//        and keep that block storage alive
+			// 1. during the server deletion process, block storage detached
+			// 2. attempt to detach from the server during the block storage in-place update process
+			// 2-1. but the server is already destroyed and detachThenWaitServerInstance() is called
+			//      by block storage to get serverInstance info, and the instance inquiry result is nil,
+			//      causing panic when access ServerInstance(nil) field.
+			if instance == nil {
+				return &server.ServerInstance{}, "NULL", nil
+			}
+
 			return instance, ncloud.StringValue(instance.ServerInstanceOperation), nil
 		},
 		Timeout:    conn.DefaultStopTimeout,


### PR DESCRIPTION
- It adds a guard to prevent panic in the detaching block storage step in a specific case.

- reproduce condition
  - User creates KVM server and attaches block storage by themself (using Terraform)
  - destroy the server but keep the block storage

Step 1.
```hcl
resource "ncloud_server" "kvm-server" {
  subnet_no                 = ncloud_subnet.subnet_private.id
  name                      = "tf-kvm-server"
  server_image_number       = data.ncloud_server_image_numbers.kvm-image.image_number_list.0.server_image_number
  server_spec_code          = data.ncloud_server_specs.kvm-spec.server_spec_list.0.server_spec_code
  login_key_name            = ncloud_login_key.kvm-loginkey.key_name
}

resource "ncloud_block_storage" "kvm-storage" {
  size = "10"
  server_instance_no = ncloud_server.kvm-server.id
  name = "tf-kvm-storage"
  hypervisor_type = "KVM"
  volume_type = "CB1"
  zone = "KR-1"
}
```

Step 2.
```hcl
# resource "ncloud_server" "kvm-server" {
#   subnet_no                 = ncloud_subnet.subnet_private.id
#   name                      = "tf-kvm-server"
#   server_image_number       = data.ncloud_server_image_numbers.kvm-image.image_number_list.0.server_image_number
#   server_spec_code          = data.ncloud_server_specs.kvm-spec.server_spec_list.0.server_spec_code
#   login_key_name            = ncloud_login_key.kvm-loginkey.key_name
# }

resource "ncloud_block_storage" "kvm-storage" {
  size = "10"
  
  # server_instance_no = ncloud_server.kvm-server.id
  name = "tf-kvm-storage"
  hypervisor_type = "KVM"
  volume_type = "CB1"
  zone = "KR-1"
}
```

- Error
```
│ Error: Request cancelled
│
│ The plugin6.(*GRPCProvider).ApplyResourceChange request was cancelled.
╵

Stack trace from the terraform-provider-ncloud plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0xc0 pc=0x1037402ec]

goroutine 120 [running]:
github.com/terraform-providers/terraform-provider-ncloud/internal/service/server.detachThenWaitServerInstance.func1()
	/Users/wonchul/work/ncloud/terraform/terraform-provider-ncloud/internal/service/server/server.go:1033 +0x2c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry.(*StateChangeConf).WaitForStateContext.func1()
	/Users/wonchul/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/retry/state.go:113 +0x140
created by github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry.(*StateChangeConf).WaitForStateContext in goroutine 94
	/Users/wonchul/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/retry/state.go:86 +0x1d0

Error: The terraform-provider-ncloud plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```