### PR TITLE
fix(nks): access_entry policy scope validation

### DIFF
--- a/docs/data-sources/nks_cluster.md
+++ b/docs/data-sources/nks_cluster.md
@@ -71,5 +71,5 @@ In addition to all arguments above, the following attributes are exported:
   * `groups` - List of groups assigned to the access entry.
   * `policies` - List of policies for the access entry.
     * `type` - Policy type. Valid values are `NKSClusterAdminPolicy`, `NKSAdminPolicy`, `NKSEditPolicy`, or `NKSViewPolicy`.
-    * `scope` - Policy scope. Valid values are `Cluster` or `Namespace`.
+    * `scope` - Policy scope. Valid values are `cluster` or `namespace`.
     * `namespaces` - List of namespaces.

--- a/docs/resources/nks_cluster.md
+++ b/docs/resources/nks_cluster.md
@@ -80,7 +80,7 @@ resource "ncloud_nks_cluster" "cluster" {
   
     policies {
       type = "NKSClusterAdminPolicy" 
-      scope = "Cluster"
+      scope = "cluster"
     }
   }
   
@@ -134,8 +134,8 @@ The following arguments are supported:
   * `groups` - (Optional) List of groups assigned to the access entry.
   * `policies` - (Optional) List of policies for the access entry.
     * `type` - (Required) Policy type. Valid values are `NKSClusterAdminPolicy`, `NKSAdminPolicy`, `NKSEditPolicy`, or `NKSViewPolicy`.
-    * `scope` - (Required) Policy scope. Valid values are `Cluster` or `Namespace`.
-    * `namespaces` - (Optional) List of namespaces when scope is `Namespace`.
+    * `scope` - (Required) Policy scope. Valid values are `cluster` or `namespace`.
+    * `namespaces` - (Optional) List of namespaces when scope is `namespace`.
 
 ## Attributes Reference
 

--- a/examples/nks/main.tf
+++ b/examples/nks/main.tf
@@ -75,7 +75,7 @@ resource "ncloud_nks_cluster" "cluster" {
     
     policies {
       type = "NKSClusterAdminPolicy"
-      scope = "Cluster"
+      scope = "cluster"
     }
   }
 }

--- a/internal/service/nks/list_test.go
+++ b/internal/service/nks/list_test.go
@@ -489,7 +489,7 @@ func TestFlattenNKSClusterAccessEntries(t *testing.T) {
 			Policies: []*vnks.AccessEntryPolicyRes{
 				{
 					Type:  ncloud.String("NKSClusterAdminPolicy"),
-					Scope: ncloud.String("Cluster"),
+					Scope: ncloud.String("cluster"),
 				},
 			},
 		},
@@ -527,7 +527,7 @@ func TestFlattenNKSClusterAccessEntries(t *testing.T) {
 		t.Fatalf("expected policy type to be 'NKSClusterAdminPolicy', but was %v", policy["type"])
 	}
 
-	if policy["scope"].(string) != "Cluster" {
+	if policy["scope"].(string) != "cluster" {
 		t.Fatalf("expected policy scope to be 'cluster', but was %v", policy["scope"])
 	}
 }
@@ -541,7 +541,7 @@ func TestExpandNKSClusterAccessEntries(t *testing.T) {
 		"policies": []interface{}{
 			map[string]interface{}{
 				"type":  "NKSClusterAdminPolicy",
-				"scope": "Cluster",
+				"scope": "cluster",
 			},
 		},
 	}
@@ -578,7 +578,7 @@ func TestExpandNKSClusterAccessEntries(t *testing.T) {
 		t.Fatalf("expected policy type to be 'NKSClusterAdminPolicy', but was %v", ncloud.StringValue(entry.Policies[0].Type))
 	}
 
-	if ncloud.StringValue(entry.Policies[0].Scope) != "Cluster" {
+	if ncloud.StringValue(entry.Policies[0].Scope) != "cluster" {
 		t.Fatalf("expected policy scope to be 'cluster', but was %v", ncloud.StringValue(entry.Policies[0].Scope))
 	}
 }

--- a/internal/service/nks/nks_cluster.go
+++ b/internal/service/nks/nks_cluster.go
@@ -282,7 +282,7 @@ func ResourceNcloudNKSCluster() *schema.Resource {
 										Type:             schema.TypeString,
 										Required:         true,
 										Description:      "Scope of the policy",
-										ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"Cluster", "Namespace"}, false)),
+										ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"cluster", "namespace"}, false)),
 									},
 									"namespaces": {
 										Type:        schema.TypeList,


### PR DESCRIPTION
### Description
- AccessEntry Policy Scope valid values are `cluster` or `namespace`.