### PR TITLE
fix(import): add missing NCP resource importers

### DIFF
--- a/docs/resources/lb_target_group_attachment.md
+++ b/docs/resources/lb_target_group_attachment.md
@@ -36,4 +36,25 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of target.
+* `id` - The ID of target group attachment. Format: `target_group_no:target_no[,target_no...]`
+
+## Import
+
+### `terraform import` command
+
+* Load Balancer Target Group Attachment can be imported using the target group number and one or more target numbers separated by commas. For example:
+
+```console
+$ terraform import ncloud_lb_target_group_attachment.rsc_name 12345:23456,34567
+```
+
+### `import` block
+
+* In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Load Balancer Target Group Attachment using the target group number and one or more target numbers separated by commas. For example:
+
+```terraform
+import {
+  to = ncloud_lb_target_group_attachment.rsc_name
+  id = "12345:23456,34567"
+}
+```

--- a/docs/resources/network_acl_rule.md
+++ b/docs/resources/network_acl_rule.md
@@ -114,3 +114,28 @@ Both `inbound` and `outbound` support  following attributes:
 ~> **NOTE:** If the value of protocol is `ICMP`, the `port_range` values will be ignored and the rule will apply to all ports.
 
 * `description` - (Optional) description to create.
+
+## Attributes Reference
+
+* `id` - The ID of Network ACL Rule. It is the same as `network_acl_no`.
+
+## Import
+
+### `terraform import` command
+
+* Network ACL Rule can be imported using the `network_acl_no`. For example:
+
+```console
+$ terraform import ncloud_network_acl_rule.rsc_name 12345
+```
+
+### `import` block
+
+* In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Network ACL Rule using the `network_acl_no`. For example:
+
+```terraform
+import {
+  to = ncloud_network_acl_rule.rsc_name
+  id = "12345"
+}
+```

