### PR TITLE
fix(Server): Add a null check to prevent panic

### DIFF
--- a/internal/service/server/block_storage.go
+++ b/internal/service/server/block_storage.go
@@ -670,7 +670,7 @@ func waitForBlockStorageDetachment(config *conn.ProviderConfig, id string) error
 			}
 
 			if instance == nil {
-				return 0, "", fmt.Errorf("GetBlockStorage is nil")
+				return 0, "", fmt.Errorf("fail to get BlockStorage instance, %s doesn't exist", id)
 			}
 			return instance, ncloud.StringValue(instance.Status), nil
 		},
@@ -754,7 +754,7 @@ func waitForBlockStorageCreation(config *conn.ProviderConfig, id string) (*Block
 			}
 
 			if resp == nil {
-				return 0, "", fmt.Errorf("GetBlockStorage is nil")
+				return 0, "", fmt.Errorf("fail to get BlockStorage instance, %s doesn't exist", id)
 			}
 			blockStorageInstance = resp
 
@@ -783,7 +783,7 @@ func waitForBlockStorageAttachment(config *conn.ProviderConfig, id string) error
 			}
 
 			if instance == nil {
-				return 0, "", fmt.Errorf("GetBlockStorage is nil")
+				return 0, "", fmt.Errorf("fail to get BlockStorage instance, %s doesn't exist", id)
 			}
 			return instance, ncloud.StringValue(instance.Status), nil
 		},
@@ -887,7 +887,7 @@ func waitForBlockStorageOperationIsNull(config *conn.ProviderConfig, id string) 
 			}
 
 			if instance == nil {
-				return 0, "", fmt.Errorf("GetBlockStorage is nil")
+				return 0, "", fmt.Errorf("fail to get BlockStorage instance, %s doesn't exist", id)
 			}
 			return instance, ncloud.StringValue(instance.Operation), nil
 		},

--- a/internal/service/server/block_storage.go
+++ b/internal/service/server/block_storage.go
@@ -668,6 +668,10 @@ func waitForBlockStorageDetachment(config *conn.ProviderConfig, id string) error
 			if err != nil {
 				return 0, "", err
 			}
+
+			if instance == nil {
+				return 0, "", fmt.Errorf("GetBlockStorage is nil")
+			}
 			return instance, ncloud.StringValue(instance.Status), nil
 		},
 		Timeout:    conn.DefaultUpdateTimeout,
@@ -777,6 +781,10 @@ func waitForBlockStorageAttachment(config *conn.ProviderConfig, id string) error
 			if err != nil {
 				return 0, "", err
 			}
+
+			if instance == nil {
+				return 0, "", fmt.Errorf("GetBlockStorage is nil")
+			}
 			return instance, ncloud.StringValue(instance.Status), nil
 		},
 		Timeout:    conn.DefaultUpdateTimeout,
@@ -876,6 +884,10 @@ func waitForBlockStorageOperationIsNull(config *conn.ProviderConfig, id string) 
 			instance, err := GetBlockStorage(config, id)
 			if err != nil {
 				return 0, "", err
+			}
+
+			if instance == nil {
+				return 0, "", fmt.Errorf("GetBlockStorage is nil")
 			}
 			return instance, ncloud.StringValue(instance.Operation), nil
 		},

--- a/internal/service/server/block_storage_snapshot.go
+++ b/internal/service/server/block_storage_snapshot.go
@@ -274,6 +274,10 @@ func createClassicBlockStorageSnapshot(d *schema.ResourceData, config *conn.Prov
 			if err != nil {
 				return 0, "", err
 			}
+
+			if instance == nil {
+				return 0, "", fmt.Errorf("GetClassicBlockStorageSnapshotInstance is nil")
+			}
 			return instance, *instance.Status, nil
 		},
 		Timeout:    conn.DefaultCreateTimeout,

--- a/internal/service/server/block_storage_snapshot.go
+++ b/internal/service/server/block_storage_snapshot.go
@@ -235,7 +235,7 @@ func waitForBlockStorageSnapshotCreation(config *conn.ProviderConfig, id string)
 			}
 
 			if resp == nil {
-				return 0, "", fmt.Errorf("GetVpcBlockStorageSnapshotDetail is nil")
+				return 0, "", fmt.Errorf("fail to get VPC BlockStorageSnapshot instance, %s doesn't exist", id)
 			}
 
 			return resp, *resp.Status, nil
