### PR TITLE
fix(lb): Restore filter attribute as block type

### DIFF
--- a/internal/common/helpers.go
+++ b/internal/common/helpers.go
@@ -6,29 +6,9 @@ package common
 import (
 	"log"
 
-	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-ncloud/internal/conn"
 )
-
-func CopyResourceSchemaToDataSourceSchema(resourceSchema datasourceschema.Schema, extraFields map[string]datasourceschema.Attribute) datasourceschema.Schema {
-	dataSourceAttributes := map[string]datasourceschema.Attribute{}
-
-	for name, attr := range resourceSchema.Attributes {
-		if name == "id" {
-			continue
-		}
-		dataSourceAttributes[name] = attr
-	}
-
-	for name, attr := range extraFields {
-		dataSourceAttributes[name] = attr
-	}
-
-	return datasourceschema.Schema{
-		Attributes: dataSourceAttributes,
-	}
-}
 
 // Get the schema for a nested DataSourceSchema generated from the ResourceSchema
 func GetDataSourceItemSchema(resourceSchema *schema.Resource) *schema.Resource {


### PR DESCRIPTION
- The `filter` attribute of Load Balancer DataSource has been unintentionally changed to SetNestedAttribute. It caused a breaking change to the user who uses `filter` as a block type attribute.
- It restores the `filter` attribute back to the block type to keep the schema compatibility
- In addition, in the previous change, it sets `name` attributes as `optional` | `computed` instead of just `computed`. This change also restores the `name` attribute only has `computed`. (https://github.com/NaverCloudPlatform/terraform-provider-ncloud/pull/508/files#diff-58c1c9a1d13df4ef359ab118f593fa210b77fe09de3f4bb6b1306c689c2dae02R47-R49)