### PR TITLE
test(lb): Fix duplicated target group name

### DIFF
--- a/internal/service/loadbalancer/lb_test.go
+++ b/internal/service/loadbalancer/lb_test.go
@@ -116,7 +116,7 @@ resource "ncloud_lb_target_group" "test" {
   protocol = "HTTP"
   target_type = "VSVR"
   port        = 8080
-  name        = "terraform-testacc-tg"
+  name        = "%s-tg"
   description = "for test"
 
   health_check {
@@ -142,5 +142,5 @@ resource "ncloud_lb" "test" {
     throughput_type = "SMALL"
     subnet_no_list = [ ncloud_subnet.test.subnet_no ]
 }
-`, name)
+`, name, name)
 }


### PR DESCRIPTION
- Target Group Name has been duplicated while running LB tests in parallel.
- It fixes to set random name of the target group to avoid this problem
- issue: https://github.com/NaverCloudPlatform/terraform-provider-ncloud/actions/runs/15220021670/job/42813833245
```sh
    lb_data_source_test.go:17: Step 1/1 error: Error running apply: exit status 1
        
        Error: terraform-testacc-tg is duplicated name
        
          with ncloud_lb_target_group.test,
          on terraform_plugin_test.tf line 15, in resource "ncloud_lb_target_group" "test":
          15: resource "ncloud_lb_target_group" "test" {
        
    lb_listener_data_source_test.go:17: Step 1/1 error: Error running apply: exit status 1
        
        Error: terraform-testacc-tg is duplicated name
        
          with ncloud_lb_target_group.test,
          on terraform_plugin_test.tf line 15, in resource "ncloud_lb_target_group" "test":
          15: resource "ncloud_lb_target_group" "test" {
```