### PR TITLE
ci: Fix aws-cli setup failure

### DIFF
--- a/.github/workflows/testScheduler.yml
+++ b/.github/workflows/testScheduler.yml
@@ -45,8 +45,10 @@ jobs:
 
       - name: Install AWS CLI
         run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
+          sudo apt install -y curl unzip
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscli.zip"
+          unzip awscli.zip
+          sudo ./aws/install
 
       - name: Configure AWS CLI with NCP S3 compatible endpoint
         run: |


### PR DESCRIPTION
## Description
- GitHub Action introduces Ubuntu 24.04 into one of GitHub Action hosts and it doesn't provide `aws-cli` package in the default apt repository. So it changes to download the binary manually and install it.
## references
- https://github.com/actions/runner-images/issues/9848
- https://itslinuxfoss.com/install-aws-cli-ubuntu-24-04/