### PR TITLE
fix(mysql): Fix import error and minor errors on recovery and slave

### DIFF
--- a/docs/resources/mysql_recovery.md
+++ b/docs/resources/mysql_recovery.md
@@ -6,39 +6,39 @@ subcategory: "MySQL"
 
 Provides a MySQL recovery resource.
  
-~> **NOTE:** This resource only supports VPC environment.
+~> **NOTE:** This resource only supports VPC environment. Only one server related resource (ncloud_mysql_slave, ncloud_mysql_recovery) can be created or deleted at a time.
 
 ## Example Usage
 
 ```terraform
-resource "ncloud_vpc" "test_vpc" {
-	name             = "%[1]s"
-	ipv4_cidr_block  = "10.5.0.0/16"
+resource "ncloud_vpc" "vpc" {
+  name             = "mysql-vpc"
+  ipv4_cidr_block  = "10.5.0.0/16"
 }
 
-resource "ncloud_subnet" "test_subnet" {
-	vpc_no             = ncloud_vpc.test_vpc.vpc_no
-	name               = "%[1]s"
-	subnet             = "10.5.0.0/24"
-	zone               = "KR-2"
-	network_acl_no     = ncloud_vpc.test_vpc.default_network_acl_no
-	subnet_type        = "PUBLIC"
+resource "ncloud_subnet" "subnet" {
+  vpc_no             = ncloud_vpc.vpc.vpc_no
+  name               = "mysql-subnet"
+  subnet             = "10.5.0.0/24"
+  zone               = "KR-2"
+  network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
+  subnet_type        = "PUBLIC"
 }
 
 resource "ncloud_mysql" "mysql" {
-	subnet_no = data.ncloud_subnet.test_subnet.id
-	service_name = "%[1]s"
-	server_name_prefix = "testprefix"
-	user_name = "testusername"
-	user_password = "t123456789!a"
-	host_ip = "192.168.0.1"
-	database_name = "test_db"
+  subnet_no          = data.ncloud_subnet.subnet.id
+  service_name       = "tf-mysql"
+  server_name_prefix = "testprefix"
+  user_name          = "testusername"
+  user_password      = "t123456789!a"
+  host_ip            = "192.168.0.1"
+  database_name      = "test_db"
 }
 
 resource "ncloud_mysql_recovery" "mysql_recovery" {
-	mysql_instance_no = ncloud_mysql.mysql.id
-	recovery_server_name = "test-recovery"
-	file_name = "20210722"
+  mysql_instance_no    = ncloud_mysql.mysql.id
+  recovery_server_name = "test-recovery"
+  file_name            = "20210722"
 }
 ```
 
@@ -47,33 +47,49 @@ resource "ncloud_mysql_recovery" "mysql_recovery" {
 The following arguments are supported:
 
 * `mysql_instance_no` - (Required) the ID of the associated Mysql Instance.
-* `subnet_no` - (Optional, Required if `is_multi_zone` of MySQL Instance is true) The ID of the associate Subnet.
 * `recovery_server_name` (Required) Recovery server name to create. In order to prevent overlapping host names, random text is added. Can comprise only lower-case English alphabets, numbers and dash ( - ). The first letter must be an English alphabet and the last letter must be an English alphabet or a number. Min: 3, Max: 25
-* `file_name` - (Optional, One of `file_name` and `recovery_time` is required) The name of backup file. If you enter `file_name`, ignore the entry of `recovery_time`. 
-* `recovery_time` - (Optional, One of `file_name` and `recovery_time` is required) The time of recovery. If you enter `recovery_time`, ignore the entry of `file_name`.
+* `subnet_no` - (Optional, Required if `is_multi_zone` of MySQL Instance is true) The ID of the associate Subnet. Not available in Neurocloud and `gov` site.
+* `file_name` - (Optional, One of `file_name` and `recovery_time` is required) The name of backup file.
+* `recovery_time` - (Optional, One of `file_name` and `recovery_time` is required) The time of recovery.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported
 
 * `id` - MySQL Recovery Server Instance Number.
+* `mysql_server_list` - The list of the MySQL server.
+  * `server_instance_no` - Server instance number.
+  * `server_name` - Server name.
+  * `server_role` - Server role code. ex) M(Master), H(Standby Master)
+  * `zone_code` - Zone code.
+  * `subnet_no` - The ID of the associated Subnet.
+  * `product_code` - Product code.
+  * `is_public_subnet` - Public subnet status.
+  * `private_domain` - Private domain.
+  * `public_domain` - Public domain.
+  * `memory_size` - Available memory size.
+  * `cpu_count` - CPU count.
+  * `data_storage_size` - Storage size.
+  * `used_data_storage_size` - Size of data storage in use.
+  * `uptime` - Running start time.
+  * `create_date` - Server create date.
 
 # Import
 
 ### `terraform import` command
 
