### PR TITLE
feat(vserver): Add raid_type_name argument for vpc baremetal server creation

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -146,12 +146,12 @@ The following arguments are supported:
 * `is_protect_server_termination` - (Optional) You can set whether or not to protect return when creating. default :false
 * `fee_system_type_code` - (Optional) A rate system identification code. There are time plan(MTRAT) and flat rate (FXSUM). Default : Time plan(MTRAT)
 * `zone` - (Optional) Zone code. You can determine the ZONE where the server will be created. Default : Assigned by NAVER Cloud Platform. Get available values using the data source `ncloud_zones`.
+* `raid_type_name` - (Optional) Raid Type Name. raidTypeName is required to create BareMetal servers. You must request an increase in BareMetal server creation limits through customer support center. Accepted value example : `1` |  `5`
 
 ~> **NOTE:** Below arguments only support Classic environment.
 
 * `access_control_group_configuration_no_list` - (Optional) You can set the ACG created when creating the server. ACG setting number can be obtained through the getAccessControlGroupList action. Default : Default ACG number
 * `user_data` - (Optional) The server will execute the user data script set by the user at first boot. To view the column, it is returned only when viewing the server instance.
-* `raid_type_name` - (Optional) Raid Type Name.
 * `tag_list` - (Optional) Server instance tag list.
   * `tag_key` - (Required) Instance tag key
   * `tag_value` - (Required) Instance tag value

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -169,6 +169,9 @@ The following arguments are supported:
   * `network_interface_no` - (Required) If you want to add a network interface that you created yourself, set the network interface ID.
   * `order` - (Required) Sets the order of network interfaces to be assigned to the server to create. The unit name (eth0, eth1, etc.) is determined in that order. There must be one primary network interface. If you set `0`, network interface is set by default. You can assign up to three network interfaces.
 * `is_encrypted_base_block_storage_volume` - (Optional) you can set whether to encrypt basic block storage if server image is RHV. Default `false`.
+* `block_device_partition_list` - (Optional) List of block device partitions for the BareMetal server. Partitions may not be supported, depending on the server specifications.
+  * `mount_point` - (Required) Mount point. It starts with the "/" (root) path. The first mount must be a "/" (root) partition. Only lowercase English letters and numbers are allowed for names under "/" (root), and must start with a lowercase English letter. Depending on the OS type, certain keywords such as /root, /bin, and /dev may not be available.
+  * `partition_size` - (Required) Partition size. It determines partition size of the mount point. The sum of the partition sizes can't exceed the total capacity of the server specifications. The last partition's size is automatically allocated as the capacity remaining. Min: 50 GiB.
 
 ## Attributes Reference
 

--- a/internal/service/server/list.go
+++ b/internal/service/server/list.go
@@ -3,6 +3,7 @@ package server
 import (
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
 
 	. "github.com/terraform-providers/terraform-provider-ncloud/internal/common"
 )
@@ -34,6 +35,25 @@ func expandTagListParams(tl []interface{}) ([]*server.InstanceTagParameter, erro
 	}
 
 	return tagList, nil
+}
+
+func expandBlockDevicePartitionListParams(bl []interface{}) ([]*vserver.BlockDevicePartition, error) {
+	blockDevicePartitionList := make([]*vserver.BlockDevicePartition, 0, len(bl))
+
+	for _, v := range bl {
+		blockDevicePartition := &vserver.BlockDevicePartition{}
+		for key, value := range v.(map[string]interface{}) {
+			switch key {
+			case "mount_point":
+				blockDevicePartition.MountPoint = ncloud.String(value.(string))
+			case "partition_size":
+				blockDevicePartition.PartitionSize = ncloud.String(value.(string))
+			}
+		}
+		blockDevicePartitionList = append(blockDevicePartitionList, blockDevicePartition)
+	}
+
+	return blockDevicePartitionList, nil
 }
 
 func flattenMapByKey(i interface{}, key string) *string {

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -132,6 +132,25 @@ func ResourceNcloudServer() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"block_device_partition_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mount_point": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ForceNew:         true,
+							ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(regexp.MustCompile(`^/(?:[a-z][a-z0-9]*)?$`), "Must start with an / character. Only lowercase English letters and numbers are allowed for names under /, and must start with a lowercase English letter.")),
+						},
+						"partition_size": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 			"tag_list": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -523,6 +542,10 @@ func createVpcServerInstance(d *schema.ResourceData, config *conn.ProviderConfig
 
 			reqParams.NetworkInterfaceList = append(reqParams.NetworkInterfaceList, niParam)
 		}
