### PR TITLE
fix(objectstorage): Fix obs import error

### DIFF
--- a/docs/resources/objectstorage_bucket.md
+++ b/docs/resources/objectstorage_bucket.md
@@ -28,11 +28,11 @@ resource "ncloud_objectstorage_bucket" "testing_bucket" {
 
 The following arguments are supported:
 
-* `id` - Unique ID for bucket. Since bucket name is already unique in specific region, ID is same as `bucket_name`.
 * `bucket_name` - (Required) Bucket name to create. Bucket name must be between 3 and 63 characters long, can contain lowercase letters, numbers, periods, and hyphens. It must start and end with a letter or number, and cannot have consecutive periods.
 
 ## Attribute Reference
 
+* `id` - Unique ID for bucket. Since bucket name is already unique in specific region, ID is same as `bucket_name`.
 * `creation_date` - Date of when this bucket created.
 
 ## Import

--- a/docs/resources/objectstorage_bucket.md
+++ b/docs/resources/objectstorage_bucket.md
@@ -30,6 +30,9 @@ The following arguments are supported:
 
 * `id` - Unique ID for bucket. Since bucket name is already unique in specific region, ID is same as `bucket_name`.
 * `bucket_name` - (Required) Bucket name to create. Bucket name must be between 3 and 63 characters long, can contain lowercase letters, numbers, periods, and hyphens. It must start and end with a letter or number, and cannot have consecutive periods.
+
+## Attribute Reference
+
 * `creation_date` - Date of when this bucket created.
 
 ## Import

--- a/docs/resources/objectstorage_bucket.md
+++ b/docs/resources/objectstorage_bucket.md
@@ -36,10 +36,10 @@ The following arguments are supported:
 
 ### `terraform import` command
 
-* Object Storage Bucket can be imported using the `bucket_name`. For example:
+* Object Storage Bucket can be imported using the `bucket-name`. For example:
 
 ```console
-$ terraform import ncloud_objectstorage_object.rsc_name bucket-name
+$ terraform import ncloud_objectstorage_bucket.rsc_name bucket-name
 ```
 
 ### `import` block
@@ -48,7 +48,7 @@ $ terraform import ncloud_objectstorage_object.rsc_name bucket-name
 
 ```terraform
 import {
-    to = ncloud_objectstorage_object.rsc_name
-    bucket_name = "bucket-name"
+    to = ncloud_objectstorage_bucket.rsc_name
+    id = "bucket-name"
 }
 ```

--- a/docs/resources/objectstorage_bucket.md
+++ b/docs/resources/objectstorage_bucket.md
@@ -39,10 +39,10 @@ The following arguments are supported:
 
 ### `terraform import` command
 
-* Object Storage Bucket can be imported using the `bucket-name`. For example:
+* Object Storage Bucket can be imported using the `id`. For example:
 
 ```console
-$ terraform import ncloud_objectstorage_bucket.rsc_name bucket-name
+$ terraform import ncloud_objectstorage_bucket.rsc_name example-id
 ```
 
 ### `import` block
@@ -52,6 +52,6 @@ $ terraform import ncloud_objectstorage_bucket.rsc_name bucket-name
 ```terraform
 import {
     to = ncloud_objectstorage_bucket.rsc_name
-    id = "bucket-name"
+    id = "example-id"
 }
 ```

--- a/docs/resources/objectstorage_bucket_acl.md
+++ b/docs/resources/objectstorage_bucket_acl.md
@@ -41,6 +41,8 @@ The following arguments are supported:
 
 ## Import
 
+~> **NOTE:** Import is temporary unavailable in `ncloud_objectstorage_bucket_acl`. Please import by manually written terraform code with right `rule` attribute in it.
+
 ### `terraform import` command
 
 * Object Storage Bucket ACL can be imported using the `bucket_name`. For example:
@@ -56,6 +58,6 @@ $ terraform import ncloud_objectstorage_bucket_acl.rsc_name bucket_acl_bucket-na
 ```terraform
 import {
     to = ncloud_objectstorage_bucket_acl.rsc_name
-    bucket_name = "bucket_acl_bucket-name"
+    id = "bucket_acl_bucket-name"
 }
 ```

--- a/docs/resources/objectstorage_bucket_acl.md
+++ b/docs/resources/objectstorage_bucket_acl.md
@@ -36,6 +36,9 @@ The following arguments are supported:
 * `id` - Unique ID for bucket. As same as `bucket_name`.
 * `bucket_name` - (Required) Target bucket id to create(same as bucket name). Bucket name must be between 3 and 63 characters long, can contain lowercase letters, numbers, periods, and hyphens. It must start and end with a letter or number, and cannot have consecutive periods.
 * `rule` - (Required) Rule to apply. Value must be one of "private", "public-read", "public-read-write", "authenticated-read".
+
+## Attribute Reference
+
 * `grants` - List of member who grants this rule. Consists of `grantee`, `permission`. Individual `grantee` has `type`, `display_name`, `email-address`, `id`, `uri` attributes.
 * `owner` - Who owns this ACL.
 

--- a/docs/resources/objectstorage_bucket_acl.md
+++ b/docs/resources/objectstorage_bucket_acl.md
@@ -25,7 +25,7 @@ resource "ncloud_objectstorage_bucket" "testing_bucket" {
 
 resource "ncloud_objectstorage_bucket_acl" "testing_acl" {
     bucket_name				= ncloud_objectstorage_bucket.testing_bucket.bucket_name
-    rule					= "RULL_TO_APPLY"
+    rule					= "public-read"
 }
 ```
 

--- a/docs/resources/objectstorage_bucket_acl.md
+++ b/docs/resources/objectstorage_bucket_acl.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 ## Import
 
-~> **NOTE:** Import is temporary unavailable in `ncloud_objectstorage_bucket_acl`. Please import by manually written terraform code with right `rule` attribute in it.
+~> **NOTE:** When importing `ncloud_objectstorage_bucket_acl`, the `rule` value cannot be retrieved automatically. User need to manually set the `rule` value in your Terraform state file before import.
 
 ### `terraform import` command
 

--- a/docs/resources/objectstorage_bucket_acl.md
+++ b/docs/resources/objectstorage_bucket_acl.md
@@ -33,13 +33,20 @@ resource "ncloud_objectstorage_bucket_acl" "testing_acl" {
 
 The following arguments are supported:
 
-* `id` - Unique ID for bucket. As same as `bucket_name`.
 * `bucket_name` - (Required) Target bucket id to create(same as bucket name). Bucket name must be between 3 and 63 characters long, can contain lowercase letters, numbers, periods, and hyphens. It must start and end with a letter or number, and cannot have consecutive periods.
 * `rule` - (Required) Rule to apply. Value must be one of "private", "public-read", "public-read-write", "authenticated-read".
 
 ## Attribute Reference
 
-* `grants` - List of member who grants this rule. Consists of `grantee`, `permission`. Individual `grantee` has `type`, `display_name`, `email-address`, `id`, `uri` attributes.
+* `id` - Unique ID for bucket. As same as `bucket_name`.
+* `grants` - List of member who grants this rule.
+  * `grantee` - The person being granted permissions.
+    * `type` - Type of grantee
+    * `display_name` - Screen name of the grantee.
+    * `email_address` - Email address of the grantee.
+    * `id` - The canonical user ID of the grantee.
+    * `uri` - URI of the grantee group.
+  * `permission` - Specifies the permission given to the grantee.
 * `owner` - Who owns this ACL.
 
 ## Import

--- a/docs/resources/objectstorage_bucket_acl.md
+++ b/docs/resources/objectstorage_bucket_acl.md
@@ -33,7 +33,7 @@ resource "ncloud_objectstorage_bucket_acl" "testing_acl" {
 
 The following arguments are supported:
 
-* `id` - Unique ID for bucket. Has format of `bucket_acl_${bucket_name}`.
+* `id` - Unique ID for bucket. As same as `bucket_name`.
 * `bucket_name` - (Required) Target bucket id to create(same as bucket name). Bucket name must be between 3 and 63 characters long, can contain lowercase letters, numbers, periods, and hyphens. It must start and end with a letter or number, and cannot have consecutive periods.
 * `rule` - (Required) Rule to apply. Value must be one of "private", "public-read", "public-read-write", "authenticated-read".
 * `grants` - List of member who grants this rule. Consists of `grantee`, `permission`. Individual `grantee` has `type`, `display_name`, `email-address`, `id`, `uri` attributes.
@@ -48,7 +48,7 @@ The following arguments are supported:
 * Object Storage Bucket ACL can be imported using the `bucket_name`. For example:
 
 ```console
-$ terraform import ncloud_objectstorage_bucket_acl.rsc_name bucket_acl_bucket-name
+$ terraform import ncloud_objectstorage_bucket_acl.rsc_name bucket-name
 ```
 
 ### `import` block
@@ -58,6 +58,6 @@ $ terraform import ncloud_objectstorage_bucket_acl.rsc_name bucket_acl_bucket-na
 ```terraform
 import {
     to = ncloud_objectstorage_bucket_acl.rsc_name
-    id = "bucket_acl_bucket-name"
+    id = "bucket-name"
 }
 ```

--- a/docs/resources/objectstorage_bucket_acl.md
+++ b/docs/resources/objectstorage_bucket_acl.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 ## Import
 
-~> **NOTE:** When importing `ncloud_objectstorage_bucket_acl`, the `rule` value cannot be retrieved automatically. User need to manually set the `rule` value in your Terraform state file before import.
+~> **NOTE:** When importing `ncloud_objectstorage_bucket_acl`, the `rule` value cannot be retrieved automatically. User need to manually set the `rule` value in your Terraform state file after import.
 
 ### `terraform import` command
 

--- a/docs/resources/objectstorage_object.md
+++ b/docs/resources/objectstorage_object.md
@@ -44,7 +44,7 @@ The following arguments are optional:
 
 ~> **NOTE:** Specially in `JPN` region, updating resource with only `content_type` changed will be blocked. 
 
-## Attribute Reference.
+## Attribute Reference
 
 ~> **NOTE:** Since Ncloud Object Stroage uses S3 Compatible SDK, these arguments are served as best-effort.
 

--- a/docs/resources/objectstorage_object.md
+++ b/docs/resources/objectstorage_object.md
@@ -50,6 +50,7 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - Unique ID for object. A combined string of bucket name and key in the format `bucket-name/key`.
 * `accept_ranges` - Indicates that a range of bytes was specified.
 * `content_length` - Size of the body in bytes.
 * `content_encoding` - Content encodings that have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field. Read [w3c content encoding](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11) for further information.

--- a/docs/resources/objectstorage_object_acl.md
+++ b/docs/resources/objectstorage_object_acl.md
@@ -48,12 +48,14 @@ The following arguments are supported:
 
 ## Import
 
+~> **NOTE:** Import is temporary unavailable in `ncloud_objectstorage_object_acl`. Please import by manually written terraform code with right `rule` attribute in it.
+
 ### `terraform import` command
 
-* Object Storage Object ACL can be imported using the `id`. For example:
+* Object Storage Object ACL can be imported using the `object-id`. For example:
 
 ```console
-$ terraform import ncloud_objectstorage_object_acl.rsc_name object_acl_objectID
+$ terraform import ncloud_objectstorage_object_acl.rsc_name object_acl_object-id
 ```
 
 ### `import` block
@@ -63,6 +65,6 @@ $ terraform import ncloud_objectstorage_object_acl.rsc_name object_acl_objectID
 ```terraform
 import {
     to = ncloud_objectstorage_object_acl.rsc_name
-    id = "object_acl_objectID"
+    id = "object_acl_object-id"
 }
 ```

--- a/docs/resources/objectstorage_object_acl.md
+++ b/docs/resources/objectstorage_object_acl.md
@@ -49,7 +49,7 @@ resource "ncloud_objectstorage_object_acl" "testing_acl" {
 
 ## Import
 
-~> **NOTE:** When importing `ncloud_objectstorage_object_acl`, the `rule` value cannot be retrieved automatically. User need to manually set the `rule` value in your Terraform state file before import.
+~> **NOTE:** When importing `ncloud_objectstorage_object_acl`, the `rule` value cannot be retrieved automatically. User need to manually set the `rule` value in your Terraform state file after import.
 
 ### `terraform import` command
 

--- a/docs/resources/objectstorage_object_acl.md
+++ b/docs/resources/objectstorage_object_acl.md
@@ -49,7 +49,7 @@ resource "ncloud_objectstorage_object_acl" "testing_acl" {
 
 ## Import
 
-~> **NOTE:** Import is temporary unavailable in `ncloud_objectstorage_object_acl`. Please import by manually written terraform code with right `rule` attribute in it.
+~> **NOTE:** When importing `ncloud_objectstorage_object_acl`, the `rule` value cannot be retrieved automatically. User need to manually set the `rule` value in your Terraform state file before import.
 
 ### `terraform import` command
 

--- a/docs/resources/objectstorage_object_acl.md
+++ b/docs/resources/objectstorage_object_acl.md
@@ -37,11 +37,12 @@ resource "ncloud_objectstorage_object_acl" "testing_acl" {
 
 ## Argument Reference
 
-The following arguments are supported:
-
-* `id` - Unique ID for ACL. As same as `object_id`.
 * `object_id` - (Required) Target object id to create.
 * `rule` - (Required) Rule to apply. Value must be one of "private", "public-read", "public-read-write", "authenticated-read".
+
+## Attribute Reference
+
+* `id` - Unique ID for ACL. As same as `object_id`.
 * `grants` - List of member who grants this rule. Consists of `grantee`, `permission`. Individual `grantee` has `type`, `display_name`, `email-address`, `id`, `uri` attributes.
 * `owner_id` - ID of owner.
 * `owner_displayname` - Name of owner.

--- a/docs/resources/objectstorage_object_acl.md
+++ b/docs/resources/objectstorage_object_acl.md
@@ -31,19 +31,26 @@ resource "ncloud_objectstorage_object" "testing_object" {
 
 resource "ncloud_objectstorage_object_acl" "testing_acl" {
     object_id			= ncloud_objectstorage_object.testing_object.id
-    rule				= "RULL_TO_APPLY"
+    rule				= "public-read'
 }
 ```
 
 ## Argument Reference
 
-* `object_id` - (Required) Target object id to create.
+* `object_id` - (Required) Target object id to create. Has format of `bucket-name/key`.
 * `rule` - (Required) Rule to apply. Value must be one of "private", "public-read", "public-read-write", "authenticated-read".
 
 ## Attribute Reference
 
-* `id` - Unique ID for ACL. As same as `object_id`.
-* `grants` - List of member who grants this rule. Consists of `grantee`, `permission`. Individual `grantee` has `type`, `display_name`, `email-address`, `id`, `uri` attributes.
+* `id` - Unique ID for ACL. As same as `object_id`. Has format of `bucket-name/key`.
+* `grants` - List of member who grants this rule.
+  * `grantee` - The person being granted permissions.
+    * `type` - Type of grantee
+    * `display_name` - Screen name of the grantee.
+    * `email_address` - Email address of the grantee.
+    * `id` - The canonical user ID of the grantee.
+    * `uri` - URI of the grantee group.
+  * `permission` - Specifies the permission given to the grantee.
 * `owner_id` - ID of owner.
 * `owner_displayname` - Name of owner.
 

--- a/docs/resources/objectstorage_object_acl.md
+++ b/docs/resources/objectstorage_object_acl.md
@@ -31,7 +31,7 @@ resource "ncloud_objectstorage_object" "testing_object" {
 
 resource "ncloud_objectstorage_object_acl" "testing_acl" {
     object_id			= ncloud_objectstorage_object.testing_object.id
-    rule				= "RULL_TO_APPLY" 
+    rule				= "RULL_TO_APPLY"
 }
 ```
 
@@ -39,7 +39,7 @@ resource "ncloud_objectstorage_object_acl" "testing_acl" {
 
 The following arguments are supported:
 
-* `id` - Unique ID for ACL. Has format of `object_acl_${object_id}`.
+* `id` - Unique ID for ACL. As same as `object_id`.
 * `object_id` - (Required) Target object id to create.
 * `rule` - (Required) Rule to apply. Value must be one of "private", "public-read", "public-read-write", "authenticated-read".
 * `grants` - List of member who grants this rule. Consists of `grantee`, `permission`. Individual `grantee` has `type`, `display_name`, `email-address`, `id`, `uri` attributes.
@@ -55,16 +55,16 @@ The following arguments are supported:
 * Object Storage Object ACL can be imported using the `object-id`. For example:
 
 ```console
-$ terraform import ncloud_objectstorage_object_acl.rsc_name object_acl_object-id
+$ terraform import ncloud_objectstorage_object_acl.rsc_name object-id
 ```
 
 ### `import` block
 
-* In Terraform v1.5.0 and later, use a [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Object Storage Bucket ACL using the `id`. For example:
+* In Terraform v1.5.0 and later, use a [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Object Storage Object ACL using the `object-id`. For example:
 
 ```terraform
 import {
     to = ncloud_objectstorage_object_acl.rsc_name
-    id = "object_acl_object-id"
+    id = "object-id"
 }
 ```

--- a/docs/resources/objectstorage_object_copy.md
+++ b/docs/resources/objectstorage_object_copy.md
@@ -60,6 +60,7 @@ The following arguments are supported:
 
 This resource exports the following attributes in addition to the arguments above:
 
+* `id` - Unique ID for object. A combined string of bucket name and key in the format `bucket-name/key`.
 * `accept_ranges` - Indicates that a range of bytes was specified.
 * `content_encoding` - Content encodings that have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field. Read [w3c content encoding](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11) for further information.
 * `content_language` - Language the content is in e.g., en-US or en-GB.

--- a/docs/resources/objectstorage_object_copy.md
+++ b/docs/resources/objectstorage_object_copy.md
@@ -46,7 +46,7 @@ The following arguments are required:
 
 * `bucket` - (Required) Name of the bucket to read the object from. Bucket name must be between 3 and 63 characters long, can contain lowercase letters, numbers, periods, and hyphens. It must start and end with a letter or number, and cannot have consecutive periods.
 * `key` - (Required) Full path to the object inside the bucket.
-* `source` - (Required) Path to the file you want to upload. 
+* `source` - (Required) Path to the file you want to upload.
 
 The following arguments are supported:
 
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 ~> **NOTE:** Specially in `JPN` region, updating resource with only `content_type` changed will be blocked. 
 
-## Attribute Reference.
+## Attribute Reference
 
 ~> **NOTE:** Since Ncloud Object Stroage uses S3 Compatible SDK, these arguments are served as best-effort.
 

--- a/internal/service/objectstorage/objectstorage_bucket.go
+++ b/internal/service/objectstorage/objectstorage_bucket.go
@@ -203,7 +203,7 @@ func waitBucketCreated(ctx context.Context, config *conn.ProviderConfig, bucketN
 			}
 
 			for _, bucket := range output.Buckets {
-				if *bucket.Name == TrimForParsing(bucketName) {
+				if *bucket.Name == RemoveQuotes(bucketName) {
 					return bucket, CREATED, nil
 				}
 			}
@@ -232,7 +232,7 @@ func waitBucketDeleted(ctx context.Context, config *conn.ProviderConfig, bucketN
 			}
 
 			for _, bucket := range output.Buckets {
-				if *bucket.Name == TrimForParsing(bucketName) {
+				if *bucket.Name == RemoveQuotes(bucketName) {
 					return bucket, DELETING, nil
 				}
 			}
@@ -267,7 +267,7 @@ func (o *bucketResourceModel) refreshFromOutput(ctx context.Context, config *con
 	}
 
 	for _, bucket := range output.Buckets {
-		if *bucket.Name == TrimForParsing(bucketName) {
+		if *bucket.Name == RemoveQuotes(bucketName) {
 			if !types.StringValue(bucket.CreationDate.GoString()).IsNull() {
 				o.CreationDate = types.StringValue(bucket.CreationDate.GoString())
 			}

--- a/internal/service/objectstorage/objectstorage_bucket.go
+++ b/internal/service/objectstorage/objectstorage_bucket.go
@@ -69,7 +69,7 @@ func (o *bucketResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	tflog.Info(ctx, "CreateObjectStorage response="+common.MarshalUncheckedString(response))
 
-	err = waitBucketCreated(ctx, o.config, plan.BucketName.String())
+	err = waitBucketCreated(ctx, o.config, plan.BucketName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("CREATING ERROR", err.Error())
 		return
@@ -104,7 +104,7 @@ func (o *bucketResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	tflog.Info(ctx, "DeleteBucket response="+common.MarshalUncheckedString(response))
 
-	if err := waitBucketDeleted(ctx, o.config, plan.BucketName.String()); err != nil {
+	if err := waitBucketDeleted(ctx, o.config, plan.BucketName.ValueString()); err != nil {
 		resp.Diagnostics.AddError("WAITING FOR DELETE ERROR", err.Error())
 	}
 }
@@ -203,7 +203,7 @@ func waitBucketCreated(ctx context.Context, config *conn.ProviderConfig, bucketN
 			}
 
 			for _, bucket := range output.Buckets {
-				if *bucket.Name == RemoveQuotes(bucketName) {
+				if *bucket.Name == bucketName {
 					return bucket, CREATED, nil
 				}
 			}
@@ -232,7 +232,7 @@ func waitBucketDeleted(ctx context.Context, config *conn.ProviderConfig, bucketN
 			}
 
 			for _, bucket := range output.Buckets {
-				if *bucket.Name == RemoveQuotes(bucketName) {
+				if *bucket.Name == bucketName {
 					return bucket, DELETING, nil
 				}
 			}
@@ -267,7 +267,7 @@ func (o *bucketResourceModel) refreshFromOutput(ctx context.Context, config *con
 	}
 
 	for _, bucket := range output.Buckets {
-		if *bucket.Name == RemoveQuotes(bucketName) {
+		if *bucket.Name == bucketName {
 			if !types.StringValue(bucket.CreationDate.GoString()).IsNull() {
 				o.CreationDate = types.StringValue(bucket.CreationDate.GoString())
 			}

--- a/internal/service/objectstorage/objectstorage_bucket.go
+++ b/internal/service/objectstorage/objectstorage_bucket.go
@@ -157,9 +157,6 @@ func (o *bucketResource) Schema(_ context.Context, req resource.SchemaRequest, r
 			},
 			"creation_date": schema.StringAttribute{
 				Computed: true,
-				// PlanModifiers: []planmodifier.String{
-				// 	stringplanmodifier.UseStateForUnknown(),
-				// },
 			},
 		},
 	}

--- a/internal/service/objectstorage/objectstorage_bucket.go
+++ b/internal/service/objectstorage/objectstorage_bucket.go
@@ -157,9 +157,9 @@ func (o *bucketResource) Schema(_ context.Context, req resource.SchemaRequest, r
 			},
 			"creation_date": schema.StringAttribute{
 				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				// PlanModifiers: []planmodifier.String{
+				// 	stringplanmodifier.UseStateForUnknown(),
+				// },
 			},
 		},
 	}

--- a/internal/service/objectstorage/objectstorage_bucket_acl.go
+++ b/internal/service/objectstorage/objectstorage_bucket_acl.go
@@ -315,7 +315,8 @@ func (b *bucketACLResourceModel) refreshFromOutput(ctx context.Context, config *
 	}
 
 	b.Grants = listValueFromGrants
-	b.ID = types.StringValue(fmt.Sprintf("bucket_acl_%s", b.BucketName))
+	b.ID = types.StringValue(fmt.Sprintf("bucket_acl_%s", RemoveQuotes(bucketName)))
+	b.BucketName = types.StringValue(RemoveQuotes(bucketName))
 	b.Owner = types.StringValue(*output.Owner.ID)
 }
 

--- a/internal/service/objectstorage/objectstorage_bucket_acl.go
+++ b/internal/service/objectstorage/objectstorage_bucket_acl.go
@@ -119,7 +119,7 @@ func (b *bucketACLResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	bucketName := TrimForParsing(plan.BucketName.String())
+	bucketName := RemoveQuotes(plan.BucketName.String())
 
 	reqParams := &s3.PutBucketAclInput{
 		Bucket: ncloud.String(bucketName),
@@ -177,7 +177,7 @@ func (b *bucketACLResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	if plan.Rule != state.Rule {
-		bucketName := TrimForParsing(state.BucketName.String())
+		bucketName := RemoveQuotes(state.BucketName.String())
 
 		reqParams := &s3.PutBucketAclInput{
 			Bucket: ncloud.String(bucketName),
@@ -270,7 +270,7 @@ type bucketACLResourceModel struct {
 
 func (b *bucketACLResourceModel) refreshFromOutput(ctx context.Context, config *conn.ProviderConfig, bucketName string, diag *diag.Diagnostics) {
 	output, err := config.Client.ObjectStorage.GetBucketAcl(ctx, &s3.GetBucketAclInput{
-		Bucket: ncloud.String(bucketName),
+		Bucket: ncloud.String(RemoveQuotes(bucketName)),
 	})
 	if err != nil {
 		diag.AddError("GetBucketAcl ERROR", err.Error())
@@ -370,9 +370,6 @@ func convertGrantsToListValueAtBucket(ctx context.Context, grants []awsTypes.Gra
 	}}, grantValues)
 }
 
-func TrimForParsing(s string) string {
-	s = strings.TrimSuffix(s, "\"")
-	s = strings.TrimPrefix(s, "\"")
-
-	return s
+func RemoveQuotes(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\"", ""), "\\", "")
 }

--- a/internal/service/objectstorage/objectstorage_bucket_acl.go
+++ b/internal/service/objectstorage/objectstorage_bucket_acl.go
@@ -156,7 +156,7 @@ func (b *bucketACLResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	plan.refreshFromOutput(ctx, b.config, strings.Split(plan.ID.String(), "_")[2], &resp.Diagnostics)
+	plan.refreshFromOutput(ctx, b.config, plan.ID.String(), &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -313,7 +313,7 @@ func (b *bucketACLResourceModel) refreshFromOutput(ctx context.Context, config *
 	}
 
 	b.Grants = listValueFromGrants
-	b.ID = types.StringValue(fmt.Sprintf("bucket_acl_%s", RemoveQuotes(bucketName)))
+	b.ID = types.StringValue(RemoveQuotes(bucketName))
 	b.BucketName = types.StringValue(RemoveQuotes(bucketName))
 	b.Owner = types.StringValue(*output.Owner.ID)
 }

--- a/internal/service/objectstorage/objectstorage_bucket_acl.go
+++ b/internal/service/objectstorage/objectstorage_bucket_acl.go
@@ -123,7 +123,7 @@ func (b *bucketACLResource) Create(ctx context.Context, req resource.CreateReque
 
 	reqParams := &s3.PutBucketAclInput{
 		Bucket: ncloud.String(bucketName),
-		ACL:    plan.Rule,
+		ACL:    *plan.Rule,
 	}
 
 	tflog.Info(ctx, "PutBucketACL reqParams="+common.MarshalUncheckedString(reqParams))
@@ -156,9 +156,7 @@ func (b *bucketACLResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	bucketName := TrimForParsing(plan.BucketName.String())
-
-	plan.refreshFromOutput(ctx, b.config, bucketName, &resp.Diagnostics)
+	plan.refreshFromOutput(ctx, b.config, strings.Split(plan.ID.String(), "_")[2], &resp.Diagnostics)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -181,7 +179,7 @@ func (b *bucketACLResource) Update(ctx context.Context, req resource.UpdateReque
 
 		reqParams := &s3.PutBucketAclInput{
 			Bucket: ncloud.String(bucketName),
-			ACL:    plan.Rule,
+			ACL:    *plan.Rule,
 		}
 
 		tflog.Info(ctx, "PutBucketACL update operation reqParams="+common.MarshalUncheckedString(reqParams))
@@ -261,11 +259,11 @@ func waitBucketACLApplied(ctx context.Context, config *conn.ProviderConfig, buck
 }
 
 type bucketACLResourceModel struct {
-	ID         types.String             `tfsdk:"id"`
-	BucketName types.String             `tfsdk:"bucket_name"`
-	Rule       awsTypes.BucketCannedACL `tfsdk:"rule"`
-	Grants     types.List               `tfsdk:"grants"`
-	Owner      types.String             `tfsdk:"owner"`
+	ID         types.String              `tfsdk:"id"`
+	BucketName types.String              `tfsdk:"bucket_name"`
+	Rule       *awsTypes.BucketCannedACL `tfsdk:"rule"`
+	Grants     types.List                `tfsdk:"grants"`
+	Owner      types.String              `tfsdk:"owner"`
 }
 
 func (b *bucketACLResourceModel) refreshFromOutput(ctx context.Context, config *conn.ProviderConfig, bucketName string, diag *diag.Diagnostics) {

--- a/internal/service/objectstorage/objectstorage_bucket_acl_test.go
+++ b/internal/service/objectstorage/objectstorage_bucket_acl_test.go
@@ -38,6 +38,12 @@ func TestAccResourceNcloudObjectStorage_bucket_acl_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rule", acl),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"rule"},
+			},
 		},
 	})
 }

--- a/internal/service/objectstorage/objectstorage_bucket_test.go
+++ b/internal/service/objectstorage/objectstorage_bucket_test.go
@@ -31,6 +31,11 @@ func TestAccResourceNcloudObjectStorage_bucket_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bucket_name", bucketName),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/internal/service/objectstorage/objectstorage_object.go
+++ b/internal/service/objectstorage/objectstorage_object.go
@@ -119,7 +119,7 @@ func (o *objectResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	tflog.Info(ctx, "DeleteObject response="+common.MarshalUncheckedString(response))
 
-	if err := waitObjectDeleted(ctx, o.config, plan.Bucket.String(), plan.Key.String()); err != nil {
+	if err := waitObjectDeleted(ctx, o.config, plan.Bucket.ValueString(), plan.Key.ValueString()); err != nil {
 		resp.Diagnostics.AddError("WAITING FOR DELETE ERROR", err.Error())
 	}
 }
@@ -428,9 +428,7 @@ func (o *objectResourceModel) refreshFromOutput(ctx context.Context, config *con
 		return
 	}
 
-	bucketName, key := RemoveQuotes(o.Bucket.String()), RemoveQuotes(o.Key.String())
-
-	o.ID = types.StringValue(ObjectIDGenerator(bucketName, key))
+	o.ID = types.StringValue(ObjectIDGenerator(o.Bucket.ValueString(), o.Key.ValueString()))
 	if !types.StringPointerValue(output.AcceptRanges).IsNull() || !types.StringPointerValue(output.AcceptRanges).IsUnknown() {
 		o.AcceptRanges = types.StringPointerValue(output.AcceptRanges)
 	}

--- a/internal/service/objectstorage/objectstorage_object.go
+++ b/internal/service/objectstorage/objectstorage_object.go
@@ -164,8 +164,7 @@ func (o *objectResource) Schema(_ context.Context, req resource.SchemaRequest, r
 				Description: "(Required) Name of the object once it is in the bucket",
 			},
 			"source": schema.StringAttribute{
-				Optional:  true,
-				Computed:  false,
+				Required:  true,
 				Sensitive: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/service/objectstorage/objectstorage_object.go
+++ b/internal/service/objectstorage/objectstorage_object.go
@@ -92,7 +92,8 @@ func (o *objectResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	if diag := plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics); diag.HasError() {
+	plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -139,7 +140,8 @@ func (o *objectResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	if diag := plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics); diag.HasError() {
+	plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -304,7 +306,8 @@ func (o *objectResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	if diag := plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics); diag.HasError() {
+	plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -422,18 +425,18 @@ type objectResourceModel struct {
 	WebsiteRedirectLocation types.String `tfsdk:"website_redirect_location"`
 }
 
-func (o *objectResourceModel) refreshFromOutput(ctx context.Context, config *conn.ProviderConfig, diag *diag.Diagnostics) diag.Diagnostics {
+func (o *objectResourceModel) refreshFromOutput(ctx context.Context, config *conn.ProviderConfig, diag *diag.Diagnostics) {
 	output, err := config.Client.ObjectStorage.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: o.Bucket.ValueStringPointer(),
 		Key:    o.Key.ValueStringPointer(),
 	})
 	if err != nil {
 		diag.AddError("HeadObject ERROR", err.Error())
-		return *diag
+		return
 	}
 	if output == nil {
 		diag.AddError("HeadObject ERROR", "invalid output")
-		return *diag
+		return
 	}
 
 	o.ID = types.StringValue(ObjectIDGenerator(o.Bucket.ValueString(), o.Key.ValueString()))
@@ -480,9 +483,8 @@ func (o *objectResourceModel) refreshFromOutput(ctx context.Context, config *con
 	if output.LastModified != nil {
 		o.LastModified = types.StringValue(output.LastModified.Format(time.RFC3339))
 	}
-
-	return nil
 }
+
 func ObjectIDGenerator(bucketName, key string) string {
 	return fmt.Sprintf("%s/%s", bucketName, key)
 }

--- a/internal/service/objectstorage/objectstorage_object.go
+++ b/internal/service/objectstorage/objectstorage_object.go
@@ -306,6 +306,14 @@ func (o *objectResource) Update(ctx context.Context, req resource.UpdateRequest,
 func (o *objectResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	bucketName, key := ObjectIDParser(req.ID)
 
+	if bucketName == "" || key == "" {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: bucket-name/key Got: %q", req.ID),
+		)
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("bucket"), bucketName)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key"), key)...)
 }

--- a/internal/service/objectstorage/objectstorage_object.go
+++ b/internal/service/objectstorage/objectstorage_object.go
@@ -164,7 +164,9 @@ func (o *objectResource) Schema(_ context.Context, req resource.SchemaRequest, r
 				Description: "(Required) Name of the object once it is in the bucket",
 			},
 			"source": schema.StringAttribute{
-				Required: true,
+				Optional:  true,
+				Computed:  false,
+				Sensitive: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -303,7 +305,10 @@ func (o *objectResource) Update(ctx context.Context, req resource.UpdateRequest,
 }
 
 func (o *objectResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	bucketName, key := ObjectIDParser(req.ID)
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("bucket"), bucketName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key"), key)...)
 }
 
 func (o *objectResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/service/objectstorage/objectstorage_object.go
+++ b/internal/service/objectstorage/objectstorage_object.go
@@ -411,8 +411,12 @@ func (o *objectResourceModel) refreshFromOutput(ctx context.Context, config *con
 		diag.AddError("HeadObject ERROR", err.Error())
 		return
 	}
+	if output == nil {
+		diag.AddError("HeadObject ERROR", "invalid output")
+		return
+	}
 
-	bucketName, key := TrimForParsing(o.Bucket.String()), TrimForParsing(o.Key.String())
+	bucketName, key := RemoveQuotes(o.Bucket.String()), RemoveQuotes(o.Key.String())
 
 	o.ID = types.StringValue(ObjectIDGenerator(bucketName, key))
 	if !types.StringPointerValue(output.AcceptRanges).IsNull() || !types.StringPointerValue(output.AcceptRanges).IsUnknown() {

--- a/internal/service/objectstorage/objectstorage_object_acl.go
+++ b/internal/service/objectstorage/objectstorage_object_acl.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
@@ -210,10 +209,8 @@ func (o *objectACLResource) Update(ctx context.Context, req resource.UpdateReque
 }
 
 func (o *objectACLResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	objectId := strings.Split(req.ID, "_")[2]
-
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("object_id"), objectId)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("object_id"), req.ID)...)
 }
 
 func (o *objectACLResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -323,7 +320,7 @@ func (o *objectACLResourceModel) refreshFromOutput(ctx context.Context, config *
 	}
 
 	o.Grants = listValueWithGrants
-	o.ID = types.StringValue(fmt.Sprintf("object_acl_%s", RemoveQuotes(o.ObjectID.String())))
+	o.ID = types.StringValue(RemoveQuotes(o.ObjectID.String()))
 	o.OwnerID = types.StringValue(*output.Owner.ID)
 	o.OwnerDisplayName = types.StringValue(*output.Owner.DisplayName)
 }

--- a/internal/service/objectstorage/objectstorage_object_acl.go
+++ b/internal/service/objectstorage/objectstorage_object_acl.go
@@ -50,7 +50,7 @@ func (o *objectACLResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	bucketName, key := ObjectIDParser(plan.ObjectID.String())
+	bucketName, key := ObjectIDParser(plan.ObjectID.ValueString())
 
 	reqParams := &s3.PutObjectAclInput{
 		Bucket: ncloud.String(bucketName),
@@ -73,7 +73,7 @@ func (o *objectACLResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	if err := plan.refreshFromOutput(ctx, o.config, plan.ObjectID.String(), &resp.Diagnostics); err != nil {
+	if err := plan.refreshFromOutput(ctx, o.config, plan.ObjectID.ValueString(), &resp.Diagnostics); err != nil {
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -94,7 +94,7 @@ func (o *objectACLResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	if err := plan.refreshFromOutput(ctx, o.config, plan.ObjectID.String(), &resp.Diagnostics); err != nil {
+	if err := plan.refreshFromOutput(ctx, o.config, plan.ObjectID.ValueString(), &resp.Diagnostics); err != nil {
 		return
 	}
 
@@ -184,7 +184,7 @@ func (o *objectACLResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	if plan.Rule != state.Rule {
-		bucketName, key := ObjectIDParser(state.ObjectID.String())
+		bucketName, key := ObjectIDParser(state.ObjectID.ValueString())
 
 		reqParams := &s3.PutObjectAclInput{
 			Bucket: ncloud.String(bucketName),
@@ -207,7 +207,7 @@ func (o *objectACLResource) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 
-		if err := plan.refreshFromOutput(ctx, o.config, state.ObjectID.String(), &resp.Diagnostics); err != nil {
+		if err := plan.refreshFromOutput(ctx, o.config, state.ObjectID.ValueString(), &resp.Diagnostics); err != nil {
 			return
 		}
 		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -280,8 +280,8 @@ func (o *objectACLResourceModel) refreshFromOutput(ctx context.Context, config *
 	bucketName, key := ObjectIDParser(id)
 
 	output, err := config.Client.ObjectStorage.GetObjectAcl(ctx, &s3.GetObjectAclInput{
-		Bucket: ncloud.String(RemoveQuotes(bucketName)),
-		Key:    ncloud.String(RemoveQuotes(key)),
+		Bucket: ncloud.String(bucketName),
+		Key:    ncloud.String(key),
 	})
 	if err != nil {
 		diag.AddError("GetObjectAcl ERROR", err.Error())
@@ -326,7 +326,7 @@ func (o *objectACLResourceModel) refreshFromOutput(ctx context.Context, config *
 	}
 
 	o.Grants = listValueWithGrants
-	o.ID = types.StringValue(RemoveQuotes(o.ObjectID.String()))
+	o.ID = types.StringValue(o.ObjectID.ValueString())
 	o.OwnerID = types.StringValue(*output.Owner.ID)
 	o.OwnerDisplayName = types.StringValue(*output.Owner.DisplayName)
 

--- a/internal/service/objectstorage/objectstorage_object_acl.go
+++ b/internal/service/objectstorage/objectstorage_object_acl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
@@ -55,7 +56,7 @@ func (o *objectACLResource) Create(ctx context.Context, req resource.CreateReque
 	reqParams := &s3.PutObjectAclInput{
 		Bucket: ncloud.String(bucketName),
 		Key:    ncloud.String(key),
-		ACL:    plan.Rule,
+		ACL:    *plan.Rule,
 	}
 
 	tflog.Info(ctx, "PutObjectACL reqParams="+common.MarshalUncheckedString(reqParams))
@@ -185,7 +186,7 @@ func (o *objectACLResource) Update(ctx context.Context, req resource.UpdateReque
 		reqParams := &s3.PutObjectAclInput{
 			Bucket: ncloud.String(bucketName),
 			Key:    ncloud.String(key),
-			ACL:    plan.Rule,
+			ACL:    *plan.Rule,
 		}
 
 		tflog.Info(ctx, "PutObjectACL update operation reqParams="+common.MarshalUncheckedString(reqParams))
@@ -264,12 +265,12 @@ func waitObjectACLApplied(ctx context.Context, config *conn.ProviderConfig, buck
 }
 
 type objectACLResourceModel struct {
-	ID               types.String             `tfsdk:"id"`
-	ObjectID         types.String             `tfsdk:"object_id"`
-	Rule             awsTypes.ObjectCannedACL `tfsdk:"rule"`
-	Grants           types.List               `tfsdk:"grants"`
-	OwnerID          types.String             `tfsdk:"owner_id"`
-	OwnerDisplayName types.String             `tfsdk:"owner_displayname"`
+	ID               types.String              `tfsdk:"id"`
+	ObjectID         types.String              `tfsdk:"object_id"`
+	Rule             *awsTypes.ObjectCannedACL `tfsdk:"rule"`
+	Grants           types.List                `tfsdk:"grants"`
+	OwnerID          types.String              `tfsdk:"owner_id"`
+	OwnerDisplayName types.String              `tfsdk:"owner_displayname"`
 }
 
 func (o *objectACLResourceModel) refreshFromOutput(ctx context.Context, config *conn.ProviderConfig, id string, diag *diag.Diagnostics) {
@@ -322,7 +323,7 @@ func (o *objectACLResourceModel) refreshFromOutput(ctx context.Context, config *
 	}
 
 	o.Grants = listValueWithGrants
-	o.ID = types.StringValue(fmt.Sprintf("object_acl_%s", o.ObjectID))
+	o.ID = types.StringValue(fmt.Sprintf("object_acl_%s", RemoveQuotes(o.ObjectID.String())))
 	o.OwnerID = types.StringValue(*output.Owner.ID)
 	o.OwnerDisplayName = types.StringValue(*output.Owner.DisplayName)
 }

--- a/internal/service/objectstorage/objectstorage_object_acl_test.go
+++ b/internal/service/objectstorage/objectstorage_object_acl_test.go
@@ -46,6 +46,12 @@ func TestAccResourceNcloudObjectStorage_object_acl_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rule", acl),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"rule"},
+			},
 		},
 	})
 }
@@ -81,6 +87,12 @@ func TestAccResourceNcloudObjectStorage_object_acl_update(t *testing.T) {
 					testAccCheckObjectACLExists(resourceName, GetTestProvider(true)),
 					resource.TestCheckResourceAttr(resourceName, "rule", newACL),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"rule"},
 			},
 		},
 	})

--- a/internal/service/objectstorage/objectstorage_object_copy.go
+++ b/internal/service/objectstorage/objectstorage_object_copy.go
@@ -424,6 +424,10 @@ func (o *objectCopyResourceModel) refreshFromOutput(ctx context.Context, config 
 		diag.AddError("HeadObject ERROR", err.Error())
 		return
 	}
+	if output == nil {
+		diag.AddError("HeadObject ERROR", "invalid output")
+		return
+	}
 
 	bucketName, key := RemoveQuotes(o.Bucket.String()), RemoveQuotes(o.Key.String())
 

--- a/internal/service/objectstorage/objectstorage_object_copy.go
+++ b/internal/service/objectstorage/objectstorage_object_copy.go
@@ -101,7 +101,8 @@ func (o *objectCopyResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	if diag := plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics); diag.HasError() {
+	plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
@@ -162,7 +163,8 @@ func (o *objectCopyResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	if diag := plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics); diag.HasError() {
+	plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -287,7 +289,8 @@ func (o *objectCopyResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 
-		if diag := plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics); diag.HasError() {
+		plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
 			return
 		}
 	}
@@ -345,7 +348,8 @@ func (o *objectCopyResource) Update(ctx context.Context, req resource.UpdateRequ
 			return
 		}
 
-		if diag := plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics); diag.HasError() {
+		plan.refreshFromOutput(ctx, o.config, &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
 			return
 		}
 
@@ -431,18 +435,18 @@ type objectCopyResourceModel struct {
 	WebsiteRedirectLocation types.String `tfsdk:"website_redirect_location"`
 }
 
-func (o *objectCopyResourceModel) refreshFromOutput(ctx context.Context, config *conn.ProviderConfig, diag *diag.Diagnostics) diag.Diagnostics {
+func (o *objectCopyResourceModel) refreshFromOutput(ctx context.Context, config *conn.ProviderConfig, diag *diag.Diagnostics) {
 	output, err := config.Client.ObjectStorage.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: o.Bucket.ValueStringPointer(),
 		Key:    o.Key.ValueStringPointer(),
 	})
 	if err != nil {
 		diag.AddError("HeadObject ERROR", err.Error())
-		return *diag
+		return
 	}
 	if output == nil {
 		diag.AddError("HeadObject ERROR", "invalid output")
-		return *diag
+		return
 	}
 
 	o.ID = types.StringValue(ObjectIDGenerator(o.Bucket.ValueString(), o.Key.ValueString()))
@@ -489,6 +493,4 @@ func (o *objectCopyResourceModel) refreshFromOutput(ctx context.Context, config 
 	if output.LastModified != nil {
 		o.LastModified = types.StringValue(output.LastModified.Format(time.RFC3339))
 	}
-
-	return nil
 }

--- a/internal/service/objectstorage/objectstorage_object_copy.go
+++ b/internal/service/objectstorage/objectstorage_object_copy.go
@@ -420,7 +420,7 @@ func (o *objectCopyResourceModel) refreshFromOutput(ctx context.Context, config 
 		return
 	}
 
-	bucketName, key := TrimForParsing(o.Bucket.String()), TrimForParsing(o.Key.String())
+	bucketName, key := RemoveQuotes(o.Bucket.String()), RemoveQuotes(o.Key.String())
 
 	o.ID = types.StringValue(ObjectIDGenerator(bucketName, key))
 	if !types.StringPointerValue(output.AcceptRanges).IsNull() || !types.StringPointerValue(output.AcceptRanges).IsUnknown() {

--- a/internal/service/objectstorage/objectstorage_object_copy.go
+++ b/internal/service/objectstorage/objectstorage_object_copy.go
@@ -136,6 +136,14 @@ func (o *objectCopyResource) Delete(ctx context.Context, req resource.DeleteRequ
 func (o *objectCopyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	bucketName, key := ObjectIDParser(req.ID)
 
+	if bucketName == "" || key == "" {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: bucket-name/key Got: %q", req.ID),
+		)
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("bucket"), bucketName)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key"), key)...)
 }

--- a/internal/service/objectstorage/objectstorage_object_copy.go
+++ b/internal/service/objectstorage/objectstorage_object_copy.go
@@ -134,7 +134,10 @@ func (o *objectCopyResource) Delete(ctx context.Context, req resource.DeleteRequ
 }
 
 func (o *objectCopyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	bucketName, key := ObjectIDParser(req.ID)
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("bucket"), bucketName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("key"), key)...)
 }
 
 func (o *objectCopyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -177,7 +180,9 @@ func (o *objectCopyResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Description: "(Required) Name of the object once it is in the bucket",
 			},
 			"source": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
+				Sensitive:   true,
+				Computed:    false,
 				Description: "(Required) Path of the object",
 			},
 			"accept_ranges": schema.StringAttribute{

--- a/internal/service/objectstorage/objectstorage_object_copy.go
+++ b/internal/service/objectstorage/objectstorage_object_copy.go
@@ -180,9 +180,8 @@ func (o *objectCopyResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Description: "(Required) Name of the object once it is in the bucket",
 			},
 			"source": schema.StringAttribute{
-				Optional:    true,
 				Sensitive:   true,
-				Computed:    false,
+				Required:    true,
 				Description: "(Required) Path of the object",
 			},
 			"accept_ranges": schema.StringAttribute{

--- a/internal/service/objectstorage/objectstorage_object_copy.go
+++ b/internal/service/objectstorage/objectstorage_object_copy.go
@@ -128,7 +128,7 @@ func (o *objectCopyResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	tflog.Info(ctx, "DeleteObject response="+common.MarshalUncheckedString(response))
 
-	if err := waitObjectCopyDeleted(ctx, o.config, plan.Bucket.String(), plan.Key.String()); err != nil {
+	if err := waitObjectCopyDeleted(ctx, o.config, plan.Bucket.ValueString(), plan.Key.ValueString()); err != nil {
 		resp.Diagnostics.AddError("WAITING FOR DELETE ERROR", err.Error())
 	}
 }
@@ -436,9 +436,7 @@ func (o *objectCopyResourceModel) refreshFromOutput(ctx context.Context, config 
 		return
 	}
 
-	bucketName, key := RemoveQuotes(o.Bucket.String()), RemoveQuotes(o.Key.String())
-
-	o.ID = types.StringValue(ObjectIDGenerator(bucketName, key))
+	o.ID = types.StringValue(ObjectIDGenerator(o.Bucket.ValueString(), o.Key.ValueString()))
 	if !types.StringPointerValue(output.AcceptRanges).IsNull() || !types.StringPointerValue(output.AcceptRanges).IsUnknown() {
 		o.AcceptRanges = types.StringPointerValue(output.AcceptRanges)
 	}

--- a/internal/service/objectstorage/objectstorage_object_copy_test.go
+++ b/internal/service/objectstorage/objectstorage_object_copy_test.go
@@ -43,6 +43,12 @@ func TestAccResourceNcloudObjectStorage_object_copy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "key", key),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source"},
+			},
 		},
 	})
 }
@@ -86,6 +92,12 @@ func TestAccResourceNcloudObjectStorage_object_copy_update_source(t *testing.T) 
 					resource.TestCheckResourceAttrPair(resourceName, "source", postObjectResourceName, "id"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source"},
+			},
 		},
 	})
 }
@@ -125,6 +137,12 @@ func TestAccResourceNcloudObjectStorage_object_copy_update_content_type(t *testi
 					resource.TestCheckResourceAttr(resourceName, "key", key),
 					resource.TestCheckResourceAttr(resourceName, "content_type", newContentType),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source"},
 			},
 		},
 	})

--- a/internal/service/objectstorage/objectstorage_object_data_source.go
+++ b/internal/service/objectstorage/objectstorage_object_data_source.go
@@ -58,7 +58,7 @@ func (o *objectDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	bucketName, key := ObjectIDParser(data.ObjectID.String())
+	bucketName, key := ObjectIDParser(data.ObjectID.ValueString())
 
 	output, err := o.config.Client.ObjectStorage.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: ncloud.String(bucketName),

--- a/internal/service/objectstorage/objectstorage_object_test.go
+++ b/internal/service/objectstorage/objectstorage_object_test.go
@@ -44,6 +44,12 @@ func TestAccResourceNcloudObjectStorage_object_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source", source),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source"},
+			},
 		},
 	})
 }
@@ -90,6 +96,12 @@ func TestAccResourceNcloudObjectStorage_object_update_source(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source", newSource),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source"},
+			},
 		},
 	})
 }
@@ -131,6 +143,12 @@ func TestAccResourceNcloudObjectStorage_object_update_content_type(t *testing.T)
 					resource.TestCheckResourceAttr(resourceName, "source", source),
 					resource.TestCheckResourceAttr(resourceName, "content_type", newContentType),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source"},
 			},
 		},
 	})
@@ -197,7 +215,7 @@ func testAccObjectConfig(bucketName, key, source string) string {
 	resource "ncloud_objectstorage_object" "testing_object" {
 		bucket				= ncloud_objectstorage_bucket.testing_bucket.bucket_name
 		key 				= "%[2]s"
-		source				= "%[3]s"	
+		source				= "%[3]s"
 	}`, bucketName, key, source)
 }
 
@@ -210,7 +228,7 @@ func testAccObjectContentType(bucketName, key, source, contentType string) strin
 	resource "ncloud_objectstorage_object" "testing_object" {
 		bucket				= ncloud_objectstorage_bucket.testing_bucket.bucket_name
 		key 				= "%[2]s"
-		source				= "%[3]s"	
+		source				= "%[3]s"
 		content_type		= "%[4]s"
 	}`, bucketName, key, source, contentType)
 }


### PR DESCRIPTION
Fix unavailable import issue as below & add import testing in acceptance tests.

- `objectstorage_bucket`, `objectstorage_bucket_acl`
  - Add creation_date refresh logic
  - Use 'id' attribute as an unique value (on behalf of bucket_name)
  
- `objectstorage_object`, `objectstorage_object_acl`, `objectstorage_object_copy`, `objectstorage_object_copy_test`
  - Since 'source' is only used for uploading object operation (create) and it contains developer's local path, treat it as an sensitive attribute (conceal in tfstate. written but invisible.)
  - Get right information of bucketName, key, objectID attribute in import operation
  
- Add import testings in all acc tests of object storage.

- Add notification for unavailable ACL import issues.

=== RUN   TestAccResourceNcloudObjectStorage_bucket_acl_basic
--- PASS: TestAccResourceNcloudObjectStorage_bucket_acl_basic (16.83s)
=== RUN   TestAccResourceNcloudObjectStorage_bucket_acl_update
--- PASS: TestAccResourceNcloudObjectStorage_bucket_acl_update (22.21s)
=== RUN   TestAccDataSourceNcloudObjectStorage_bucket_basic
--- PASS: TestAccDataSourceNcloudObjectStorage_bucket_basic (11.39s)
=== RUN   TestAccResourceNcloudObjectStorage_bucket_basic
--- PASS: TestAccResourceNcloudObjectStorage_bucket_basic (11.53s)
=== RUN   TestAccResourceNcloudObjectStorage_object_acl_basic
--- PASS: TestAccResourceNcloudObjectStorage_object_acl_basic (26.81s)
=== RUN   TestAccResourceNcloudObjectStorage_object_acl_update
--- PASS: TestAccResourceNcloudObjectStorage_object_acl_update (32.60s)
=== RUN   TestAccResourceNcloudObjectStorage_object_copy_basic
--- PASS: TestAccResourceNcloudObjectStorage_object_copy_basic (31.89s)
=== RUN   TestAccResourceNcloudObjectStorage_object_copy_update_source
--- PASS: TestAccResourceNcloudObjectStorage_object_copy_update_source (43.40s)
=== RUN   TestAccResourceNcloudObjectStorage_object_copy_update_content_type
--- PASS: TestAccResourceNcloudObjectStorage_object_copy_update_content_type (37.97s)
=== RUN   TestAccDataSourceNcloudObjectStorage_object_basic
--- PASS: TestAccDataSourceNcloudObjectStorage_object_basic (21.52s)
=== RUN   TestAccResourceNcloudObjectStorage_object_basic
--- PASS: TestAccResourceNcloudObjectStorage_object_basic (22.06s)
=== RUN   TestAccResourceNcloudObjectStorage_object_update_source
--- PASS: TestAccResourceNcloudObjectStorage_object_update_source (33.71s)
=== RUN   TestAccResourceNcloudObjectStorage_object_update_content_type
--- PASS: TestAccResourceNcloudObjectStorage_object_update_content_type (27.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-ncloud/internal/service/objectstorage	340.207s