### PR TITLE
fix: Deprecate `ncloud_load_balancer_ssl_certificate` resource

### DIFF
--- a/docs/resources/load_balancer_ssl_certificate.md
+++ b/docs/resources/load_balancer_ssl_certificate.md
@@ -2,12 +2,11 @@
 subcategory: "Classic Load Balancer"
 ---
 
-
 # Resource: load_balancer_ssl_certificate
 
 Provides a ncloud load balancer ssl certificate resource.
 
-~> **NOTE:** This resource only supports Classic environment.
+~> **NOTE:** This resource only supports Classic environment. Deprecated.
 
 ## Example Usage
 

--- a/internal/service/classicloadbalancer/load_balancer_ssl_certificate.go
+++ b/internal/service/classicloadbalancer/load_balancer_ssl_certificate.go
@@ -29,6 +29,7 @@ func ResourceNcloudLoadBalancerSSLCertificate() *schema.Resource {
 			"certificate_name": {
 				Type:        schema.TypeString,
 				Required:    true,
+				Deprecated:  "This resource is deprecated!",
 				Description: "Name of a certificate to add",
 			},
 			"privatekey": {

--- a/internal/service/classicloadbalancer/load_balancer_ssl_certificate_test.go
+++ b/internal/service/classicloadbalancer/load_balancer_ssl_certificate_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 func TestAccNcloudLoadBalancerSSLCertificateBasic(t *testing.T) {
+	// Deprecated
+	t.Skip()
+
 	var sc loadbalancer.SslCertificate
 	prefix := GetTestPrefix()
 	testSSLCertificateName := prefix + "_cert"


### PR DESCRIPTION
### Description
- CLASSIC Resource: `ncloud_load_balancer_ssl_certificate`
- API is deprecated and no longer available.
- Add wording to announce deprecation and exclude from regression testing.