### PR TITLE
test: Change the ACC test code to deprecate CentOS images

### DIFF
--- a/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
@@ -39,7 +39,7 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic(t *testing.T) {
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(),
+				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig,
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID(dataName),
 				),
@@ -115,12 +115,9 @@ func testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig(lcName strin
 	`, lcName, policyName)
 }
 
-func testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig() string {
-	return fmt.Sprintf(`
-	data "ncloud_auto_scaling_adjustment_types" "test" {
-	}
-	`)
-}
+var testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig = `
+	data "ncloud_auto_scaling_adjustment_types" "test" { }
+`
 
 func testAccDataSourceNcloudAutoScalingAdjustmentTypesByFilterCodeConfig(code string) string {
 	return fmt.Sprintf(`

--- a/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
@@ -32,16 +32,14 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic(t *testing.
 }
 
 func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic(t *testing.T) {
-	lcName := fmt.Sprintf("lc-%s", acctest.RandString(5))
-	policyName := fmt.Sprintf("policy-%s", acctest.RandString(5))
 	dataName := "data.ncloud_auto_scaling_adjustment_types.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(lcName, policyName),
+				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID(dataName),
 				),
@@ -75,7 +73,7 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_byFilterCode(t *testi
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
-		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNcloudAutoScalingAdjustmentTypesByFilterCodeConfig("EXACT"),
@@ -117,33 +115,11 @@ func testAccDataSourceNcloudAutoScalingAdjustmentTypesClassicConfig(lcName strin
 	`, lcName, policyName)
 }
 
-func testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig(lcName string, policyName string) string {
+func testAccDataSourceNcloudAutoScalingAdjustmentTypesVpcConfig() string {
 	return fmt.Sprintf(`
-	resource "ncloud_launch_configuration" "lc" {
-		name = "%s"
-		server_image_product_code = "SPSW0LINUX000046"
-		server_product_code = "SPSVRSSD00000003"
-	}
-
-	resource "ncloud_auto_scaling_group" "asg" {
-		launch_configuration_no = ncloud_launch_configuration.lc.launch_configuration_no
-		min_size = 1
-		max_size = 1
-		zone_no_list = ["2"]
-		wait_for_capacity_timeout = "0"
-	}
-
-	resource "ncloud_auto_scaling_policy" "policy" {
-		name = "%s"
-		adjustment_type_code = data.ncloud_auto_scaling_adjustment_types.test.types[2].code 
-		scaling_adjustment = 2
-		auto_scaling_group_no = ncloud_auto_scaling_group.asg.auto_scaling_group_no
-	}
-	
-	
 	data "ncloud_auto_scaling_adjustment_types" "test" {
 	}
-	`, lcName, policyName)
+	`)
 }
 
 func testAccDataSourceNcloudAutoScalingAdjustmentTypesByFilterCodeConfig(code string) string {

--- a/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_adjustment_types_data_source_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	lcName := fmt.Sprintf("lc-%s", acctest.RandString(5))
 	policyName := fmt.Sprintf("policy-%s", acctest.RandString(5))
 	dataName := "data.ncloud_auto_scaling_adjustment_types.test"
@@ -48,6 +51,9 @@ func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_vpc_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudAutoScalingAdjustmentTypes_classic_byFilterCode(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	dataName := "data.ncloud_auto_scaling_adjustment_types.by_filter"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/autoscaling/auto_scaling_group_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_group_data_source_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestAccDataSourceNcloudAutoScalingGroup_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	dataName := "data.ncloud_auto_scaling_group.auto"
 	resourceName := "ncloud_auto_scaling_group.auto"
 

--- a/internal/service/autoscaling/auto_scaling_group_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_group_data_source_test.go
@@ -46,11 +46,6 @@ func TestAccDataSourceNcloudAutoScalingGroup_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudAutoScalingGroup_vpc_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	dataName := "data.ncloud_auto_scaling_group.auto"
 	resourceName := "ncloud_auto_scaling_group.auto"
 
@@ -117,7 +112,7 @@ resource "ncloud_subnet" "test" {
 }
 
 resource "ncloud_launch_configuration" "lc" {
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
 }
 

--- a/internal/service/autoscaling/auto_scaling_group_test.go
+++ b/internal/service/autoscaling/auto_scaling_group_test.go
@@ -15,6 +15,9 @@ import (
 )
 
 func TestAccResourceNcloudAutoScalingGroup_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var autoScalingGroup autoscaling.AutoScalingGroup
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
@@ -78,6 +81,9 @@ func TestAccResourceNcloudAutoScalingGroup_vpc_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingGroup_classic_zero_value(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var autoScalingGroup autoscaling.AutoScalingGroup
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
@@ -147,6 +153,9 @@ func TestAccResourceNcloudAutoScalingGroup_vpc_zero_value(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingGroup_classic_disappears(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var autoScalingGroup autoscaling.AutoScalingGroup
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/service/autoscaling/auto_scaling_group_test.go
+++ b/internal/service/autoscaling/auto_scaling_group_test.go
@@ -116,11 +116,6 @@ func TestAccResourceNcloudAutoScalingGroup_classic_zero_value(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingGroup_vpc_zero_value(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var autoScalingGroup autoscaling.AutoScalingGroup
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
@@ -178,11 +173,6 @@ func TestAccResourceNcloudAutoScalingGroup_classic_disappears(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingGroup_vpc_disappears(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var autoScalingGroup autoscaling.AutoScalingGroup
 	resourceName := "ncloud_auto_scaling_group.auto"
 	resource.ParallelTest(t, resource.TestCase{
@@ -279,7 +269,7 @@ resource "ncloud_subnet" "test" {
 }
 
 resource "ncloud_launch_configuration" "lc" {
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
 }
 
@@ -327,7 +317,7 @@ resource "ncloud_subnet" "test" {
 }
 
 resource "ncloud_launch_configuration" "lc" {
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
 }
 

--- a/internal/service/autoscaling/auto_scaling_policy_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_policy_data_source_test.go
@@ -36,11 +36,6 @@ func TestAccDataSourceNcloudAutoScalingPolicy_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudAutoScalingPolicy_vpc_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	dataName := "data.ncloud_auto_scaling_policy.policy"
 	resourceName := "ncloud_auto_scaling_policy.test-policy-CHANG"

--- a/internal/service/autoscaling/auto_scaling_policy_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_policy_data_source_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestAccDataSourceNcloudAutoScalingPolicy_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	dataName := "data.ncloud_auto_scaling_policy.policy"
 	resourceName := "ncloud_auto_scaling_policy.test-policy-CHANG"

--- a/internal/service/autoscaling/auto_scaling_policy_test.go
+++ b/internal/service/autoscaling/auto_scaling_policy_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 func TestAccResourceNcloudAutoScalingPolicy_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var policy autoscaling.AutoScalingPolicy
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceCHANG := "ncloud_auto_scaling_policy.test-policy-CHANG"
@@ -55,6 +58,9 @@ func TestAccResourceNcloudAutoScalingPolicy_classic_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingPolicy_classic_zero_value(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var policy autoscaling.AutoScalingPolicy
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceCHANG := "ncloud_auto_scaling_policy.test-policy-CHANG"
@@ -186,6 +192,9 @@ func TestAccResourceNcloudAutoScalingPolicy_vpc_zero_value(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingPolicy_classic_disappears(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var policy autoscaling.AutoScalingPolicy
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceCHANG := "ncloud_auto_scaling_policy.test-policy-CHANG"

--- a/internal/service/autoscaling/auto_scaling_policy_test.go
+++ b/internal/service/autoscaling/auto_scaling_policy_test.go
@@ -123,11 +123,6 @@ func TestAccResourceNcloudAutoScalingPolicy_classic_zero_value(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingPolicy_vpc_zero_value(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var policy autoscaling.AutoScalingPolicy
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceCHANG := "ncloud_auto_scaling_policy.test-policy-CHANG"
@@ -225,11 +220,6 @@ func TestAccResourceNcloudAutoScalingPolicy_classic_disappears(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingPolicy_vpc_disappears(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var policy autoscaling.AutoScalingPolicy
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceCHANG := "ncloud_auto_scaling_policy.test-policy-CHANG"
@@ -319,7 +309,7 @@ resource "ncloud_subnet" "test" {
 
 resource "ncloud_launch_configuration" "test" {
     name = "%[1]s"
-    server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+    server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
     server_product_code = "SVR.VSVR.HICPU.C002.M004.NET.SSD.B050.G002"
 }
 

--- a/internal/service/autoscaling/auto_scaling_schedule_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_schedule_data_source_test.go
@@ -39,11 +39,6 @@ func TestAccDataSourceNcloudAutoScalingSchedule_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudAutoScalingSchedule_vpc_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	dataName := "data.ncloud_auto_scaling_schedule.schedule"
 	resourceName := "ncloud_auto_scaling_schedule.test-schedule"

--- a/internal/service/autoscaling/auto_scaling_schedule_data_source_test.go
+++ b/internal/service/autoscaling/auto_scaling_schedule_data_source_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestAccDataSourceNcloudAutoScalingSchedule_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	dataName := "data.ncloud_auto_scaling_schedule.schedule"
 	resourceName := "ncloud_auto_scaling_schedule.test-schedule"

--- a/internal/service/autoscaling/auto_scaling_schedule_test.go
+++ b/internal/service/autoscaling/auto_scaling_schedule_test.go
@@ -17,6 +17,9 @@ import (
 )
 
 func TestAccResourceNcloudAutoScalingSchedule_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var schedule autoscaling.AutoScalingSchedule
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceName := "ncloud_auto_scaling_schedule.test-schedule"
@@ -69,6 +72,9 @@ func TestAccResourceNcloudAutoScalingSchedule_vpc_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingSchedule_classic_disappears(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var schedule autoscaling.AutoScalingSchedule
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceName := "ncloud_auto_scaling_schedule.test-schedule"

--- a/internal/service/autoscaling/auto_scaling_schedule_test.go
+++ b/internal/service/autoscaling/auto_scaling_schedule_test.go
@@ -44,11 +44,6 @@ func TestAccResourceNcloudAutoScalingSchedule_classic_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingSchedule_vpc_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var schedule autoscaling.AutoScalingSchedule
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceName := "ncloud_auto_scaling_schedule.test-schedule"
@@ -101,11 +96,6 @@ func TestAccResourceNcloudAutoScalingSchedule_classic_disappears(t *testing.T) {
 }
 
 func TestAccResourceNcloudAutoScalingSchedule_vpc_disappears(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var schedule autoscaling.AutoScalingSchedule
 	name := fmt.Sprintf("terraform-testacc-asp-%s", acctest.RandString(5))
 	resourceName := "ncloud_auto_scaling_schedule.test-schedule"
@@ -243,7 +233,7 @@ resource "ncloud_subnet" "test" {
 
 resource "ncloud_launch_configuration" "test" {
     name = "%[1]s"
-    server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+    server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
     server_product_code = "SVR.VSVR.HICPU.C002.M004.NET.SSD.B050.G002"
 }
 

--- a/internal/service/autoscaling/launch_configuration_data_source_test.go
+++ b/internal/service/autoscaling/launch_configuration_data_source_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestAccDataSourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	dataName := "data.ncloud_launch_configuration.lc"
 	resourceName := "ncloud_launch_configuration.lc"
 

--- a/internal/service/autoscaling/launch_configuration_data_source_test.go
+++ b/internal/service/autoscaling/launch_configuration_data_source_test.go
@@ -38,11 +38,6 @@ func TestAccDataSourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	dataName := "data.ncloud_launch_configuration.lc"
 	resourceName := "ncloud_launch_configuration.lc"
 
@@ -85,7 +80,7 @@ data "ncloud_launch_configuration" "lc" {
 func testAccDataSourceNcloudLaunchConfigurationVpcConfig() string {
 	return `
 resource "ncloud_launch_configuration" "lc" {
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
 }
 

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -15,6 +15,9 @@ import (
 )
 
 func TestAccResourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var launchConfiguration autoscaling.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
 	serverImageProductCode := "SPSW0LINUX000046"
@@ -74,6 +77,9 @@ func TestAccResourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudLaunchConfiguration_classic_disappears(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var launchConfiguration autoscaling.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
 	serverImageProductCode := "SPSW0LINUX000046"

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -45,14 +45,9 @@ func TestAccResourceNcloudLaunchConfiguration_classic_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudLaunchConfiguration_vpc_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var launchConfiguration autoscaling.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
-	serverImageProductCode := "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	serverImageProductCode := "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	serverProductCode := "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
@@ -104,14 +99,9 @@ func TestAccResourceNcloudLaunchConfiguration_classic_disappears(t *testing.T) {
 }
 
 func TestAccResourceNcloudLaunchConfiguration_vpc_disappears(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var launchConfiguration autoscaling.LaunchConfiguration
 	resourceName := "ncloud_launch_configuration.lc"
-	serverImageProductCode := "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	serverImageProductCode := "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	serverProductCode := "SVR.VSVR.STAND.C002.M008.NET.SSD.B050.G002"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },

--- a/internal/service/devtools/sourcedeploy_project_stage_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_data_source_test.go
@@ -49,7 +49,7 @@ resource "ncloud_subnet" "subnet" {
 resource "ncloud_server" "server" {
 	subnet_no = ncloud_subnet.subnet.id
 	name = "%[1]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	server_product_code = "%[3]s"
 	login_key_name = ncloud_login_key.loginkey.key_name
 }

--- a/internal/service/devtools/sourcedeploy_project_stage_scenarios_data_source_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_scenarios_data_source_test.go
@@ -49,7 +49,7 @@ resource "ncloud_subnet" "subnet" {
 resource "ncloud_server" "server" {
 	subnet_no = ncloud_subnet.subnet.id
 	name = "%[2]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	server_product_code = "%[3]s"
 	login_key_name = ncloud_login_key.loginkey.key_name
 }

--- a/internal/service/loadbalancer/lb_target_group_attachment_test.go
+++ b/internal/service/loadbalancer/lb_target_group_attachment_test.go
@@ -16,11 +16,6 @@ import (
 )
 
 func TestAccResourceNcloudLbTargetGroupAttachment_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var target string
 	targetGroupName := fmt.Sprintf("terraform-testacc-tga-%s", acctest.RandString(5))
 	testServerName := GetTestServerName()
@@ -114,7 +109,7 @@ resource "ncloud_login_key" "test" {
 resource "ncloud_server" "test" {
 	subnet_no = ncloud_subnet.test.subnet_no
 	name = "%[1]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	login_key_name = ncloud_login_key.test.key_name
 }

--- a/internal/service/mongodb/mongodb_products_data_source_test.go
+++ b/internal/service/mongodb/mongodb_products_data_source_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccDataSourceNcloudMongoDbProducts_basic(t *testing.T) {
-	imageProductCode := "SW.VMGDB.LNX64.CNTOS.0708.MNGDB.4223.CE.B050"
+	imageProductCode := "SW.VMGDB.OS.LNX64.ROCKY.0810.MNGDB.CE.B050"
 	infraResourceDetailTypeCode := "MNGOD"
 	productType := "STAND"
 

--- a/internal/service/mysql/mysql_products_data_source_test.go
+++ b/internal/service/mysql/mysql_products_data_source_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccDataSourceNcloudMysqlProducts_basic(t *testing.T) {
-	imageProductCode := "SW.VDBAS.DBAAS.LNX64.CNTOS.0708.MYSQL.8025.B050"
+	imageProductCode := "SW.VMYSL.OS.LNX64.ROCKY.0810.MYSQL.B050"
 	productType := "STAND"
 
 	resource.Test(t, resource.TestCase{

--- a/internal/service/nasvolume/nas_volume_test.go
+++ b/internal/service/nasvolume/nas_volume_test.go
@@ -105,6 +105,9 @@ func testAccResourceNcloudNasVolumeResize(t *testing.T, isVpc bool) {
 }
 
 func TestAccResourceNcloudNasVolume_classic_changeAccessControl(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var before nasvolume.NasVolume
 	var after nasvolume.NasVolume
 	postfix := GetTestPrefix()

--- a/internal/service/nasvolume/nas_volume_test.go
+++ b/internal/service/nasvolume/nas_volume_test.go
@@ -144,11 +144,6 @@ func TestAccResourceNcloudNasVolume_classic_changeAccessControl(t *testing.T) {
 }
 
 func TestAccResourceNcloudNasVolume_vpc_changeAccessControl(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var before nasvolume.NasVolume
 	var after nasvolume.NasVolume
 	postfix := GetTestPrefix()
@@ -309,10 +304,17 @@ resource "ncloud_subnet" "test" {
 	usage_type         = "GEN"
 }
 
+data "ncloud_server_image" "image" {
+  filter {
+    name = "product_name"
+    values = ["Rocky Linux 8.10"]
+  }
+}
+
 resource "ncloud_server" "server-foo" {
 	subnet_no = ncloud_subnet.test.id
 	name = "%[1]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = data.ncloud_server_image.image.product_code
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	login_key_name = ncloud_login_key.loginkey.key_name
 }
@@ -320,7 +322,7 @@ resource "ncloud_server" "server-foo" {
 resource "ncloud_server" "server-bar" {
 	subnet_no = ncloud_subnet.test.id
 	name = "%[1]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = data.ncloud_server_image.image.product_code
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	login_key_name = ncloud_login_key.loginkey.key_name
 }

--- a/internal/service/redis/redis_data_source_test.go
+++ b/internal/service/redis/redis_data_source_test.go
@@ -58,7 +58,8 @@ resource "ncloud_redis" "test" {
 	vpc_no             = ncloud_vpc.test_vpc.vpc_no
     subnet_no          = ncloud_subnet.test_subnet.id
     config_group_no    = ncloud_redis_config_group.example.id
-	image_product_code = "SW.VDBAS.VRDS.LNX64.CNTOS.0708.REDIS.7013.B050"
+	image_product_code  = "SW.VRDS.OS.LNX64.ROCKY.0810.REDIS.B050"
+	engine_version_code = "7.0.13"
     mode = "SIMPLE"
 }
 

--- a/internal/service/redis/redis_products_data_source_test.go
+++ b/internal/service/redis/redis_products_data_source_test.go
@@ -29,7 +29,7 @@ func TestAccDataSourceNcloudRedisProducts_vpc_basic(t *testing.T) {
 func testAccDataSourceNcloudRedisProductsConfig(productType string) string {
 	return fmt.Sprintf(`
 data "ncloud_redis_products" "all" {
-    redis_image_product_code = "SW.VDBAS.VRDS.LNX64.CNTOS.0708.REDIS.7013.B050"
+    redis_image_product_code = "SW.VRDS.OS.LNX64.ROCKY.0810.REDIS.B050"
 	filter {
 			name = "product_type"
 			values = ["%[1]s"]

--- a/internal/service/server/block_storage_test.go
+++ b/internal/service/server/block_storage_test.go
@@ -17,6 +17,9 @@ import (
 )
 
 func TestAccResourceNcloudBlockStorage_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var storageInstance server.BlockStorage
 	name := fmt.Sprintf("tf-storage-basic-%s", acctest.RandString(5))
 	resourceName := "ncloud_block_storage.storage"
@@ -131,6 +134,9 @@ func TestAccResourceNcloudBlockStorage_vpc_kvm(t *testing.T) {
 }
 
 func TestAccResourceNcloudBlockStorage_classic_ChangeServerInstance(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var storageInstance server.BlockStorage
 	name := fmt.Sprintf("tf-storage-update-%s", acctest.RandString(5))
 	resourceName := "ncloud_block_storage.storage"
@@ -185,6 +191,9 @@ func TestAccResourceNcloudBlockStorage_vpc_ChangeServerInstance(t *testing.T) {
 }
 
 func TestAccResourceNcloudBlockStorage_classic_size(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var storageInstance server.BlockStorage
 	name := fmt.Sprintf("tf-storage-size-%s", acctest.RandString(5))
 	resourceName := "ncloud_block_storage.storage"

--- a/internal/service/server/network_interface_test.go
+++ b/internal/service/server/network_interface_test.go
@@ -52,11 +52,6 @@ func TestAccresourceNcloudNetworkInterface_basic(t *testing.T) {
 }
 
 func TestAccresourceNcloudNetworkInterface_update(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var networkInterface vserver.NetworkInterface
 	resourceName := "ncloud_network_interface.foo"
 	name := fmt.Sprintf("tf-nic-update-%s", acctest.RandString(5))
@@ -166,7 +161,7 @@ resource "ncloud_login_key" "loginkey" {
 resource "ncloud_server" "server" {
 	subnet_no = ncloud_subnet.test.id
 	name = "%[1]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	login_key_name = ncloud_login_key.loginkey.key_name
 }
 

--- a/internal/service/server/port_forwarding_rule_test.go
+++ b/internal/service/server/port_forwarding_rule_test.go
@@ -20,6 +20,9 @@ import (
 )
 
 func TestAccResourceNcloudPortForwardingRuleBasic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var portForwarding server.PortForwardingRule
 
 	externalPort := int(generateExternalPort(1024, 65534)) // acctest.RandIntRange(1024, 65534+1024)

--- a/internal/service/server/public_ip_data_source_test.go
+++ b/internal/service/server/public_ip_data_source_test.go
@@ -13,9 +13,7 @@ import (
 )
 
 func TestAccDataSourceNcloudPublicIp_classic_basic(t *testing.T) {
-	/*
-		TODO - it's	for atomicity of regression testing. remove when error has solved.
-	*/
+	// Images are all deprecated in Classic
 	t.Skip()
 
 	resourceName := "ncloud_public_ip.public_ip"
@@ -164,7 +162,7 @@ resource "ncloud_subnet" "test" {
 resource "ncloud_server" "server" {
 	subnet_no = ncloud_subnet.test.id
 	name = "%[1]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	login_key_name = ncloud_login_key.loginkey.key_name
 }
 

--- a/internal/service/server/public_ip_test.go
+++ b/internal/service/server/public_ip_test.go
@@ -17,6 +17,9 @@ import (
 )
 
 func TestAccResourceNcloudPublicIpInstance_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var instance *server.PublicIpInstance
 	description := fmt.Sprintf("test-public-ip-basic-%s", acctest.RandString(5))
 	resourceName := "ncloud_public_ip.public_ip"
@@ -87,6 +90,9 @@ func TestAccResourceNcloudPublicIpInstance_vpc_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudPublicIpInstance_classic_updateServerInstanceNo(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var instance *server.PublicIpInstance
 	serverNameFoo := fmt.Sprintf("test-public-ip-foo-%s", acctest.RandString(5))
 	serverNameBar := fmt.Sprintf("test-public-ip-bar-%s", acctest.RandString(5))

--- a/internal/service/server/public_ip_test.go
+++ b/internal/service/server/public_ip_test.go
@@ -52,11 +52,6 @@ func TestAccResourceNcloudPublicIpInstance_classic_basic(t *testing.T) {
 }
 
 func TestAccResourceNcloudPublicIpInstance_vpc_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var instance *server.PublicIpInstance
 
 	name := fmt.Sprintf("test-public-ip-basic-%s", acctest.RandString(5))
@@ -126,11 +121,6 @@ func TestAccResourceNcloudPublicIpInstance_classic_updateServerInstanceNo(t *tes
 }
 
 func TestAccResourceNcloudPublicIpInstance_vpc_updateServerInstanceNo(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	var instance *server.PublicIpInstance
 	serverNameFoo := fmt.Sprintf("test-public-ip-foo-%s", acctest.RandString(5))
 	serverNameBar := fmt.Sprintf("test-public-ip-bar-%s", acctest.RandString(5))
@@ -257,10 +247,17 @@ resource "ncloud_subnet" "test" {
 	usage_type         = "GEN"
 }
 
+data "ncloud_server_image" "image" {
+  filter {
+    name = "product_name"
+    values = ["Rocky Linux 8.10"]
+  }
+}
+
 resource "ncloud_server" "server" {
 	subnet_no = ncloud_subnet.test.id
 	name = "%[1]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = data.ncloud_server_image.image.product_code
 	login_key_name = ncloud_login_key.loginkey.key_name
 }
 
@@ -319,10 +316,17 @@ resource "ncloud_subnet" "test" {
 	usage_type         = "GEN"
 }
 
+data "ncloud_server_image" "image" {
+  filter {
+    name = "product_name"
+    values = ["Rocky Linux 8.10"]
+  }
+}
+
 resource "ncloud_server" "foo" {
 	subnet_no = ncloud_subnet.test.id
 	name = "%[1]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = data.ncloud_server_image.image.product_code
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	login_key_name = ncloud_login_key.loginkey.key_name
 }
@@ -330,7 +334,7 @@ resource "ncloud_server" "foo" {
 resource "ncloud_server" "bar" {
 	subnet_no = ncloud_subnet.test.id
 	name = "%[2]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = data.ncloud_server_image.image.product_code
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	login_key_name = ncloud_login_key.loginkey.key_name
 }

--- a/internal/service/server/root_password_data_source_test.go
+++ b/internal/service/server/root_password_data_source_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestAccDataSourceNcloudRootPassword_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	resourceName := "data.ncloud_root_password.default"
 	name := fmt.Sprintf("tf-passwd-basic-%s", acctest.RandString(5))
 

--- a/internal/service/server/root_password_data_source_test.go
+++ b/internal/service/server/root_password_data_source_test.go
@@ -33,11 +33,6 @@ func TestAccDataSourceNcloudRootPassword_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudRootPassword_vpc_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	resourceName := "data.ncloud_root_password.default"
 	name := fmt.Sprintf("tf-passwd-basic-%s", acctest.RandString(5))
 
@@ -100,7 +95,7 @@ resource "ncloud_subnet" "test" {
 resource "ncloud_server" "server" {
 	subnet_no = ncloud_subnet.test.id
 	name = "%[1]s"
-	server_image_product_code = "SW.VSVR.OS.LNX64.CNTOS.0703.B050"
+	server_image_product_code = "SW.VSVR.OS.LNX64.ROCKY.0810.B050"
 	server_product_code = "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
 	login_key_name = ncloud_login_key.key.key_name
 }

--- a/internal/service/server/server_data_source_test.go
+++ b/internal/service/server/server_data_source_test.go
@@ -53,6 +53,9 @@ func TestAccDataSourceNcloudServer_vpc_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServer_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	dataName := "data.ncloud_server.by_id"
 	resourceName := "ncloud_server.server"
 	testServerName := GetTestServerName()

--- a/internal/service/server/server_image_data_source_test.go
+++ b/internal/service/server/server_image_data_source_test.go
@@ -37,11 +37,6 @@ func TestAccDataSourceNcloudServerImage_classic_byCode(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServerImage_vpc_byCode(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	dataName := "data.ncloud_server_image.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -49,10 +44,10 @@ func TestAccDataSourceNcloudServerImage_vpc_byCode(t *testing.T) {
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerImageByCodeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
+				Config: testAccDataSourceNcloudServerImageByCodeConfig("SW.VSVR.OS.LNX64.ROCKY.0810.B050"),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID(dataName),
-					resource.TestCheckResourceAttr(dataName, "product_code", "SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
+					resource.TestCheckResourceAttr(dataName, "product_code", "SW.VSVR.OS.LNX64.ROCKY.0810.B050"),
 					resource.TestCheckResourceAttr(dataName, "product_name", "centos-7.3-64"),
 					resource.TestCheckResourceAttr(dataName, "product_description", "CentOS 7.3 (64-bit)"),
 					resource.TestCheckResourceAttr(dataName, "infra_resource_type", "SW"),
@@ -84,17 +79,12 @@ func TestAccDataSourceNcloudServerImage_classic_byFilterProductCode(t *testing.T
 }
 
 func TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerImageByFilterProductCodeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
+				Config: testAccDataSourceNcloudServerImageByFilterProductCodeConfig("SW.VSVR.OS.LNX64.ROCKY.0810.B050"),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID("data.ncloud_server_image.test2"),
 				),
@@ -207,7 +197,7 @@ var testAccDataSourceNcloudServerImageByFilterProductNameConfig = `
 data "ncloud_server_image" "test3" {
   filter {
     name = "product_name"
-    values = ["centos-7.3-64"]
+    values = ["Rocky Linux 8.10"]
   }
 }
 `
@@ -216,7 +206,7 @@ var testAccDataSourceNcloudServerImageByBlockStorageSizeConfig = `
 data "ncloud_server_image" "test4" {
 	filter {
 		name = "product_name"
-		values = ["centos-7.3-64"]
+		values = ["Rocky Linux 8.10"]
 	}
 
 	filter {

--- a/internal/service/server/server_image_data_source_test.go
+++ b/internal/service/server/server_image_data_source_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestAccDataSourceNcloudServerImage_classic_byCode(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	dataName := "data.ncloud_server_image.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -63,6 +66,9 @@ func TestAccDataSourceNcloudServerImage_vpc_byCode(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServerImage_classic_byFilterProductCode(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
@@ -98,6 +104,9 @@ func TestAccDataSourceNcloudServerImage_vpc_byFilterProductCode(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServerImage_classic_byFilterProductName(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	testAccDataSourceNcloudServerImageByFilterProductName(t, false)
 }
 
@@ -121,6 +130,9 @@ func testAccDataSourceNcloudServerImageByFilterProductName(t *testing.T, isVpc b
 }
 
 func TestAccDataSourceNcloudServerImage_classic_byBlockStorageSize(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	testAccDataSourceNcloudServerImageByBlockStorageSize(t, false)
 }
 

--- a/internal/service/server/server_product_data_source_test.go
+++ b/internal/service/server/server_product_data_source_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestAccDataSourceNcloudServerProduct_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	dataName := "data.ncloud_server_product.test1"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
@@ -68,6 +71,9 @@ func TestAccDataSourceNcloudServerProduct_vpc_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,
@@ -103,6 +109,9 @@ func TestAccDataSourceNcloudServerProduct_vpc_FilterByProductCode(t *testing.T) 
 }
 
 func TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ClassicProtoV6ProviderFactories,

--- a/internal/service/server/server_product_data_source_test.go
+++ b/internal/service/server/server_product_data_source_test.go
@@ -39,11 +39,6 @@ func TestAccDataSourceNcloudServerProduct_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServerProduct_vpc_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	dataName := "data.ncloud_server_product.test1"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -51,10 +46,10 @@ func TestAccDataSourceNcloudServerProduct_vpc_basic(t *testing.T) {
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050", "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"),
+				Config: testAccDataSourceNcloudServerProductConfig("SW.VSVR.OS.LNX64.ROCKY.0810.B050", "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID(dataName),
-					resource.TestCheckResourceAttr(dataName, "server_image_product_code", "SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
+					resource.TestCheckResourceAttr(dataName, "server_image_product_code", "SW.VSVR.OS.LNX64.ROCKY.0810.B050"),
 					resource.TestCheckResourceAttr(dataName, "product_code", "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"),
 					resource.TestCheckResourceAttr(dataName, "product_name", "vCPU 2EA, Memory 8GB, Disk 50GB"),
 					resource.TestCheckResourceAttr(dataName, "product_description", "vCPU 2EA, Memory 8GB, Disk 50GB"),
@@ -89,17 +84,12 @@ func TestAccDataSourceNcloudServerProduct_classic_FilterByProductCode(t *testing
 }
 
 func TestAccDataSourceNcloudServerProduct_vpc_FilterByProductCode(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductFilterByProductCodeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050", "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"),
+				Config: testAccDataSourceNcloudServerProductFilterByProductCodeConfig("SW.VSVR.OS.LNX64.ROCKY.0810.B050", "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID("data.ncloud_server_product.test2"),
 				),
@@ -127,17 +117,12 @@ func TestAccDataSourceNcloudServerProduct_classic_FilterByProductNameProductType
 }
 
 func TestAccDataSourceNcloudServerProduct_vpc_FilterByProductNameProductType(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050", "G2"),
+				Config: testAccDataSourceNcloudServerProductFilterByProductNameProductTypeConfig("SW.VSVR.OS.LNX64.ROCKY.0810.B050", "G2"),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID("data.ncloud_server_product.test3"),
 				),

--- a/internal/service/server/server_products_data_source_test.go
+++ b/internal/service/server/server_products_data_source_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestAccDataSourceNcloudServerProducts_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		IsUnitTest:               false,

--- a/internal/service/server/server_products_data_source_test.go
+++ b/internal/service/server/server_products_data_source_test.go
@@ -27,11 +27,6 @@ func TestAccDataSourceNcloudServerProducts_classic_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServerProducts_vpc_basic(t *testing.T) {
-	t.Skip()
-	{
-		// Skip: deprecated server_image_product_code
-	}
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		IsUnitTest:               false,
@@ -39,7 +34,7 @@ func TestAccDataSourceNcloudServerProducts_vpc_basic(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceNcloudServerProductsConfig("SW.VSVR.OS.LNX64.CNTOS.0703.B050"),
+				Config: testAccDataSourceNcloudServerProductsConfig("SW.VSVR.OS.LNX64.ROCKY.0810.B050"),
 				Check: resource.ComposeTestCheckFunc(
 					TestAccCheckDataSourceID("data.ncloud_server_products.all"),
 				),

--- a/internal/service/server/server_test.go
+++ b/internal/service/server/server_test.go
@@ -17,6 +17,9 @@ import (
 )
 
 func TestAccResourceNcloudServer_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var serverInstance serverservice.ServerInstance
 	testServerName := GetTestServerName()
 	resourceName := "ncloud_server.server"
@@ -212,6 +215,9 @@ func TestAccResourceNcloudServer_vpc_networkInterface(t *testing.T) {
 }
 
 func TestAccResourceNcloudServer_classic_changeSpec(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	var before serverservice.ServerInstance
 	var after serverservice.ServerInstance
 	testServerName := GetTestServerName()

--- a/internal/service/server/servers_data_source_test.go
+++ b/internal/service/server/servers_data_source_test.go
@@ -40,6 +40,9 @@ func TestAccDataSourceNcloudServers_vpc_basic(t *testing.T) {
 }
 
 func TestAccDataSourceNcloudServers_classic_basic(t *testing.T) {
+	// Images are all deprecated in Classic
+	t.Skip()
+
 	testServerName := GetTestServerName()
 	testServerName2 := GetTestServerName()
 


### PR DESCRIPTION
### Description
- As of 2024-12-19, CentOS images are deprecated
- Skip image ACC testing in Classic
- Change deprecated CentOS image ACC tests in VPC
