### PR TITLE
fix(products): prevent nil pointer panic on G3 database product queries

### DIFF
--- a/internal/service/hadoop/hadoop_image_products_data_source.go
+++ b/internal/service/hadoop/hadoop_image_products_data_source.go
@@ -185,8 +185,12 @@ func (h *hadoopImageProduct) refreshFromOutput(output *vhadoop.Product) {
 	h.ProductCode = types.StringPointerValue(output.ProductCode)
 	h.GenerationCode = types.StringPointerValue(output.GenerationCode)
 	h.ProductName = types.StringPointerValue(output.ProductName)
-	h.ProductType = types.StringPointerValue(output.ProductType.Code)
-	h.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	if output.ProductType != nil {
+		h.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
+	if output.PlatformType != nil {
+		h.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	}
 	h.OsInformation = types.StringPointerValue(output.OsInformation)
 	h.EngineVersionCode = types.StringPointerValue(output.EngineVersionCode)
 }

--- a/internal/service/hadoop/hadoop_products_data_source.go
+++ b/internal/service/hadoop/hadoop_products_data_source.go
@@ -239,11 +239,19 @@ func (_ hadoopProductModel) attrTypes() map[string]attr.Type {
 func (h *hadoopProductModel) refreshFromOutput(output *vhadoop.Product) {
 	h.ProductName = types.StringPointerValue(output.ProductName)
 	h.ProductCode = types.StringPointerValue(output.ProductCode)
-	h.ProductType = types.StringPointerValue(output.ProductType.Code)
+	if output.ProductType != nil {
+		h.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
 	h.ProductDescription = types.StringPointerValue(output.ProductDescription)
-	h.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
-	h.InfraResourceDetailType = types.StringPointerValue(output.InfraResourceDetailType.Code)
+	if output.InfraResourceType != nil {
+		h.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
+	}
+	if output.InfraResourceDetailType != nil {
+		h.InfraResourceDetailType = types.StringPointerValue(output.InfraResourceDetailType.Code)
+	}
 	h.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
 	h.MemorySize = types.Int64PointerValue(output.MemorySize)
-	h.DiskType = types.StringPointerValue(output.DiskType.Code)
+	if output.DiskType != nil {
+		h.DiskType = types.StringPointerValue(output.DiskType.Code)
+	}
 }

--- a/internal/service/mongodb/mongodb_image_products_data_source.go
+++ b/internal/service/mongodb/mongodb_image_products_data_source.go
@@ -187,8 +187,12 @@ func (m *mongodbImageProduct) refreshFromOutput(output *vmongodb.Product) {
 	m.ProductCode = types.StringPointerValue(output.ProductCode)
 	m.GenerationCode = types.StringPointerValue(output.GenerationCode)
 	m.ProductName = types.StringPointerValue(output.ProductName)
-	m.ProductType = types.StringPointerValue(output.ProductType.Code)
-	m.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	if output.ProductType != nil {
+		m.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
+	if output.PlatformType != nil {
+		m.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	}
 	m.OsInformation = types.StringPointerValue(output.OsInformation)
 	m.EngineVersionCode = types.StringPointerValue(output.EngineVersionCode)
 }

--- a/internal/service/mongodb/mongodb_products_data_source.go
+++ b/internal/service/mongodb/mongodb_products_data_source.go
@@ -245,11 +245,19 @@ func (m mongodbProductModel) attrTypes() map[string]attr.Type {
 func (m *mongodbProductModel) refreshFromOutput(ctx context.Context, output *vmongodb.Product) {
 	m.ProductCode = types.StringPointerValue(output.ProductCode)
 	m.ProductName = types.StringPointerValue(output.ProductName)
-	m.ProductType = types.StringPointerValue(output.ProductType.Code)
+	if output.ProductType != nil {
+		m.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
 	m.ProductDescription = types.StringPointerValue(output.ProductDescription)
-	m.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
-	m.InfraResourceDetailType = types.StringPointerValue(output.InfraResourceDetailType.Code)
+	if output.InfraResourceType != nil {
+		m.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
+	}
+	if output.InfraResourceDetailType != nil {
+		m.InfraResourceDetailType = types.StringPointerValue(output.InfraResourceDetailType.Code)
+	}
 	m.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
 	m.MemorySize = types.Int64PointerValue(output.MemorySize)
-	m.DiskType = types.StringPointerValue(output.DiskType.Code)
+	if output.DiskType != nil {
+		m.DiskType = types.StringPointerValue(output.DiskType.Code)
+	}
 }

--- a/internal/service/mssql/mssql_image_products_data_source.go
+++ b/internal/service/mssql/mssql_image_products_data_source.go
@@ -207,7 +207,11 @@ func (m *mssqlImageProduct) refreshFromOutput(output *vmssql.Product) {
 	m.ProductCode = types.StringPointerValue(output.ProductCode)
 	m.GenerationCode = types.StringPointerValue(output.GenerationCode)
 	m.ProductName = types.StringPointerValue(output.ProductName)
-	m.ProductType = types.StringPointerValue(output.ProductType.Code)
-	m.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	if output.ProductType != nil {
+		m.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
+	if output.PlatformType != nil {
+		m.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	}
 	m.OsInformation = types.StringPointerValue(output.OsInformation)
 }

--- a/internal/service/mssql/mssql_products_data_source.go
+++ b/internal/service/mssql/mssql_products_data_source.go
@@ -223,10 +223,16 @@ func (m mssqlProductModel) attrTypes() map[string]attr.Type {
 func (m *mssqlProductModel) refreshFromOutput(output *vmssql.Product) {
 	m.ProductCode = types.StringPointerValue(output.ProductCode)
 	m.ProductName = types.StringPointerValue(output.ProductName)
-	m.ProductType = types.StringPointerValue(output.ProductType.Code)
+	if output.ProductType != nil {
+		m.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
 	m.ProductDescription = types.StringPointerValue(output.ProductDescription)
-	m.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
+	if output.InfraResourceType != nil {
+		m.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
+	}
 	m.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
 	m.MemorySize = types.Int64PointerValue(output.MemorySize)
-	m.DiskType = types.StringPointerValue(output.DiskType.Code)
+	if output.DiskType != nil {
+		m.DiskType = types.StringPointerValue(output.DiskType.Code)
+	}
 }

--- a/internal/service/mysql/mysql_image_products_data_source.go
+++ b/internal/service/mysql/mysql_image_products_data_source.go
@@ -185,8 +185,12 @@ func (m *mysqlImageProduct) refreshFromOutput(output *vmysql.CloudDbProduct) {
 	m.ProductCode = types.StringPointerValue(output.ProductCode)
 	m.GenerationCode = types.StringPointerValue(output.GenerationCode)
 	m.ProductName = types.StringPointerValue(output.ProductName)
-	m.ProductType = types.StringPointerValue(output.ProductType.Code)
-	m.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	if output.ProductType != nil {
+		m.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
+	if output.PlatformType != nil {
+		m.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	}
 	m.OsInformation = types.StringPointerValue(output.OsInformation)
 	m.EngineVersionCode = types.StringPointerValue(output.EngineVersionCode)
 }

--- a/internal/service/mysql/mysql_products_data_source.go
+++ b/internal/service/mysql/mysql_products_data_source.go
@@ -223,10 +223,16 @@ func (m mysqlProductModel) attrTypes() map[string]attr.Type {
 func (m *mysqlProductModel) refreshFromOutput(output *vmysql.CloudDbProduct) {
 	m.ProductCode = types.StringPointerValue(output.ProductCode)
 	m.ProductName = types.StringPointerValue(output.ProductName)
-	m.ProductType = types.StringPointerValue(output.ProductType.Code)
+	if output.ProductType != nil {
+		m.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
 	m.ProductDescription = types.StringPointerValue(output.ProductDescription)
-	m.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
+	if output.InfraResourceType != nil {
+		m.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
+	}
 	m.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
 	m.MemorySize = types.Int64PointerValue(output.MemorySize)
-	m.DiskType = types.StringPointerValue(output.DiskType.Code)
+	if output.DiskType != nil {
+		m.DiskType = types.StringPointerValue(output.DiskType.Code)
+	}
 }

--- a/internal/service/postgresql/postgresql_image_products_data_source.go
+++ b/internal/service/postgresql/postgresql_image_products_data_source.go
@@ -194,8 +194,12 @@ func (d postgresqlImageProduct) attrTypes() map[string]attr.Type {
 func (d *postgresqlImageProduct) refreshFromOutput(output *vpostgresql.Product) {
 	d.ProductCode = types.StringPointerValue(output.ProductCode)
 	d.ProductName = types.StringPointerValue(output.ProductName)
-	d.ProductType = types.StringPointerValue(output.ProductType.Code)
-	d.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	if output.ProductType != nil {
+		d.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
+	if output.PlatformType != nil {
+		d.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	}
 	d.OsInformation = types.StringPointerValue(output.OsInformation)
 	d.GenerationCode = types.StringPointerValue(output.GenerationCode)
 	d.EngineVersionCode = types.StringPointerValue(output.EngineVersionCode)

--- a/internal/service/postgresql/postgresql_products_data_source.go
+++ b/internal/service/postgresql/postgresql_products_data_source.go
@@ -234,10 +234,16 @@ func (d postgresqlProductModel) attrTypes() map[string]attr.Type {
 func (d *postgresqlProductModel) refreshFromOutput(output *vpostgresql.Product) {
 	d.ProductCode = types.StringPointerValue(output.ProductCode)
 	d.ProductName = types.StringPointerValue(output.ProductName)
-	d.ProductType = types.StringPointerValue(output.ProductType.Code)
+	if output.ProductType != nil {
+		d.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
 	d.ProductDescription = types.StringPointerValue(output.ProductDescription)
-	d.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
+	if output.InfraResourceType != nil {
+		d.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
+	}
 	d.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
 	d.MemorySize = types.Int64PointerValue(output.MemorySize)
-	d.DiskType = types.StringPointerValue(output.DiskType.Code)
+	if output.DiskType != nil {
+		d.DiskType = types.StringPointerValue(output.DiskType.Code)
+	}
 }

--- a/internal/service/redis/redis_image_products_data_source.go
+++ b/internal/service/redis/redis_image_products_data_source.go
@@ -185,8 +185,12 @@ func (r *redisImageProduct) refreshFromOutput(output *vredis.Product) {
 	r.ProductCode = types.StringPointerValue(output.ProductCode)
 	r.GenerationCode = types.StringPointerValue(output.GenerationCode)
 	r.ProductName = types.StringPointerValue(output.ProductName)
-	r.ProductType = types.StringPointerValue(output.ProductType.Code)
-	r.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	if output.ProductType != nil {
+		r.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
+	if output.PlatformType != nil {
+		r.PlatformType = types.StringPointerValue(output.PlatformType.Code)
+	}
 	r.OsInformation = types.StringPointerValue(output.OsInformation)
 	r.EngineVersionCode = types.StringPointerValue(output.EngineVersionCode)
 }

--- a/internal/service/redis/redis_products_data_source.go
+++ b/internal/service/redis/redis_products_data_source.go
@@ -225,10 +225,16 @@ func (r redisProductModel) attrTypes() map[string]attr.Type {
 func (r *redisProductModel) refreshFromOutput(output *vredis.Product) {
 	r.ProductCode = types.StringPointerValue(output.ProductCode)
 	r.ProductName = types.StringPointerValue(output.ProductName)
-	r.ProductType = types.StringPointerValue(output.ProductType.Code)
+	if output.ProductType != nil {
+		r.ProductType = types.StringPointerValue(output.ProductType.Code)
+	}
 	r.ProductDescription = types.StringPointerValue(output.ProductDescription)
-	r.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
+	if output.InfraResourceType != nil {
+		r.InfraResourceType = types.StringPointerValue(output.InfraResourceType.Code)
+	}
 	r.CpuCount = common.Int64ValueFromInt32(output.CpuCount)
 	r.MemorySize = types.Int64PointerValue(output.MemorySize)
-	r.DiskType = types.StringPointerValue(output.DiskType.Code)
+	if output.DiskType != nil {
+		r.DiskType = types.StringPointerValue(output.DiskType.Code)
+	}
 }


### PR DESCRIPTION
## Summary

- Add nil guards for nested struct field accesses in `refreshFromOutput` methods across all database product and image product data sources
- Prevents `panic: runtime error: invalid memory address or nil pointer dereference` when querying G3 database products

## Root Cause

G3 API responses may return `nil` for nested struct fields (`ProductType`, `InfraResourceType`, `InfraResourceDetailType`, `DiskType`, `PlatformType`), while G2 responses always populate these fields. The existing code accesses `.Code` on these structs without nil checks, causing a panic:

```go
// Before (unsafe) — panics when ProductType is nil
m.ProductType = types.StringPointerValue(output.ProductType.Code)

// After (safe) — skips assignment when nil
if output.ProductType != nil {
    m.ProductType = types.StringPointerValue(output.ProductType.Code)
}
```

> **Note:** The G3 API returning `nil` for these fields may itself be an API-side issue worth investigating. However, the provider should handle any valid API response gracefully without crashing.

## Affected Services

All 6 database services are affected:

| Service | Products | Image Products |
|---------|----------|----------------|
| MongoDB | ✅ Fixed | ✅ Fixed |
| MySQL | ✅ Fixed | ✅ Fixed |
| MSSQL | ✅ Fixed | ✅ Fixed |
| PostgreSQL | ✅ Fixed | ✅ Fixed |
| Redis | ✅ Fixed | ✅ Fixed |
| Hadoop | ✅ Fixed | ✅ Fixed |

**12 files changed, 24 nil guards added.**

## Test plan

- [x] `go build ./...` passes
- [x] `go vet` passes on all 6 affected packages
- [x] `go test` passes on all 6 affected packages (mongodb, mysql, mssql, postgresql, redis, hadoop)

Closes #566