-* MySQL Recovery can be imported using the `id`. For example:
+* MySQL Recovery can be imported using the `mysql_instance_no`:`id`. For example:
 ```console
-$ terraform import ncloud_mysql_recovery.rsc_name 12345
+$ terraform import ncloud_mysql_recovery.rsc_name 12345:24678
 ```
 
 ### `import` block
 
-* In terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import MySQL Recovery using the `id`. For example:
+* In terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import MySQL Recovery using the `mysql_instance_no`:`id`. For example:
 
 ```terraform
 import {
     to = ncloud_mysql_recovery.rsc_name
-    id = "12345"
+    id = "12345:24678"
 }
 ```

--- a/docs/resources/mysql_slave.md
+++ b/docs/resources/mysql_slave.md
@@ -6,37 +6,37 @@ subcategory: "MySQL"
 
 Provides a MySQL slave resource.
 
-~> **NOTE:** This resource only supports VPC environment.
+~> **NOTE:** This resource only supports VPC environment. Only one server related resource (ncloud_mysql_slave, ncloud_mysql_recovery) can be created or deleted at a time.
 
 ## Example Usage
 
 ```terraform
-resource "ncloud_vpc" "test_vpc" {
-	name             = "%[1]s"
-	ipv4_cidr_block  = "10.5.0.0/16"
+resource "ncloud_vpc" "vpc" {
+  name             = "mysql-vpc"
+  ipv4_cidr_block  = "10.5.0.0/16"
 }
 
-resource "ncloud_subnet" "test_subnet" {
-	vpc_no             = ncloud_vpc.test_vpc.vpc_no
-	name               = "%[1]s"
-	subnet             = "10.5.0.0/24"
-	zone               = "KR-2"
-	network_acl_no     = ncloud_vpc.test_vpc.default_network_acl_no
-	subnet_type        = "PUBLIC"
+resource "ncloud_subnet" "subnet" {
+  vpc_no             = ncloud_vpc.vpc.vpc_no
+  name               = "mysql-subnet"
+  subnet             = "10.5.0.0/24"
+  zone               = "KR-2"
+  network_acl_no     = ncloud_vpc.vpc.default_network_acl_no
+  subnet_type        = "PUBLIC"
 }
 
 resource "ncloud_mysql" "mysql" {
-	subnet_no = data.ncloud_subnet.test_subnet.id
-	service_name = "%[1]s"
-	server_name_prefix = "testprefix"
-	user_name = "testusername"
-	user_password = "t123456789!a"
-	host_ip = "192.168.0.1"
-	database_name = "test_db"
+  subnet_no          = data.ncloud_subnet.subnet.id
+  service_name       = "tf-mysql"
+  server_name_prefix = "testprefix"
+  user_name          = "testusername"
+  user_password      = "t123456789!a"
+  host_ip            = "192.168.0.1"
+  database_name      = "test_db"
 }
 
 resource "ncloud_mysql_slave" "mysql_slave" {
-	mysql_instance_no = ncloud_mysql.mysql.id
+  mysql_instance_no = ncloud_mysql.mysql.id
 }
 ```
 
@@ -45,30 +45,46 @@ resource "ncloud_mysql_slave" "mysql_slave" {
 The following arguments are supported:
 
 * `mysql_instance_no` - (Required) the ID of the associated Mysql Instance.
-* `subnet_no` - (Optional, Required if `is_multi_zone` of MySQL Instance is true) The ID of the associate Subnet.
+* `subnet_no` - (Optional, Required if `is_multi_zone` of MySQL Instance is true) The ID of the associate Subnet. Not available in Neurocloud and `gov` site.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported
 
 * `id` - MySQL Slave Server Instance Number.
+* `mysql_server_list` - The list of the MySQL server.
+  * `server_instance_no` - Server instance number.
+  * `server_name` - Server name.
+  * `server_role` - Server role code. ex) M(Master), H(Standby Master)
+  * `zone_code` - Zone code.
+  * `subnet_no` - The ID of the associated Subnet.
+  * `product_code` - Product code.
+  * `is_public_subnet` - Public subnet status.
+  * `private_domain` - Private domain.
+  * `public_domain` - Public domain.
+  * `memory_size` - Available memory size.
+  * `cpu_count` - CPU count.
+  * `data_storage_size` - Storage size.
+  * `used_data_storage_size` - Size of data storage in use.
+  * `uptime` - Running start time.
+  * `create_date` - Server create date.
 
 # Import
 
 ### `terraform import` command
 