+	}
+
+	if blockDevicePartitionList, err := expandBlockDevicePartitionListParams(d.Get("block_device_partition_list").([]interface{})); err == nil {
+		reqParams.BlockDevicePartitionList = blockDevicePartitionList
 	}
 
 	LogCommonRequest("createVpcServerInstance", reqParams)
@@ -932,6 +955,7 @@ func convertVcpServerInstance(r *vserver.ServerInstance) *ServerInstance {
 		InitScriptNo:                   r.InitScriptNo,
 		PlacementGroupNo:               r.PlacementGroupNo,
 		HypervisorType:                 common.GetCodePtrByCommonCode(r.HypervisorType),
+		BlockDevicePartitionList:       r.BlockDevicePartitionList,
 	}
 
 	for _, networkInterfaceNo := range r.NetworkInterfaceNoList {
@@ -1456,14 +1480,15 @@ type ServerInstance struct {
 	BaseBlockStorageDiskDetailType *string               `json:"base_block_storage_disk_detail_type,omitempty"`
 	InstanceTagList                []*server.InstanceTag `json:"tag_list,omitempty"`
 	// VPC
-	ServerImageNo        *string                           `json:"server_image_number,omitempty"`
-	ServerSpecCode       *string                           `json:"server_spec_code,omitempty"`
-	HypervisorType       *string                           `json:"hypervisor_type,omitempty"`
-	VpcNo                *string                           `json:"vpc_no,omitempty"`
-	SubnetNo             *string                           `json:"subnet_no,omitempty"`
-	InitScriptNo         *string                           `json:"init_script_no,omitempty"`
-	PlacementGroupNo     *string                           `json:"placement_group_no,omitempty"`
-	NetworkInterfaceList []*ServerInstanceNetworkInterface `json:"network_interface"`
+	ServerImageNo            *string                           `json:"server_image_number,omitempty"`
+	ServerSpecCode           *string                           `json:"server_spec_code,omitempty"`
+	HypervisorType           *string                           `json:"hypervisor_type,omitempty"`
+	VpcNo                    *string                           `json:"vpc_no,omitempty"`
+	SubnetNo                 *string                           `json:"subnet_no,omitempty"`
+	InitScriptNo             *string                           `json:"init_script_no,omitempty"`
+	PlacementGroupNo         *string                           `json:"placement_group_no,omitempty"`
+	NetworkInterfaceList     []*ServerInstanceNetworkInterface `json:"network_interface"`
+	BlockDevicePartitionList []*vserver.BlockDevicePartition   `json:"block_device_partition_list,omitempty"`
 }
 
 // ServerInstanceNetworkInterface network interface model in server instance

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -485,6 +485,7 @@ func createVpcServerInstance(d *schema.ResourceData, config *conn.ProviderConfig
 		SubnetNo:                          subnet.SubnetNo,
 		PlacementGroupNo:                  StringPtrOrNil(d.GetOk("placement_group_no")),
 		IsEncryptedBaseBlockStorageVolume: BoolPtrOrNil(d.GetOk("is_encrypted_base_block_storage_volume")),
+		RaidTypeName:                      StringPtrOrNil(d.GetOk("raid_type_name")),
 	}
 
 	if networkInterfaceList, ok := d.GetOk("network_interface"); !ok {


### PR DESCRIPTION
### Description
- Added raidTypeName parameter to API to enable BareMetal server creation in VPC.
- Add the `raid_type_name` to VPC to support the feature.