### PR TITLE
feat(mysql): add refreshFromOutput diags

### DIFF
--- a/internal/service/mysql/mysql_databases_data_source_test.go
+++ b/internal/service/mysql/mysql_databases_data_source_test.go
@@ -36,16 +36,22 @@ func TestAccDataSourceNcloudMysqlDatabases_vpc_basic(t *testing.T) {
 
 func testAccDataSourceMysqlDatabasesConfig(testName string) string {
 	return fmt.Sprintf(`
-data "ncloud_vpc" "test_vpc" {
-	id = "75658"
+resource "ncloud_vpc" "test_vpc" {
+	name             = "%[1]s"
+	ipv4_cidr_block  = "10.5.0.0/16"
 }
 
-data "ncloud_subnet" "test_subnet" {
-	id = "172709"
+resource "ncloud_subnet" "test_subnet" {
+	vpc_no             = ncloud_vpc.test_vpc.vpc_no
+	name               = "%[1]s"
+	subnet             = "10.5.0.0/24"
+	zone               = "KR-2"
+	network_acl_no     = ncloud_vpc.test_vpc.default_network_acl_no
+	subnet_type        = "PUBLIC"
 }
 
 resource "ncloud_mysql" "mysql" {
-	subnet_no = data.ncloud_subnet.test_subnet.id
+	subnet_no = ncloud_subnet.test_subnet.id
 	service_name = "%[1]s"
 	server_name_prefix = "testprefix"
 	user_name = "testusername"

--- a/internal/service/mysql/mysql_databases_test.go
+++ b/internal/service/mysql/mysql_databases_test.go
@@ -43,16 +43,22 @@ func TestAccResourceNcloudMysqlDatabases_vpc_basic(t *testing.T) {
 
 func testAccMysqlDatabasesConfig(testMysqlName string) string {
 	return fmt.Sprintf(`
-data "ncloud_vpc" "test_vpc" {
-	id = "75658"
+resource "ncloud_vpc" "test_vpc" {
+	name             = "%[1]s"
+	ipv4_cidr_block  = "10.5.0.0/16"
 }
 
-data "ncloud_subnet" "test_subnet" {
-	id = "172709"
+resource "ncloud_subnet" "test_subnet" {
+	vpc_no             = ncloud_vpc.test_vpc.vpc_no
+	name               = "%[1]s"
+	subnet             = "10.5.0.0/24"
+	zone               = "KR-2"
+	network_acl_no     = ncloud_vpc.test_vpc.default_network_acl_no
+	subnet_type        = "PUBLIC"
 }
 
 resource "ncloud_mysql" "mysql" {
-	subnet_no = data.ncloud_subnet.test_subnet.id
+	subnet_no = ncloud_subnet.test_subnet.id
 	service_name = "%[1]s"
 	server_name_prefix = "testprefix"
 	user_name = "testusername"


### PR DESCRIPTION
- Mysql database 리소스 테스트 vpc, subnet 코드를 데이터 소스에서 리소스로 변경(Regression test 에러 유발건)
- mysql database, user 리소스에 대해 refreshFromOutput에서 Err가 아닌 diag.Diagnostics를 반환하도록 변경
    - user의 경우 진행중 ListValueFrom에서 불일치 문제 방지를 위해 plan의 password값 삽입