### PR TITLE
fix: Change the support_vpc setting back to optional

### DIFF
--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -57,7 +57,7 @@ func (p *fwprovider) Schema(ctx context.Context, req provider.SchemaRequest, res
 				Description: "Site of ncloud (public / gov / fin)",
 			},
 			"support_vpc": schema.BoolAttribute{
-				Required:    true,
+				Optional:    true,
 				Description: "Support VPC platform",
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -164,7 +164,7 @@ func SchemaMap() map[string]*schema.Schema {
 		},
 		"support_vpc": {
 			Type:        schema.TypeBool,
-			Required:    true,
+			Optional:    true,
 			Description: "Support VPC platform",
 		},
 	}


### PR DESCRIPTION
### Description
- In #533  PR, we changed the support_vpc setting to required to block Classic usage
- However, there is an issue with schema validation throwing an error when running Acc Test, so we change it back to optional.
- This doesn't affect normal users, support_vpc must be set to true to run normally.