### PR TITLE
ci: bypass checksum integrity validation from aws cli v2

### DIFF
--- a/.github/workflows/testScheduler.yml
+++ b/.github/workflows/testScheduler.yml
@@ -65,6 +65,8 @@ jobs:
               export NCLOUD_REGION=${{ secrets.NCLOUD_REGION }}
               export NCLOUD_ACCESS_KEY=${{ secrets.NCLOUD_ACCESS_KEY }}
               export NCLOUD_SECRET_KEY=${{ secrets.NCLOUD_SECRET_KEY }}
+              export AWS_REQUEST_CHECKSUM_CALCULATION=WHEN_REQUIRED
+
               echo $PWD
               echo $ls
               echo "$test"


### PR DESCRIPTION
- Bypass checksum integrity validation with `AWS_REQUEST_CHECKSUM_CALCULATION=WHEN_REQUIRED` option.
- Can be solved when checksum generation with `CRC64NVME` CLI tool is provided.