### PR TITLE
fix(Server): Drop delete block storage feature temporally

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -170,7 +170,6 @@ The following arguments are supported:
   * `network_interface_no` - (Required) If you want to add a network interface that you created yourself, set the network interface ID.
   * `order` - (Required) Sets the order of network interfaces to be assigned to the server to create. The unit name (eth0, eth1, etc.) is determined in that order. There must be one primary network interface. If you set `0`, network interface is set by default. You can assign up to three network interfaces.
 * `is_encrypted_base_block_storage_volume` - (Optional) you can set whether to encrypt basic block storage if server image is RHV. Default `false`.
-* `delete_blockstorage_server_termination` - (Optional) you can set whether to delete all attached BlockStorages when returning the server. Default `false`.
 
 ## Attributes Reference
 

--- a/internal/service/server/block_storage_snapshot_test.go
+++ b/internal/service/server/block_storage_snapshot_test.go
@@ -242,7 +242,6 @@ resource "ncloud_server" "server" {
 	server_image_number = data.ncloud_server_image_numbers.server_images.image_number_list.0.server_image_number
 	server_spec_code = "%[4]s"
 	login_key_name = ncloud_login_key.loginkey.key_name
-	delete_blockstorage_server_termination = true
 }
 
 resource "ncloud_block_storage" "storage" {

--- a/internal/service/server/block_storage_test.go
+++ b/internal/service/server/block_storage_test.go
@@ -384,7 +384,6 @@ resource "ncloud_server" "server" {
 	server_image_number = data.ncloud_server_image_numbers.server_images.image_number_list.0.server_image_number
 	server_spec_code = "s2-g2-s50"
 	login_key_name = ncloud_login_key.loginkey.key_name
-	delete_blockstorage_server_termination = true
 }
 
 resource "ncloud_block_storage" "storage" {
@@ -462,7 +461,6 @@ resource "ncloud_server" "foo" {
 	server_image_number = data.ncloud_server_image_numbers.server_images.image_number_list.0.server_image_number
 	server_spec_code = "s2-g2-s50"
 	login_key_name = ncloud_login_key.loginkey.key_name
-	delete_blockstorage_server_termination = true
 }
 
 resource "ncloud_server" "bar" {
@@ -471,7 +469,6 @@ resource "ncloud_server" "bar" {
 	server_image_number = data.ncloud_server_image_numbers.server_images.image_number_list.0.server_image_number
 	server_spec_code = "s2-g2-s50"
 	login_key_name = ncloud_login_key.loginkey.key_name
-	delete_blockstorage_server_termination = true
 }
 
 resource "ncloud_block_storage" "storage" {
@@ -517,7 +514,6 @@ resource "ncloud_server" "server" {
 	server_image_number = data.ncloud_server_image_numbers.server_images.image_number_list.0.server_image_number
 	server_spec_code = "s2-g3"
 	login_key_name = ncloud_login_key.loginkey.key_name
-	delete_blockstorage_server_termination = true
 }
 
 resource "ncloud_block_storage" "storage" {

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -95,11 +95,6 @@ func ResourceNcloudServer() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"delete_blockstorage_server_termination": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
 			// Deprecated
 			"internet_line_type": {
 				Type:             schema.TypeString,
@@ -346,13 +341,6 @@ func resourceNcloudServerDelete(d *schema.ResourceData, meta interface{}) error 
 
 			if err := waitForDisconnectBlockStorage(config, *blockStorage.BlockStorageInstanceNo); err != nil {
 				return err
-			}
-
-			if d.Get("delete_blockstorage_server_termination").(bool) {
-				log.Printf("[INFO] Delete BlockStorage %s", *blockStorage.BlockStorageInstanceNo)
-				if err := deleteBlockStorage(d, config, *blockStorage.BlockStorageInstanceNo); err != nil {
-					return err
-				}
 			}
 		}
 

--- a/internal/service/server/server_data_source_test.go
+++ b/internal/service/server/server_data_source_test.go
@@ -121,7 +121,6 @@ resource "ncloud_server" "server" {
 	server_image_number = data.ncloud_server_image_numbers.server_images.image_number_list.0.server_image_number
 	server_spec_code = "%[2]s"
 	login_key_name = ncloud_login_key.loginkey.key_name
-	delete_blockstorage_server_termination = true
 }
 
 data "ncloud_server" "by_id" {

--- a/internal/service/server/server_test.go
+++ b/internal/service/server/server_test.go
@@ -437,7 +437,6 @@ resource "ncloud_server" "server" {
 	server_image_number = data.ncloud_server_image_numbers.server_images.image_number_list.0.server_image_number
 	server_spec_code = "%[2]s"
 	login_key_name = ncloud_login_key.loginkey.key_name
-	delete_blockstorage_server_termination = true
 }
 `, testServerName, specCode)
 }

--- a/internal/service/server/servers_data_source_test.go
+++ b/internal/service/server/servers_data_source_test.go
@@ -96,7 +96,6 @@ resource "ncloud_server" "test" {
 	server_image_number = data.ncloud_server_image_numbers.server_images.image_number_list.0.server_image_number
 	server_spec_code = "s2-g3"
 	login_key_name = ncloud_login_key.loginkey.key_name
-	delete_blockstorage_server_termination = true
 }
 
 resource "ncloud_server" "test2" {
@@ -105,7 +104,6 @@ resource "ncloud_server" "test2" {
 	server_image_number = data.ncloud_server_image_numbers.server_images.image_number_list.0.server_image_number
 	server_spec_code = "s2-g3"
 	login_key_name = ncloud_login_key.loginkey.key_name
-	delete_blockstorage_server_termination = true
 }
 
 data "ncloud_servers" "by_id" {


### PR DESCRIPTION
- Drop `delete_blockstorage_server_termination` feature (temporally)
- If user explicitly declares block storage, the delete storage option can cause terraform state inconsistencies.
- refer to the case in this PR https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/464
- temporarily remove this feature and re-introduce it after releasing the Terraform version today