-* MySQL Slave can be imported using the `id`. For example:
+* MySQL Slave can be imported using the `mysql_instance_no`:`id`. For example:
 ```console
-$ terraform import ncloud_mysql_slave.rsc_name 12345
+$ terraform import ncloud_mysql_slave.rsc_name 12345:24678
 ```
 
 ### `import` block
 
-* In terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import MySQL Slave using the `id`. For example:
+* In terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import MySQL Slave using the `mysql_instance_no`:`id`. For example:
 
 ```terraform
 import {
     to = ncloud_mysql_slave.rsc_name
-    id = "12345"
+    id = "12345:24678"
 }
 ```

--- a/internal/service/mysql/mysql_slave.go
+++ b/internal/service/mysql/mysql_slave.go
@@ -3,10 +3,12 @@ package mysql
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vmysql"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -35,7 +37,18 @@ type mysqlSlaveResource struct {
 }
 
 func (r *mysqlSlaveResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	idParts := strings.Split(req.ID, ":")
+
+	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: mysql_instance_no:id Got: %q", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("mysql_instance_no"), idParts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), idParts[1])...)
 }
 
 func (r *mysqlSlaveResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -75,6 +88,59 @@ func (r *mysqlSlaveResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"mysql_server_list": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"server_instance_no": schema.StringAttribute{
+							Computed: true,
+						},
+						"server_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"server_role": schema.StringAttribute{
+							Computed: true,
+						},
+						"zone_code": schema.StringAttribute{
+							Computed: true,
+						},
+						"subnet_no": schema.StringAttribute{
+							Computed: true,
+						},
+						"product_code": schema.StringAttribute{
+							Computed: true,
+						},
+						"is_public_subnet": schema.BoolAttribute{
+							Computed: true,
+						},
+						"public_domain": schema.StringAttribute{
+							Computed: true,
+						},
+						"private_domain": schema.StringAttribute{
+							Computed: true,
+						},
+						"data_storage_size": schema.Int64Attribute{
+							Computed: true,
+						},
+						"used_data_storage_size": schema.Int64Attribute{
+							Computed: true,
+						},
+						"cpu_count": schema.Int64Attribute{
+							Computed: true,
+						},
+						"memory_size": schema.Int64Attribute{
+							Computed: true,
+						},
+						"uptime": schema.StringAttribute{
+							Computed: true,
+						},
+						"create_date": schema.StringAttribute{
+							Computed: true,
+						},
+					},
 				},
 			},
 		},
@@ -102,6 +168,18 @@ func (r *mysqlSlaveResource) Create(ctx context.Context, req resource.CreateRequ
 		CloudMysqlInstanceNo: plan.MysqlInstanceNo.ValueStringPointer(),
 	}
 
+	if !plan.SubnetNo.IsNull() && !plan.SubnetNo.IsUnknown() {
+		// In `gov`, multi_zone is always false, so subnet is auto-generated with default value
+		if r.config.Site == "gov" {
+			resp.Diagnostics.AddError(
+				"NOT SUPPORT GOV SITE",
+				"`subnet_no` does not support gov site",
+			)
+			return
+		}
+		reqParams.SubnetNo = plan.SubnetNo.ValueStringPointer()
+	}
+
 	tflog.Info(ctx, "CreateCloudMysqlSlave reqParams="+common.MarshalUncheckedString(reqParams))
 
 	response, err := r.config.Client.Vmysql.V2Api.CreateCloudMysqlSlaveInstance(reqParams)
@@ -109,6 +187,7 @@ func (r *mysqlSlaveResource) Create(ctx context.Context, req resource.CreateRequ
 		resp.Diagnostics.AddError("CREATING ERROR", err.Error())
 		return
 	}
