### PR TITLE
fix(devtools): validate SourceDeploy import IDs

### DIFF
--- a/internal/service/devtools/sourcedeploy_import_test.go
+++ b/internal/service/devtools/sourcedeploy_import_test.go
@@ -1,0 +1,119 @@
+package devtools_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/terraform-providers/terraform-provider-ncloud/internal/service/devtools"
+)
+
+func Test_SourceDeployStageImporter_rejects_non_numeric_project_id(t *testing.T) {
+	// Given
+	resource := devtools.ResourceNcloudSourceDeployStage()
+	data := schema.TestResourceDataRaw(t, resource.Schema, nil)
+	data.SetId("not-a-number:stage-id")
+
+	// When
+	_, err := resource.Importer.StateContext(context.Background(), data, nil)
+
+	// Then
+	if err == nil {
+		t.Fatal("expected an error for a non-numeric project ID")
+	}
+	if !strings.Contains(err.Error(), "project ID") {
+		t.Fatalf("expected a project ID error, got %q", err)
+	}
+}
+
+func Test_SourceDeployStageImporter_preserves_valid_id(t *testing.T) {
+	// Given
+	resource := devtools.ResourceNcloudSourceDeployStage()
+	data := schema.TestResourceDataRaw(t, resource.Schema, nil)
+	data.SetId("123:stage-id")
+
+	// When
+	states, err := resource.Importer.StateContext(context.Background(), data, nil)
+
+	// Then
+	if err != nil {
+		t.Fatalf("expected a valid ID to import, got %v", err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("expected one imported state, got %d", len(states))
+	}
+	if got := states[0].Get("project_id"); got != 123 {
+		t.Fatalf("expected project_id 123, got %v", got)
+	}
+	if got := states[0].Id(); got != "stage-id" {
+		t.Fatalf("expected resource ID stage-id, got %q", got)
+	}
+}
+
+func Test_SourceDeployScenarioImporter_rejects_non_numeric_ids(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		wantErr string
+	}{
+		{
+			name:    "non-numeric project ID",
+			id:      "not-a-number:456:scenario-id",
+			wantErr: "project ID",
+		},
+		{
+			name:    "non-numeric stage ID",
+			id:      "123:not-a-number:scenario-id",
+			wantErr: "stage ID",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Given
+			resource := devtools.ResourceNcloudSourceDeployScenario()
+			data := schema.TestResourceDataRaw(t, resource.Schema, nil)
+			data.SetId(test.id)
+
+			// When
+			_, err := resource.Importer.StateContext(context.Background(), data, nil)
+
+			// Then
+			if err == nil {
+				t.Fatalf("expected an error for %s", test.name)
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("expected a %s error, got %q", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func Test_SourceDeployScenarioImporter_preserves_valid_id(t *testing.T) {
+	// Given
+	resource := devtools.ResourceNcloudSourceDeployScenario()
+	data := schema.TestResourceDataRaw(t, resource.Schema, nil)
+	data.SetId("123:456:scenario-id")
+
+	// When
+	states, err := resource.Importer.StateContext(context.Background(), data, nil)
+
+	// Then
+	if err != nil {
+		t.Fatalf("expected a valid ID to import, got %v", err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("expected one imported state, got %d", len(states))
+	}
+	if got := states[0].Get("project_id"); got != 123 {
+		t.Fatalf("expected project_id 123, got %v", got)
+	}
+	if got := states[0].Get("stage_id"); got != 456 {
+		t.Fatalf("expected stage_id 456, got %v", got)
+	}
+	if got := states[0].Id(); got != "scenario-id" {
+		t.Fatalf("expected resource ID scenario-id, got %q", got)
+	}
+}

--- a/internal/service/devtools/sourcedeploy_project_stage.go
+++ b/internal/service/devtools/sourcedeploy_project_stage.go
@@ -29,7 +29,10 @@ func ResourceNcloudSourceDeployStage() *schema.Resource {
 				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 					return nil, fmt.Errorf("unexpected format of ID (%q), expected PROJECT_ID:STAGE_ID", d.Id())
 				}
-				projectId, _ := strconv.ParseInt(idParts[0], 10, 32)
+				projectId, err := strconv.ParseInt(idParts[0], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid project ID %q: %w", idParts[0], err)
+				}
 				stageId := idParts[1]
 
 				d.Set("project_id", projectId)

--- a/internal/service/devtools/sourcedeploy_project_stage_scenario.go
+++ b/internal/service/devtools/sourcedeploy_project_stage_scenario.go
@@ -30,8 +30,14 @@ func ResourceNcloudSourceDeployScenario() *schema.Resource {
 				if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {
 					return nil, fmt.Errorf("unexpected format of ID (%q), expected PROJECT_ID:STAGE_ID:SCENARIO_ID", d.Id())
 				}
-				projectId, _ := strconv.ParseInt(idParts[0], 10, 32)
-				stageId, _ := strconv.ParseInt(idParts[1], 10, 32)
+				projectId, err := strconv.ParseInt(idParts[0], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid project ID %q: %w", idParts[0], err)
+				}
+				stageId, err := strconv.ParseInt(idParts[1], 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid stage ID %q: %w", idParts[1], err)
+				}
 				scenarioId := idParts[2]
 
 				d.Set("project_id", projectId)


### PR DESCRIPTION
## Summary
- return parse errors for non-numeric SourceDeploy project and stage import identifiers
- preserve the existing valid import ID formats
- add credential-free regression tests for stage and scenario importers

## Test
- `go test -count=1 ./internal/service/devtools -run '^Test_SourceDeploy'`\n- `go test -count=1 ./...`\n- `go vet ./...`\n- `golangci-lint run` (v1.64.8)\n\nCloses #590