### PR TITLE
test: Skip tests that uses deprecated CentOS image

### DIFF
--- a/internal/service/autoscaling/auto_scaling_group_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_group_data_source_test.go
@@ -43,6 +43,11 @@ func TestAccDataSourceNcloudAutoScalingGroup_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudAutoScalingGroup_vpc_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	dataName := "data.ncloud_auto_scaling_group.auto"
 	resourceName := "ncloud_auto_scaling_group.auto"
 

--- a/internal/service/autoscaling/auto_scaling_group_test.go
+++ b/internal/service/autoscaling/auto_scaling_group_test.go
@@ -110,6 +110,11 @@ func TestAccResourceNcloudAutoScalingGroup_classic_zero_value(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingGroup_vpc_zero_value(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var autoScalingGroup autoscaling.AutoScalingGroup
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
@@ -164,6 +169,11 @@ func TestAccResourceNcloudAutoScalingGroup_classic_disappears(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingGroup_vpc_disappears(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var autoScalingGroup autoscaling.AutoScalingGroup
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/autoscaling/auto_scaling_policy_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_policy_data_source_test.go
@@ -36,6 +36,11 @@ func TestAccDataSourceNcloudAutoScalingPolicy_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudAutoScalingPolicy_vpc_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	dataName := "data.ncloud_auto_scaling_policy.policy"
 	resourceName := "ncloud_auto_scaling_policy.test-policy-CHANG"

--- a/internal/service/autoscaling/auto_scaling_policy_test.go
+++ b/internal/service/autoscaling/auto_scaling_policy_test.go
@@ -117,6 +117,11 @@ func TestAccResourceNcloudAutoScalingPolicy_classic_zero_value(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingPolicy_vpc_zero_value(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var policy autoscaling.AutoScalingPolicy
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceCHANG := "ncloud_auto_scaling_policy.test-policy-CHANG"
@@ -211,6 +216,11 @@ func TestAccResourceNcloudAutoScalingPolicy_classic_disappears(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingPolicy_vpc_disappears(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var policy autoscaling.AutoScalingPolicy
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceCHANG := "ncloud_auto_scaling_policy.test-policy-CHANG"

--- a/internal/service/autoscaling/auto_scaling_schedule_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_schedule_data_source_test.go
@@ -39,6 +39,11 @@ func TestAccDataSourceNcloudAutoScalingSchedule_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudAutoScalingSchedule_vpc_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	dataName := "data.ncloud_auto_scaling_schedule.schedule"
 	resourceName := "ncloud_auto_scaling_schedule.test-schedule"

--- a/internal/service/autoscaling/auto_scaling_schedule_test.go
+++ b/internal/service/autoscaling/auto_scaling_schedule_test.go
@@ -41,6 +41,11 @@ func TestAccResourceNcloudAutoScalingSchedule_classic_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingSchedule_vpc_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var schedule autoscaling.AutoScalingSchedule
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceName := "ncloud_auto_scaling_schedule.test-schedule"
@@ -90,6 +95,11 @@ func TestAccResourceNcloudAutoScalingSchedule_classic_disappears(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingSchedule_vpc_disappears(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var schedule autoscaling.AutoScalingSchedule
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceName := "ncloud_auto_scaling_schedule.test-schedule"

--- a/internal/service/autoscaling/launch_configuration_data_source_test.go
+++ b/internal/service/autoscaling/launch_configuration_data_source_test.go
@@ -35,6 +35,11 @@ func TestAccDataSourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	dataName := "data.ncloud_launch_configuration.lc"
 	resourceName := "ncloud_launch_configuration.lc"
 

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -42,6 +42,11 @@ func TestAccResourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var launchConfiguration autoscaling.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
 	serverImageProductCode := "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
@@ -93,6 +98,11 @@ func TestAccResourceNcloudLaunchConfiguration_classic_disappears(t *testing.T) {
 }
 
 func TestAccResourceNcloudLaunchConfiguration_vpc_disappears(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var launchConfiguration autoscaling.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
 	serverImageProductCode := "SW.VSVR.OS.LNX64.CNTOS.0703.B050"

--- a/internal/service/loadbalancer/lb_target_group_attachment_test.go
+++ b/internal/service/loadbalancer/lb_target_group_attachment_test.go
@@ -16,6 +16,11 @@ import (
 )
 
 func TestAccResourceNcloudLbTargetGroupAttachment_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var target string
 	targetGroupName := fmt.Sprintf("terraform-testacc-tga-%s", acctest.RandString(5))
 	testServerName := GetTestServerName()

--- a/internal/service/nasvolume/nas_volume_test.go
+++ b/internal/service/nasvolume/nas_volume_test.go
@@ -141,6 +141,11 @@ func TestAccResourceNcloudNasVolume_classic_changeAccessControl(t *testing.T) {
 }
 
 func TestAccResourceNcloudNasVolume_vpc_changeAccessControl(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var before nasvolume.NasVolume
 	var after nasvolume.NasVolume
 	postfix := GetTestPrefix()

--- a/internal/service/server/network_interface_test.go
+++ b/internal/service/server/network_interface_test.go
@@ -52,6 +52,11 @@ func TestAccresourceNcloudNetworkInterface_basic(t *testing.T) {
 }
 
 func TestAccresourceNcloudNetworkInterface_update(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var networkInterface vserver.NetworkInterface
 	resourceName := "ncloud_network_interface.foo"
 	name := fmt.Sprintf("tf-nic-update-%s", acctest.RandString(5))

--- a/internal/service/server/public_ip_test.go
+++ b/internal/service/server/public_ip_test.go
@@ -49,6 +49,11 @@ func TestAccResourceNcloudPublicIpInstance_classic_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudPublicIpInstance_vpc_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var instance *server.PublicIpInstance
 
 	name := fmt.Sprintf("test-public-ip-basic-%s", acctest.RandString(5))
@@ -115,6 +120,11 @@ func TestAccResourceNcloudPublicIpInstance_classic_updateServerInstanceNo(t *tes
 }
 
 func TestAccResourceNcloudPublicIpInstance_vpc_updateServerInstanceNo(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	var instance *server.PublicIpInstance
 	serverNameFoo := fmt.Sprintf("test-public-ip-foo-%s", acctest.RandString(5))
 	serverNameBar := fmt.Sprintf("test-public-ip-bar-%s", acctest.RandString(5))

--- a/internal/service/server/root_password_data_source_test.go
+++ b/internal/service/server/root_password_data_source_test.go
@@ -30,6 +30,11 @@ func TestAccDataSourceNcloudRootPassword_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudRootPassword_vpc_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	resourceName := "data.ncloud_root_password.default"
 	name := fmt.Sprintf("tf-passwd-basic-%s", acctest.RandString(5))
 

--- a/internal/service/server/server_image_data_source_test.go
+++ b/internal/service/server/server_image_data_source_test.go
@@ -34,6 +34,11 @@ func TestAccDataSourceNcloudServerImage_classic_byCode(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServerImage_vpc_byCode(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	dataName := "data.ncloud_server_image.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -73,6 +78,11 @@ func TestAccDataSourceNcloudServerImage_classic_byFilterProductCode(t *testing.T
 }
 
 func TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
@@ -134,6 +144,11 @@ func testAccDataSourceNcloudServerImageByBlockStorageSize(t *testing.T, isVpc bo
 }
 
 func TestAccDataSourceNcloudServerImage_vpc_byPlatformType(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	dataName := "data.ncloud_server_image.test5"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/server/server_product_data_source_test.go
+++ b/internal/service/server/server_product_data_source_test.go
@@ -36,6 +36,11 @@ func TestAccDataSourceNcloudServerProduct_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServerProduct_vpc_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	dataName := "data.ncloud_server_product.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -78,6 +83,11 @@ func TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode(t *testing
 }
 
 func TestAccDataSourceNcloudServerProduct_vpc_FilterByProductCode(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
@@ -108,6 +118,11 @@ func TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType
 }
 
 func TestAccDataSourceNcloudServerProduct_vpc_FilterByProductNameProductType(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,

--- a/internal/service/server/server_products_data_source_test.go
+++ b/internal/service/server/server_products_data_source_test.go
@@ -27,6 +27,11 @@ func TestAccDataSourceNcloudServerProducts_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServerProducts_vpc_basic(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		IsUnitTest:               false,

--- a/internal/service/ses/ses_node_os_images_data_source_test.go
+++ b/internal/service/ses/ses_node_os_images_data_source_test.go
@@ -26,6 +26,11 @@ func TestAccDataSourceNcloudSESNodeOsImages(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudSESNodeOsImagesFilter(t *testing.T) {
+	t.Skip()
+	{
+		// Skip: deprecated server_image_product_code
+	}
+
 	dataName := "data.ncloud_ses_node_os_images.filter"
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
- Skip tests that uses deprecated CentOS image.
  - `SW.VSVR.OS.LNX64.CNTOS.0703.B050`
  - `SW.VSVR.APP.LNX64.CNTOS.0708.PINPT.LATEST.B050`
  - `SW.VELST.OS.LNX64.CNTOS.0708.B050`
- Did not skip tests in CDB resources that do not executed at regression testing.