### PR TITLE
ci: Disable fail fast while running regression test

### DIFF
--- a/.github/workflows/testScheduler.yml
+++ b/.github/workflows/testScheduler.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'NaverCloudPlatform/terraform-provider-ncloud' }}
     strategy:
+      fail-fast: false
       matrix:
         go-version: ["1.23"]
         # TODO: enable cloud db resources and nks


### PR DESCRIPTION
- Daily regression test has been canceled in the middle of testing if any of the tests failed
- It does not interrupt running tests even if one of the tests has been canceled.