+	tflog.Info(ctx, "CreateCloudMysqlSlave response="+common.MarshalUncheckedString(response))
 
 	if response == nil || len(response.CloudMysqlInstanceList) < 1 {
 		resp.Diagnostics.AddError("CREATING ERROR", "response valid")
@@ -117,38 +196,25 @@ func (r *mysqlSlaveResource) Create(ctx context.Context, req resource.CreateRequ
 
 	mysqlIns := response.CloudMysqlInstanceList[0]
 	serverList := mysqlIns.CloudMysqlServerInstanceList
+	var index int
 
-	if *mysqlIns.IsMultiZone {
-		if !plan.SubnetNo.IsNull() {
-			reqParams.SubnetNo = plan.SubnetNo.ValueStringPointer()
-		} else {
-			resp.Diagnostics.AddError(
-				"CREATING ERROR",
-				"when `is_multi_zone` is ture, SubnetNo should be set",
-			)
+	for i, server := range serverList {
+		if (server.CloudMysqlServerRole != nil && *server.CloudMysqlServerRole.Code == "S") && (*server.CloudMysqlServerInstanceStatusName == CREATING) {
+			index = i
+			break
 		}
 	}
 
-	if len(serverList) < 2 {
-		resp.Diagnostics.AddError("CREATING ERROR", "response invalid")
-		return
-	}
-
-	slaveServer, err := GetMysqlSlave(ctx, r.config, plan.MysqlInstanceNo.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("READ ERROR", err.Error())
-		return
-	}
-
-	plan.ID = types.StringPointerValue(slaveServer.CloudMysqlServerInstanceNo)
-
-	output, err := waitMysqlSlaveCreation(ctx, r.config, *mysqlIns.CloudMysqlInstanceNo)
+	output, err := waitMysqlServerCreation(ctx, r.config, *mysqlIns.CloudMysqlInstanceNo, index)
 	if err != nil {
 		resp.Diagnostics.AddError("WAITING FOR CREATION ERROR", err.Error())
 		return
 	}
 
-	plan.refreshFromOutput(output, plan.MysqlInstanceNo.ValueStringPointer())
+	if diags := plan.refreshFromOutput(ctx, output, mysqlIns.CloudMysqlInstanceNo); diags.HasError() {
+		resp.Diagnostics.AddError("CREATING ERROR", "refreshFromOutput error")
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
@@ -161,7 +227,7 @@ func (r *mysqlSlaveResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	output, err := GetMysqlSlave(ctx, r.config, state.MysqlInstanceNo.ValueString())
+	output, err := GetMysqlSlave(ctx, r.config, state.MysqlInstanceNo.ValueString(), state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("READING ERROR", err.Error())
 		return
@@ -172,12 +238,12 @@ func (r *mysqlSlaveResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	state.refreshFromOutput(output, state.MysqlInstanceNo.ValueStringPointer())
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	if diags := state.refreshFromOutput(ctx, output, state.MysqlInstanceNo.ValueStringPointer()); diags.HasError() {
+		resp.Diagnostics.AddError("READING ERROR", "refreshFromOutput error")
 		return
 	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r *mysqlSlaveResource) Update(_ context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
@@ -202,43 +268,39 @@ func (r *mysqlSlaveResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("DELETING ERROR", err.Error())
 		return
 	}
-
 	tflog.Info(ctx, "DeleteMysqlSlave response="+common.MarshalUncheckedString(response))
 
-	if err := waitMysqlSlaveDeletion(ctx, r.config, state.MysqlInstanceNo.ValueString()); err != nil {
+	if err := waitMysqlSlaveDeletion(ctx, r.config, state.MysqlInstanceNo.ValueString(), state.ID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("WAITING FOR DELETE ERROR", err.Error())
+		return
 	}
 }
 
-func waitMysqlSlaveCreation(ctx context.Context, config *conn.ProviderConfig, id string) (*vmysql.CloudMysqlServerInstance, error) {
-	var mysqlInstance *vmysql.CloudMysqlServerInstance
+func waitMysqlServerCreation(ctx context.Context, config *conn.ProviderConfig, instanceNo string, index int) ([]*vmysql.CloudMysqlServerInstance, error) {
+	var mysqlInstance []*vmysql.CloudMysqlServerInstance
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{CREATING, SETTING},
 		Target:  []string{RUNNING},
 		Refresh: func() (interface{}, string, error) {
-			instance, err := GetMysqlSlave(ctx, config, id)
+			instance, err := findMysqlServerByIndex(ctx, config, instanceNo, index)
 			mysqlInstance = instance
 			if err != nil {
 				return 0, "", err
 			}
 
-			status := instance.CloudMysqlServerInstanceStatusName
-			if *status == CREATING {
-				return instance, CREATING, nil
+			if instance == nil {
+				return 0, "", fmt.Errorf("Instance is nil")
 			}
 
-			if *status == SETTING {
-				return instance, SETTING, nil
-			}
-
-			if *status == RUNNING {
-				return instance, RUNNING, nil
+			status := instance[0].CloudMysqlServerInstanceStatusName
+			if *status == CREATING || *status == SETTING || *status == RUNNING {
+				return instance, *status, nil
 			}
 
 			return 0, "", fmt.Errorf("error occurred while waiting to create mysql slave")
 		},
 		Timeout:    6 * conn.DefaultTimeout,
-		Delay:      2 * time.Second,
+		Delay:      3 * time.Minute,
 		MinTimeout: 3 * time.Second,
 	}
 
@@ -250,12 +312,12 @@ func waitMysqlSlaveCreation(ctx context.Context, config *conn.ProviderConfig, id
 	return mysqlInstance, nil
 }
 
-func waitMysqlSlaveDeletion(ctx context.Context, config *conn.ProviderConfig, id string) error {
+func waitMysqlSlaveDeletion(ctx context.Context, config *conn.ProviderConfig, instanceNo string, serverInstanceNo string) error {
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{DELETING},
 		Target:  []string{DELETED},
 		Refresh: func() (interface{}, string, error) {
-			instance, err := GetMysqlSlave(ctx, config, id)
+			instance, err := GetMysqlSlave(ctx, config, instanceNo, serverInstanceNo)
 			if err != nil {
 				return 0, "", err
 			}
@@ -264,34 +326,57 @@ func waitMysqlSlaveDeletion(ctx context.Context, config *conn.ProviderConfig, id
 				return instance, DELETED, nil
 			}
 
-			status := instance.CloudMysqlServerInstanceStatusName
+			status := instance[0].CloudMysqlServerInstanceStatusName
 
-			if *status == DELETING {
-				return instance, DELETING, nil
-			}
-
-			if *status == DELETED {
-				return instance, DELETED, nil
+			if *status == DELETING || *status == DELETED {
+				return instance, *status, nil
 			}
 
 			return 0, "", fmt.Errorf("error occurred while waiting to delete mysql slave")
 		},
 		Timeout:    conn.DefaultTimeout,
-		Delay:      2 * time.Second,
+		Delay:      1 * time.Minute,
 		MinTimeout: 3 * time.Second,
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("error waiting for mysql slave (%s) to become terminating: %s", id, err)
+		return fmt.Errorf("error waiting for mysql slave (%s) to become terminating: %s", serverInstanceNo, err)
 	}
 
 	return nil
 }
 
-func GetMysqlSlave(ctx context.Context, config *conn.ProviderConfig, no string) (*vmysql.CloudMysqlServerInstance, error) {
+func findMysqlServerByIndex(ctx context.Context, config *conn.ProviderConfig, instanceNo string, index int) ([]*vmysql.CloudMysqlServerInstance, error) {
 	reqParams := &vmysql.GetCloudMysqlInstanceDetailRequest{
 		RegionCode:           &config.RegionCode,
-		CloudMysqlInstanceNo: ncloud.String(no),
+		CloudMysqlInstanceNo: ncloud.String(instanceNo),
+	}
+	tflog.Info(ctx, "GetMysqlDetail reqParams="+common.MarshalUncheckedString(reqParams))
+
+	resp, err := config.Client.Vmysql.V2Api.GetCloudMysqlInstanceDetail(reqParams)
+	if err != nil && !CheckIfAlreadyDeleted(err) {
+		return nil, err
+	}
+	tflog.Info(ctx, "GetMysqlDetail response="+common.MarshalUncheckedString(resp))
+
+	if resp == nil || len(resp.CloudMysqlInstanceList) < 1 {
+		return nil, fmt.Errorf("response is nil")
+	}
+
+	serverList := resp.CloudMysqlInstanceList[0].CloudMysqlServerInstanceList
+
+	for i, server := range serverList {
+		if i == index {
+			return []*vmysql.CloudMysqlServerInstance{server}, nil
+		}
+	}
+	return nil, nil
+}
+
+func GetMysqlSlave(ctx context.Context, config *conn.ProviderConfig, instanceNo string, serverInstanceNo string) ([]*vmysql.CloudMysqlServerInstance, error) {
+	reqParams := &vmysql.GetCloudMysqlInstanceDetailRequest{
+		RegionCode:           &config.RegionCode,
+		CloudMysqlInstanceNo: ncloud.String(instanceNo),
 	}
 	tflog.Info(ctx, "GetMysqlDetail reqParams="+common.MarshalUncheckedString(reqParams))
 
@@ -308,8 +393,8 @@ func GetMysqlSlave(ctx context.Context, config *conn.ProviderConfig, no string) 
 	serverList := resp.CloudMysqlInstanceList[0].CloudMysqlServerInstanceList
 
 	for _, server := range serverList {
-		if *server.CloudMysqlServerRole.CodeName == "Slave" {
-			return server, nil
+		if (server.CloudMysqlServerRole != nil && *server.CloudMysqlServerRole.Code == "S") && (*server.CloudMysqlServerInstanceNo == serverInstanceNo) {
+			return []*vmysql.CloudMysqlServerInstance{server}, nil
 		}
 	}
 	return nil, nil
@@ -319,10 +404,16 @@ type mysqlSlaveResourceModel struct {
 	ID              types.String `tfsdk:"id"`
 	MysqlInstanceNo types.String `tfsdk:"mysql_instance_no"`
 	SubnetNo        types.String `tfsdk:"subnet_no"`
+	MysqlServerList types.List   `tfsdk:"mysql_server_list"`
 }
 
-func (r *mysqlSlaveResourceModel) refreshFromOutput(output *vmysql.CloudMysqlServerInstance, id *string) {
-	r.ID = types.StringPointerValue(output.CloudMysqlServerInstanceNo)
-	r.MysqlInstanceNo = types.StringPointerValue(id)
-	r.SubnetNo = types.StringPointerValue(output.SubnetNo)
+func (r *mysqlSlaveResourceModel) refreshFromOutput(ctx context.Context, output []*vmysql.CloudMysqlServerInstance, instanceNo *string) diag.Diagnostics {
+	r.ID = types.StringPointerValue(output[0].CloudMysqlServerInstanceNo)
+	r.MysqlInstanceNo = types.StringPointerValue(instanceNo)
+	r.SubnetNo = types.StringPointerValue(output[0].SubnetNo)
+
+	serverList, diags := listValueFromMysqlServerList(ctx, output)
+	r.MysqlServerList = serverList
+
+	return diags
 }

--- a/internal/service/mysql/mysql_test.go
+++ b/internal/service/mysql/mysql_test.go
@@ -158,11 +158,11 @@ func TestAccResourceNcloudMysql_error_case(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccMysqlVpcConfigErrorCaseWhenIsHaSetFalse1(testMysqlName),
-				ExpectError: regexp.MustCompile("when `is_ha` is false, `is_multi_zone` parameter is not used"),
+				ExpectError: regexp.MustCompile("Invalid Attribute Combination"),
 			},
 			{
 				Config:      testAccMysqlVpcConfigErrorCaseWhenIsHaSetFalse2(testMysqlName),
-				ExpectError: regexp.MustCompile("when `is_ha` is false, `standby_master_subnet_no` is not used"),
+				ExpectError: regexp.MustCompile("Invalid Attribute Combination"),
 			},
 			{
 				Config:      testAccMysqlVpcConfigErrorCaseWhenIsHaSetFalse3(testMysqlName),


### PR DESCRIPTION
### Related
https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/447
https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/450

### Description
- FIX import and minor errors
- Change to a common function that can be reused across multiple resources
- Modify DOC

### AccTest results
```
=== RUN   TestAccResourceNcloudMysqlSlave_vpc_basic
--- PASS: TestAccResourceNcloudMysqlSlave_vpc_basic (1970.24s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ncloud/internal/service/mysql	1971.140s

=== RUN   TestAccResourceNcloudMysqlRecovery_vpc_basic
--- PASS: TestAccResourceNcloudMysqlRecovery_vpc_basic (1857.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ncloud/internal/service/mysql	1857.993s
```