### PR TITLE
ci: Fix aws-cli installation failure

### DIFF
--- a/.github/workflows/testScheduler.yml
+++ b/.github/workflows/testScheduler.yml
@@ -43,13 +43,6 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: false
 
-      - name: Install AWS CLI
-        run: |
-          sudo apt install -y curl unzip
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscli.zip"
-          unzip awscli.zip
-          sudo ./aws/install
-
       - name: Configure AWS CLI with NCP S3 compatible endpoint
         run: |
           aws configure set aws_access_key_id ${{ secrets.NCLOUD_ACCESS_KEY }}


### PR DESCRIPTION
# Description
aws-cli has already been installed in the default ubunbu 24.04 images, doesn't need to install manually

```
Found preexisting AWS CLI installation: /usr/local/aws-cli/v2/current. Please rerun install script with --update flag.
```

# References
- https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/503
- GitHub Action failure https://github.com/NaverCloudPlatform/terraform-provider-ncloud/actions/runs/12421530452/job/34681437647