--- a/internal/service/loadbalancer/lb_target_group_attachment.go
+++ b/internal/service/loadbalancer/lb_target_group_attachment.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
+	"strings"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vloadbalancer"
@@ -20,6 +20,9 @@ const (
 	TargetGroupAttachmentBusyStateErrorCode            = "1200004"
 	TargetGroupAttachmentPleaseTryAgainErrorCode       = "1250000"
 	TargetGroupAttachmentInvalidTargetGroupNoErrorCode = "1205009"
+	targetGroupAttachmentIDSeparator                   = ":"
+	targetGroupAttachmentTargetNoSeparator             = ","
+	targetGroupAttachmentImportIDFormat                = "TARGET_GROUP_NO:TARGET_NO[,TARGET_NO...]"
 )
 
 func ResourceNcloudLbTargetGroupAttachment() *schema.Resource {
@@ -31,6 +34,9 @@ func ResourceNcloudLbTargetGroupAttachment() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(conn.DefaultCreateTimeout),
 			Delete: schema.DefaultTimeout(conn.DefaultTimeout),
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceNcloudLbTargetGroupAttachmentImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"target_group_no": {
@@ -63,8 +69,25 @@ func resourceNcloudLbTargetGroupAttachmentCreate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
-	d.SetId(time.Now().UTC().String())
-	return nil
+	d.SetId(lbTargetGroupAttachmentID(d.Get("target_group_no").(string), ncloud.StringListValue(reqParams.TargetNoList)))
+	return resourceNcloudLbTargetGroupAttachmentRead(ctx, d, meta)
+}
+
+func resourceNcloudLbTargetGroupAttachmentImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	targetGroupNo, targetNoList, err := parseLbTargetGroupAttachmentID(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.Set("target_group_no", targetGroupNo); err != nil {
+		return nil, err
+	}
+	if err := d.Set("target_no_list", targetNoList); err != nil {
+		return nil, err
+	}
+	d.SetId(lbTargetGroupAttachmentID(targetGroupNo, targetNoList))
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceNcloudLbTargetGroupAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -84,9 +107,13 @@ func resourceNcloudLbTargetGroupAttachmentRead(ctx context.Context, d *schema.Re
 	if targetNoList == nil {
 		log.Printf("[WARN] Target dose not exist, removing target attachment %s", d.Id())
 		d.SetId("")
+		return nil
 	}
 
-	d.Set("target_no_list", targetNoList)
+	if err := d.Set("target_no_list", targetNoList); err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(lbTargetGroupAttachmentID(d.Get("target_group_no").(string), targetNoList))
 	return nil
 }
 
@@ -188,6 +215,34 @@ func GetVpcLoadBalancerTargetGroupAttachment(config *conn.ProviderConfig, target
 	}
 
 	return matchTargetNoList, nil
+}
+
+func lbTargetGroupAttachmentID(targetGroupNo string, targetNoList []string) string {
+	return fmt.Sprintf("%s%s%s", targetGroupNo, targetGroupAttachmentIDSeparator, strings.Join(targetNoList, targetGroupAttachmentTargetNoSeparator))
+}
+
+func parseLbTargetGroupAttachmentID(id string) (string, []string, error) {
+	idParts := strings.Split(id, targetGroupAttachmentIDSeparator)
+	if len(idParts) != 2 {
+		return "", nil, fmt.Errorf("unexpected format of ID (%q), expected %s", id, targetGroupAttachmentImportIDFormat)
+	}
+
+	targetGroupNo := strings.TrimSpace(idParts[0])
+	if targetGroupNo == "" || idParts[1] == "" {
+		return "", nil, fmt.Errorf("unexpected format of ID (%q), expected %s", id, targetGroupAttachmentImportIDFormat)
+	}
+
+	targetNoParts := strings.Split(idParts[1], targetGroupAttachmentTargetNoSeparator)
+	targetNoList := make([]string, 0, len(targetNoParts))
+	for _, targetNo := range targetNoParts {
+		trimmedTargetNo := strings.TrimSpace(targetNo)
+		if trimmedTargetNo == "" {
+			return "", nil, fmt.Errorf("unexpected format of ID (%q), target numbers must not be empty", id)
+		}
+		targetNoList = append(targetNoList, trimmedTargetNo)
+	}
+
+	return targetGroupNo, targetNoList, nil
 }
 
 func getMatchTargetNoListFromResponse(respTargetList []*vloadbalancer.Target, targetNoList []string) []string {

--- a/internal/service/loadbalancer/lb_target_group_attachment_test.go
+++ b/internal/service/loadbalancer/lb_target_group_attachment_test.go
@@ -35,8 +35,25 @@ func TestAccResourceNcloudLbTargetGroupAttachment_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "target_no_list.#", "1"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccNcloudLbTargetGroupAttachmentImportStateIDFunc(resourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
+}
+
+func testAccNcloudLbTargetGroupAttachmentImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s:%s", rs.Primary.Attributes["target_group_no"], rs.Primary.Attributes["target_no_list.0"]), nil
+	}
 }
 
 func testAccCheckLbTargetGroupAttachmentExists(n string, t *string, provider *schema.Provider) resource.TestCheckFunc {

--- a/internal/service/loadbalancer/lb_target_group_attachment_unit_test.go
+++ b/internal/service/loadbalancer/lb_target_group_attachment_unit_test.go
@@ -1,0 +1,84 @@
+package loadbalancer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseLbTargetGroupAttachmentID(t *testing.T) {
+	tests := []struct {
+		name              string
+		id                string
+		wantTargetGroupNo string
+		wantTargetNoList  []string
+		wantErr           bool
+	}{
+		{
+			name:              "single target",
+			id:                "12345:23456",
+			wantTargetGroupNo: "12345",
+			wantTargetNoList:  []string{"23456"},
+		},
+		{
+			name:              "multiple targets",
+			id:                "12345:23456,34567",
+			wantTargetGroupNo: "12345",
+			wantTargetNoList:  []string{"23456", "34567"},
+		},
+		{
+			name:              "trims whitespace",
+			id:                " 12345 : 23456, 34567 ",
+			wantTargetGroupNo: "12345",
+			wantTargetNoList:  []string{"23456", "34567"},
+		},
+		{
+			name:    "missing separator",
+			id:      "12345",
+			wantErr: true,
+		},
+		{
+			name:    "missing target group",
+			id:      ":23456",
+			wantErr: true,
+		},
+		{
+			name:    "missing target",
+			id:      "12345:",
+			wantErr: true,
+		},
+		{
+			name:    "empty target in list",
+			id:      "12345:23456,",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetGroupNo, targetNoList, err := parseLbTargetGroupAttachmentID(tt.id)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if targetGroupNo != tt.wantTargetGroupNo {
+				t.Fatalf("target group no = %q, want %q", targetGroupNo, tt.wantTargetGroupNo)
+			}
+			if !reflect.DeepEqual(targetNoList, tt.wantTargetNoList) {
+				t.Fatalf("target no list = %#v, want %#v", targetNoList, tt.wantTargetNoList)
+			}
+		})
+	}
+}
+
+func TestLbTargetGroupAttachmentID(t *testing.T) {
+	got := lbTargetGroupAttachmentID("12345", []string{"23456", "34567"})
+	want := "12345:23456,34567"
+	if got != want {
+		t.Fatalf("id = %q, want %q", got, want)
+	}
+}

--- a/internal/service/vpc/network_acl_rule.go
+++ b/internal/service/vpc/network_acl_rule.go
@@ -23,6 +23,9 @@ func ResourceNcloudNetworkACLRule() *schema.Resource {
 		Read:   resourceNcloudNetworkACLRuleRead,
 		Update: resourceNcloudNetworkACLRuleUpdate,
 		Delete: resourceNcloudNetworkACLRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"network_acl_no": {
 				Type:     schema.TypeString,

--- a/internal/service/vpc/network_acl_rule_test.go
+++ b/internal/service/vpc/network_acl_rule_test.go
@@ -37,6 +37,11 @@ func TestAccResourceNcloudNetworkACLRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "outbound.#", "1"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary
- add import support for `ncloud_network_acl_rule`
- add custom import support and stable IDs for `ncloud_lb_target_group_attachment`
- document import formats and add import acceptance-test steps
- add unit coverage for target group attachment import ID parsing

## Test Plan
- `go test ./internal/service/vpc ./internal/service/loadbalancer`
- `go vet ./...`
- `go test ./...`

## Notes
- `ncloud_postgresql` already implements Framework import, but some create-time fields are not recoverable from the instance detail response after import. That post-import drift issue is separate from the missing importer implementation fixed here.
