### PR TITLE
fix(devtools): use constant format string in log.Printf to satisfy govet

### DIFF
--- a/internal/service/devtools/sourcedeploy_project_stage_scenario_test.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_scenario_test.go
@@ -516,7 +516,7 @@ func testAccCheckSourceDeployScenarioDestroy(s *terraform.State) error {
 	config := TestAccProvider.Meta().(*conn.ProviderConfig)
 
 	for _, rs := range s.RootModule().Resources {
-		log.Printf(rs.Type)
+		log.Printf("%s", rs.Type)
 		if rs.Type != "ncloud_sourcedeploy_project_stage_scenario" {
 			continue
 		}


### PR DESCRIPTION
## Summary

CI on `main` (`Go Lint & Test in CI`) is failing in both the **Test** and **Lint** jobs with a govet `printf` violation:

```
printf: non-constant format string in call to log.Printf (govet)
internal/service/devtools/sourcedeploy_project_stage_scenario_test.go:519
```

In `testAccCheckSourceDeployScenarioDestroy`, `rs.Type` was passed directly as the format string. Passing it as an argument with a `%s` verb resolves the vet error:

```go
// Before — rs.Type used as the format string (flagged by govet)
log.Printf(rs.Type)

// After
log.Printf("%s", rs.Type)
```

## Test plan

- [ ] `go vet ./internal/service/devtools/` passes
- [ ] `golangci-lint run` passes

Closes #586