@@ -276,7 +276,7 @@ func createClassicBlockStorageSnapshot(d *schema.ResourceData, config *conn.Prov
 			}
 
 			if instance == nil {
-				return 0, "", fmt.Errorf("GetClassicBlockStorageSnapshotInstance is nil")
+				return 0, "", fmt.Errorf("fail to get Classic BlockStorageSnapshot instance, %s doesn't exist", blockStorageSnapshotInstanceNo)
 			}
 			return instance, *instance.Status, nil
 		},

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -321,6 +321,11 @@ func resourceNcloudServerDelete(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
+	if serverInstance == nil {
+		d.SetId("")
+		return nil
+	}
+
 	if ncloud.StringValue(serverInstance.ServerInstanceStatus) != "NSTOP" {
 		log.Printf("[INFO] Stopping Instance %q for terminate", d.Id())
 		if err := stopThenWaitServerInstance(config, d.Id()); err != nil {
@@ -557,6 +562,11 @@ func waitStateNcloudServerForCreation(config *conn.ProviderConfig, id string) er
 			if err != nil {
 				return 0, "", err
 			}
+
+			if instance == nil {
+				return 0, "", fmt.Errorf("GetServerInstance is nil")
+			}
+
 			return instance, ncloud.StringValue(instance.ServerInstanceStatus), nil
 		},
 		Timeout:    conn.DefaultCreateTimeout,
@@ -576,6 +586,10 @@ func updateServerInstanceSpec(d *schema.ResourceData, config *conn.ProviderConfi
 	serverInstance, err := GetServerInstance(config, d.Id())
 	if err != nil {
 		return err
+	}
+
+	if serverInstance == nil {
+		return fmt.Errorf("GetServerInstance is nil")
 	}
 
 	log.Printf("[INFO] Stopping Instance %q for server_product_code change", d.Id())
@@ -617,6 +631,10 @@ func changeServerInstanceSpec(d *schema.ResourceData, config *conn.ProviderConfi
 
 			if err != nil {
 				return 0, "", err
+			}
+
+			if instance == nil {
+				return 0, "", fmt.Errorf("GetServerInstance is nil")
 			}
 
 			return instance, ncloud.StringValue(instance.ServerInstanceOperation), nil
@@ -737,6 +755,10 @@ func startThenWaitServerInstance(config *conn.ProviderConfig, id string) error {
 			instance, err := GetServerInstance(config, id)
 			if err != nil {
 				return 0, "", err
+			}
+
+			if instance == nil {
+				return 0, "", fmt.Errorf("GetServerInstance is nil")
 			}
 
 			return instance, ncloud.StringValue(instance.ServerInstanceStatus), nil
@@ -962,6 +984,10 @@ func stopThenWaitServerInstance(config *conn.ProviderConfig, id string) error {
 				return 0, "", err
 			}
 
+			if instance == nil {
+				return &server.ServerInstance{}, "NULL", nil
+			}
+
 			return instance, ncloud.StringValue(instance.ServerInstanceOperation), nil
 		},
 		Timeout:    conn.DefaultStopTimeout,
@@ -991,6 +1017,10 @@ func stopThenWaitServerInstance(config *conn.ProviderConfig, id string) error {
 			instance, err := GetServerInstance(config, id)
 			if err != nil {
 				return 0, "", err
+			}
+
+			if instance == nil {
+				return &server.ServerInstance{}, "NULL", nil
 			}
 
 			return instance, ncloud.StringValue(instance.ServerInstanceStatus), nil

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -564,7 +564,7 @@ func waitStateNcloudServerForCreation(config *conn.ProviderConfig, id string) er
 			}
 
 			if instance == nil {
-				return 0, "", fmt.Errorf("GetServerInstance is nil")
+				return 0, "", fmt.Errorf("fail to get Server instance, %s doesn't exist", id)
 			}
 
 			return instance, ncloud.StringValue(instance.ServerInstanceStatus), nil
@@ -589,7 +589,7 @@ func updateServerInstanceSpec(d *schema.ResourceData, config *conn.ProviderConfi
 	}
 
 	if serverInstance == nil {
-		return fmt.Errorf("GetServerInstance is nil")
+		return fmt.Errorf("fail to get Server instance, %s doesn't exist", d.Id())
 	}
 
 	log.Printf("[INFO] Stopping Instance %q for server_product_code change", d.Id())
@@ -634,7 +634,7 @@ func changeServerInstanceSpec(d *schema.ResourceData, config *conn.ProviderConfi
 			}
 
 			if instance == nil {
-				return 0, "", fmt.Errorf("GetServerInstance is nil")
+				return 0, "", fmt.Errorf("fail to get Server instance, %s doesn't exist", d.Id())
 			}
 
 			return instance, ncloud.StringValue(instance.ServerInstanceOperation), nil
@@ -758,7 +758,7 @@ func startThenWaitServerInstance(config *conn.ProviderConfig, id string) error {
 			}
 
 			if instance == nil {
-				return 0, "", fmt.Errorf("GetServerInstance is nil")
+				return 0, "", fmt.Errorf("fail to get Server instance, %s doesn't exist", id)
 			}
 
 			return instance, ncloud.StringValue(instance.ServerInstanceStatus), nil
@@ -1355,7 +1355,7 @@ func waitForDisconnectBlockStorage(config *conn.ProviderConfig, no string) error
 			}
 
 			if resp == nil {
-				return 0, "", fmt.Errorf("GetBlockStorage is nil")
+				return 0, "", fmt.Errorf("fail to get BlockStorage instance, %s doesn't exist", no)
 			}
 
 			if *resp.StatusName == BlockStorageStatusNameAttach {
@@ -1389,7 +1389,7 @@ func waitForAttachedBlockStorage(config *conn.ProviderConfig, no string) error {
 			}
 
 			if resp == nil {
-				return 0, "", fmt.Errorf("GetBlockStorage is nil")
+				return 0, "", fmt.Errorf("fail to get BlockStorage instance, %s doesn't exist", no)
 			}
 
 			if *resp.StatusName == BlockStorageStatusNameInit {


### PR DESCRIPTION
- related
  - https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/463
  - https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/464
- Add a null check to prevent panic if you run an instance lookup and the response is abnormal or has already been deleted.