### PR TITLE
docs(nks_node_pool): fix autoscale argument typo (enable -> enabled)

### DIFF
--- a/docs/resources/nks_node_pool.md
+++ b/docs/resources/nks_node_pool.md
@@ -131,7 +131,7 @@ The following arguments are supported:
 * `software_code` - (Optional) Server image code.
 * `server_role_id` - (Optional) SubAccount Server Role ID.
 * `autoscale`- (Optional) 
-  * `enable` - (Required) Auto scaling availability.
+  * `enabled` - (Required) Auto scaling availability.
   * `max` - (Required) Maximum number of nodes available for auto scaling.
   * `min` - (Required) Minimum number of nodes available for auto scaling.
 * `subnet_no` - (Deprecated) Subnet No.


### PR DESCRIPTION
## Summary

The Argument Reference for `ncloud_nks_node_pool` in `docs/resources/nks_node_pool.md` lists the autoscale block field as `enable`, but the actual provider schema and the example in the same document both use `enabled`. This PR fixes the documentation typo so users can copy the correct field name from the Argument Reference without hitting a schema validation error.

## Problem

In `docs/resources/nks_node_pool.md`:

```diff
 * `autoscale`- (Optional)
-  * `enable` - (Required) Auto scaling availability.
+  * `enabled` - (Required) Auto scaling availability.
   * `max` - (Required) Maximum number of nodes available for auto scaling.
   * `min` - (Required) Minimum number of nodes available for auto scaling.
```

The Example Usage section (line 113-117) already shows the correct field name:

```hcl
autoscale {
  enabled = false
  min = 2
  max = 2
}
```

## Evidence that `enabled` is the correct field name

- `internal/service/nks/nks_node_pool.go:170` — the schema key is defined as `"enabled"`:
  ```go
  "autoscale": {
      ...
      Schema: map[string]*schema.Schema{
          "enabled": {
              Type:     schema.TypeBool,
              Required: true,
          },
          ...
      },
  },
  ```
- `internal/service/nks/list.go:267` — reads `autoScale["enabled"].(bool)`.
- `internal/service/nks/nks_node_pool_test.go` — all acceptance tests use `autoscale.0.enabled`.
- The Example Usage block in the same doc file uses `enabled`.

## Why this matters

Users who copy the field name from the Argument Reference (`enable`) get an error like:

```
Error: Unsupported argument
  on main.tf line N, in resource "ncloud_nks_node_pool" "..." :
    M:   enable = true
An argument named "enable" is not expected here. Did you mean "enabled"?
```

This is a doc-only change. No code or behavior changes.

## Test plan

- [x] Confirmed the Example Usage block in the same file already uses `enabled`.
- [x] Confirmed the Go schema in `internal/service/nks/nks_node_pool.go` defines the key as `"enabled"`.
- [x] No code paths affected; markdown-only change.