### PR TITLE
refactor(postgresql): Update PostgreSQL image products Data Source

### DIFF
--- a/docs/data-sources/postgresql_image_products.md
+++ b/docs/data-sources/postgresql_image_products.md
@@ -14,6 +14,7 @@ Get a list of PostgreSQL image products.
 data "ncloud_postgresql_image_products" "example" {
     output_file = "image.json"
 }
+
 output "image_list" {
     value = {
         for image in data.ncloud_postgresql_image_products.example.image_product_list:
@@ -22,19 +23,21 @@ output "image_list" {
 }
 ```
 
-```terraform
-data "ncloud_postgresql_image_products" "example" {
-    filter {
-        name = "engine_Version_code"
-        values = ["13.13"]
-    }
-}
-```
-
 Outputs:
 ```terraform
 image_list = {
-    "13.13": "SW.VPGSL.OS.LNX64.ROCKY.0810.PGSQL.B050"
+  "13.15" = "SW.VPGSL.OS.LNX64.ROCKY.0810.PGSQL.B050"
+  "13.13" = "SW.VPGSL.OS.LNX64.ROCKY.0810.PGSQL.B050"
+  "13.10" = "SW.VPGSL.OS.LNX64.ROCKY.0810.PGSQL.B050"
+}
+```
+
+```terraform
+data "ncloud_postgresql_image_products" "example" {
+    filter {
+        name = "engine_version_code"
+        values = ["13.13"]
+    }
 }
 ```
 

--- a/examples/postgresql/main.tf
+++ b/examples/postgresql/main.tf
@@ -37,12 +37,12 @@ data "ncloud_postgresql_image_products" "images_by_code" {
 output "image_list" {
   value = {
     for image in data.ncloud_postgresql_image_products.images_by_code.image_product_list:
-    image.product_name => image.product_code
+    image.engine_version_code => image.product_code
   }
 }
 
 data "ncloud_postgresql_products" "all" {
-  postgresql_image_product_code = "SW.VSVR.DBMS.LNX64.CNTOS.0708.PSTGR.1403.B050"
+  image_product_code = data.ncloud_postgresql_image_products.images_by_code.image_product_list.0.product_code
   output_file = "products.json"
 }
 

--- a/internal/service/postgresql/postgresql_image_products_data_source.go
+++ b/internal/service/postgresql/postgresql_image_products_data_source.go
@@ -167,7 +167,7 @@ func (d *postgresqlImageProductsDataSourceModel) refreshFromOutput(ctx context.C
 	d.ImageProductList = imageProductListValue
 	d.ID = types.StringValue("")
 
-	return nil
+	return diags
 }
 
 type postgresqlImageProductsDataSourceModel struct {

--- a/internal/service/postgresql/postgresql_image_products_data_source_test.go
+++ b/internal/service/postgresql/postgresql_image_products_data_source_test.go
@@ -1,7 +1,7 @@
 package postgresql_test
 
 import (
-	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -9,29 +9,23 @@ import (
 )
 
 func TestAccDataSourceNcloudPostgresqlImageProducts_basic(t *testing.T) {
-	productType := "LINUX"
+	dataName := "data.ncloud_postgresql_image_products.all"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudPostgresqlImageProductsConfig_basic(productType),
+				Config: testAccDataSourcePostgresqlImageProductsConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.ncloud_postgresql_image_products.all", "image_product_list.0.product_type", productType),
+					resource.TestMatchResourceAttr(dataName, "image_product_list.0.product_code", regexp.MustCompile(`^[A-Z0-9]+[A-Z0-9-.]+[A-Z0-9]$`)),
+					resource.TestMatchResourceAttr(dataName, "image_product_list.1.product_code", regexp.MustCompile(`^[A-Z0-9]+[A-Z0-9-.]+[A-Z0-9]$`)),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceNcloudPostgresqlImageProductsConfig_basic(productType string) string {
-	return fmt.Sprintf(`
-data "ncloud_postgresql_image_products" "all" {
-	filter {
-			name = "product_type"
-			values = ["%s"]
-	}
-}
-`, productType)
-}
+var testAccDataSourcePostgresqlImageProductsConfig = `
+data "ncloud_postgresql_image_products" "all" { }
+`


### PR DESCRIPTION
### Related
https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/452

### Description
- Data-Source : ncloud_postgresql_image_products
- Change
  - Update DOCS
  - Update example
  - Modify AccTest

### AccTest results
```
=== RUN   TestAccDataSourceNcloudPostgresqlImageProducts_basic
--- PASS: TestAccDataSourceNcloudPostgresqlImageProducts_basic (1.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ncloud/internal/service/postgresql	2.212s
```
