### PR TITLE
feat(blockstorage): Add the CB2,FB2 storage type

### DIFF
--- a/docs/data-sources/block_storage.md
+++ b/docs/data-sources/block_storage.md
@@ -46,4 +46,4 @@ The following arguments are supported:
 * `encrypted_volume` - Volume encryption status. (`true` or `false`)
 * `return_protection` - Enable return protection. (`true` or `false`)
 * `hypervisor_type` - Hypervisor type. (`XEN` or `KVM`)
-* `volume_type` - Volume type of the block storage. `XEN` type(` SSD` | `HDD`), `KVM`type(`FB1` | `CB1`)
+* `volume_type` - Volume type of the block storage. `XEN` type(` SSD`|`HDD`), `KVM`type(`FB1`|`CB1`|`FB2`|`CB2`)

--- a/docs/data-sources/server_image_numbers.md
+++ b/docs/data-sources/server_image_numbers.md
@@ -110,7 +110,7 @@ This data source exports the following attributes in addition to the arguments a
     * `block_storage_snapshot_name` - Block storage snapshot name.
     * `block_storage_size` - Block storage size (byte).
     * `block_storage_name` - Block storage name.
-    * `block_storage_volume_type` - Block storage volume type. (`SSD` or `HDD` or `CB1` or `FB1`).
+    * `block_storage_volume_type` - Block storage volume type. (`SSD`|`HDD`|`CB1`|`FB1`|`CB2`|`FB2`).
     * `iops` - IOPS.
     * `throughput` - Load balancing performance.
     * `is_encrypted_volume` - Volume encryption status. (`true` or `false`)

--- a/docs/resources/block_storage.md
+++ b/docs/resources/block_storage.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `zone` - (Optional, Required if to select KVM type) The availability zone in which the block storage instance will be created. It must be the same zone code as the server..
 * `snapshot_no` - (Optional) Create the block storage from the snapshots you take.
 * `hypervisor_type` - (Optional) Hypervisor type. Required with `volume_type`. (`XEN` or `KVM`)
-* `volume_type` - (Optional) Decides the volume type of the block storage to be created. Required for KVM block storage. Conflicts with `disk_detail_type`. Required with `hypervisor_type`. Options : `XEN` type(` SSD` | `HDD`), `KVM`type(`FB1` | `CB1`)
+* `volume_type` - (Optional) Decides the volume type of the block storage to be created. Required for KVM block storage. Conflicts with `disk_detail_type`. Required with `hypervisor_type`. Options : `XEN` type(`SSD`|`HDD`), `KVM`type(`FB1`|`CB1`|`FB2`|`CB2`)
 * `return_protection` - (Optional) Enable return protection. Default: `false`. Options: `true`| `false`
 
 ## Attributes Reference

--- a/internal/service/server/block_storage.go
+++ b/internal/service/server/block_storage.go
@@ -33,6 +33,8 @@ const (
 	BlockStorageVolumeTypeSsd        = "SSD"
 	BlockStorageVolumeTypeFb1        = "FB1"
 	BlockStorageVolumeTypeCb1        = "CB1"
+	BlockStorageVolumeTypeFb2        = "FB2"
+	BlockStorageVolumeTypeCb2        = "CB2"
 	BlockStorageHypervisorTypeXen    = "XEN"
 	BlockStorageHypervisorTypeKvm    = "KVM"
 )
@@ -101,7 +103,7 @@ func ResourceNcloudBlockStorage() *schema.Resource {
 				ForceNew:         true,
 				ConflictsWith:    []string{"disk_detail_type"},
 				RequiredWith:     []string{"hypervisor_type"},
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{BlockStorageVolumeTypeHdd, BlockStorageVolumeTypeSsd, BlockStorageVolumeTypeFb1, BlockStorageVolumeTypeCb1}, false)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{BlockStorageVolumeTypeHdd, BlockStorageVolumeTypeSsd, BlockStorageVolumeTypeFb1, BlockStorageVolumeTypeCb1, BlockStorageVolumeTypeFb2, BlockStorageVolumeTypeCb2}, false)),
 			},
 			"zone": {
 				Type:     schema.TypeString,
@@ -321,14 +323,14 @@ func createBlockStorage(d *schema.ResourceData, config *conn.ProviderConfig) (*s
 		reqParams.ServerInstanceNo = ncloud.String(d.Get("server_instance_no").(string))
 	}
 
-	if (hypervisorType == BlockStorageHypervisorTypeXen) && ((volumeType == BlockStorageVolumeTypeFb1) || (volumeType == BlockStorageVolumeTypeCb1)) {
+	if (hypervisorType == BlockStorageHypervisorTypeXen) && ((volumeType != BlockStorageVolumeTypeHdd) && (volumeType != BlockStorageVolumeTypeSsd)) {
 		err := fmt.Errorf("Only `%s` and `%s` can be entered as `%s` hypervisor type", BlockStorageVolumeTypeSsd, BlockStorageVolumeTypeHdd, BlockStorageHypervisorTypeXen)
 		LogErrorResponse("createVpcBlockStorage", err, reqParams)
 		return nil, err
 	}
 
 	if (hypervisorType == BlockStorageHypervisorTypeKvm) && ((volumeType == BlockStorageVolumeTypeHdd) || (volumeType == BlockStorageVolumeTypeSsd)) {
-		err := fmt.Errorf("Only `%s` and `%s` can be entered as `%s` hypervisor type", BlockStorageVolumeTypeCb1, BlockStorageVolumeTypeFb1, BlockStorageHypervisorTypeKvm)
+		err := fmt.Errorf("Only `%s`, `%s`, `%s`, `%s` can be entered as `%s` hypervisor type", BlockStorageVolumeTypeCb1, BlockStorageVolumeTypeFb1, BlockStorageVolumeTypeCb2, BlockStorageVolumeTypeFb2, BlockStorageHypervisorTypeKvm)
 		LogErrorResponse("createVpcBlockStorage", err, reqParams)
 		return nil, err
 	}


### PR DESCRIPTION
### Description
- When creating a G3 generation, enable the option to set `CB2` or `FB2` in the `volume_type` argument.