### PR TITLE
docs(server): Add hypervisor type compatibility guide for ncloud_server resource

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -107,9 +107,8 @@ resource "ncloud_server" "xen-server" {
 ## Argument Reference
 
 ~> **NOTE:** When creating a server with a new server image, the available fields differ depending on the hypervisor type of the server to be created:
-<br> - **KVM**: Use `server_image_number` and `server_spec_code`
-<br> - **XEN**: Use `server_image_number` and `server_spec_code` OR `server_image_product_code` and `server_product_code`
-<br> - **RHV**: Use `server_image_number` and `server_spec_code` OR `server_image_product_code` and `server_product_code`
+<br> - `server_image_number` and `server_spec_code`: Available for all types. **KVM**, **XEN**, **RHV**
+<br> - `server_image_product_code` and `server_product_code`: Available for **XEN**, **RHV**
 
 The following arguments are supported:
 

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -106,6 +106,11 @@ resource "ncloud_server" "xen-server" {
 
 ## Argument Reference
 
+~> **NOTE:** When creating a server with a new server image, the available fields differ depending on the hypervisor type of the server to be created:
+<br> - **KVM**: Use `server_image_number` and `server_spec_code`
+<br> - **XEN**: Use `server_image_number` and `server_spec_code` OR `server_image_product_code` and `server_product_code`
+<br> - **RHV**: Use `server_image_number` and `server_spec_code` OR `server_image_product_code` and `server_product_code`
+
 The following arguments are supported:
 
 * `server_image_product_code` - (Optional, Required if `member_server_image_no` or `server_image_number` is not provided) Server image product code to determine which server image to create. It can be obtained through `data.ncloud_server_image(s)`.


### PR DESCRIPTION
### Description

Add hypervisor type compatibility guide for `ncloud_server` resource based on the official API documentation.

### Changes

Added NOTE section documenting that when creating a server with a new server image, available fields differ by hypervisor type:
- **KVM**: `server_image_number` + `server_spec_code`
- **XEN**: `server_image_number` + `server_spec_code` OR `server_image_product_code` + `server_product_code`
- **RHV**: `server_image_number` + `server_spec_code` OR `server_image_product_code` + `server_product_code`

### Reference

[createServerInstances API Guide](https://api.ncloud-docs.com/docs/compute-vserver-server-createserverinstances)